### PR TITLE
docs(README): add missing flags, exit codes, and sandbox env-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It does several things that are typically required for releasing a Git repositor
   - [Config file (`.ver-bumprc`)](#config-file-ver-bumprc)
   - [Version suggestion](#version-suggestion)
   - [Dry-run](#dry-run)
+  - [Exit codes](#exit-codes)
 - [Shell completions](#shell-completions)
 - [Example](#example)
 - [Development](#development)
@@ -167,10 +168,11 @@ $ npm install -g ver-bump
 ### CLI
 
 ```sh
-$ ver-bump [-v|--version <v>] [-m|--message <msg>] [-f|--file <file.json>]... \
+$ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... \
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
-           [-c|--no-changelog] [-l|--pause-changelog] [-h|--help]
+           [-c|--no-changelog] [-l|--pause-changelog] [-h|--help] \
+           [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
 
 ## Options
@@ -217,7 +219,8 @@ one you wouldn't execute. As a safeguard, `ver-bump` refuses to load a
 world-writable rc and exits with code 3; `chmod 644 .ver-bumprc` fixes it.
 
 ```text
--v, --version <version>       Manual SemVer version (validated against SemVer 2.0).
+-v, --version [<version>]     Without a value: print tool version and exit.
+                              With a value: set manual SemVer (validated against 2.0).
 -m, --message <message>       Custom annotated-tag release message.
 -f, --file <filename.json>    Also bump "version" in this JSON file. Repeatable:
                                 ver-bump -f src/plugin/package.json -f composer.json
@@ -231,6 +234,10 @@ world-writable rc and exits with code 3; `chmod 644 .ver-bumprc` fixes it.
 -c, --no-changelog            Disable updating CHANGELOG.md automatically.
 -l, --pause-changelog         Pause before commit so CHANGELOG.md can be hand-edited.
 -h, --help                    Show help message.
+    --about                   Print name, version, author, and homepage; then exit.
+    --completions <shell>     Emit completion script for bash, zsh, or fish to stdout.
+    --install-completions [=<shell>]
+                              Install completion script (auto-detects shell if omitted).
 ```
 
 ### Version suggestion
@@ -278,6 +285,17 @@ $ ver-bump --dry-run
 
 Combine with `--no-branch` / `--no-commit` / `--no-changelog` to narrow the
 preview down to just the steps you want to see.
+
+### Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Success. |
+| `1` | Generic runtime error (failed commit, jq write error, etc.). |
+| `2` | Usage / argument-parse error (unknown flag, missing value). |
+| `3` | Precondition failure (missing `package.json`, missing `git`/`jq`, SemVer validation, insecure `.ver-bumprc`, branch/tag already exists). |
+| `4` | Hook failure (reserved for future use). |
+| `5` | User abort (declined a prompt, e.g. push confirmation). |
 
 ## Shell completions
 
@@ -375,6 +393,7 @@ pnpm dev -- -v 2.0.0                  # non-interactive, explicit version
 pnpm dev:dry                          # alias for pnpm dev -- --dry-run
 pnpm dev -- --keep                    # leaves the temp dir around for inspection
 SANDBOX_VERSION=4.0.0-dev.6 pnpm dev  # exercise the prerelease bumper
+SANDBOX_COMMITS='feat!: big change; fix: oops' pnpm dev  # custom seed commits
 ```
 
 Under the hood, [`dev/sandbox.sh`](dev/sandbox.sh) `mktemp -d`s a fresh dir,
@@ -382,6 +401,13 @@ writes a minimal `package.json`, seeds a git repo with conventional-commit
 messages and a starting tag, then invokes `ver-bump` inside it. The temp
 dir is wiped on exit (or `^C`) unless you pass `--keep`. All flags after
 `--` are forwarded to `ver-bump`.
+
+**Environment variables** for the sandbox:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SANDBOX_VERSION` | `0.1.0` | Starting `"version"` in the seed `package.json`. |
+| `SANDBOX_COMMITS` | *(three built-in seeds)* | Semicolon-separated commit subjects to seed, e.g. `'feat!: big; fix: small'`. |
 
 You can invoke the script directly if you prefer — `./dev/sandbox.sh -v 2.0.0`
 needs no `--` separator.

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -425,8 +425,12 @@ install-completions() {
       log_info "Rebuild zsh's completion cache to pick it up:"
       log_trace "rm -f ~/.zcompdump*; exec zsh"
     else
-      # Show ~-relative path in the reminder so it copy-pastes cleanly.
-      local dir_pretty="${dir/#$HOME/~}"
+      local dir_pretty
+      if [[ "$dir" == "$HOME"* ]]; then
+        dir_pretty="~${dir#"$HOME"}"
+      else
+        dir_pretty="$dir"
+      fi
       log_info "Add this to ~/.zshrc BEFORE any 'source \$ZSH/oh-my-zsh.sh' line:"
       log_trace "fpath=(${dir_pretty} \$fpath)"
       log_info "Then rebuild the completion cache:"

--- a/test/args.bats
+++ b/test/args.bats
@@ -18,11 +18,9 @@ load 'test_helper'
   assert_output --partial "--version"
 }
 
-@test "process-arguments: -v: fail when not supplying version" {
-  source ${profile_script}
-  run process-arguments -v
-  assert_failure 2
-  assert_output --partial "Option -v requires an argument."
+@test "process-arguments: -v: bare prints version pill and exits 0" {
+  run ${profile_script} -v
+  assert_success
 }
 
 @test "process-arguments: -v x.x.x: succeed when supplying version" {
@@ -107,9 +105,9 @@ load 'test_helper'
 
 @test "long options: rejects missing value for long option" {
   source ${profile_script}
-  run process-arguments --version
+  run process-arguments --push
   assert_failure
-  assert_output --partial "Option --version requires an argument"
+  assert_output --partial "Option --push requires an argument"
 }
 
 @test "long options: rejects value given to boolean long option" {
@@ -289,4 +287,17 @@ load 'test_helper'
   run process-arguments --version= -d
   assert_failure 2
   assert_output --partial "Option --version requires a non-empty value"
+}
+
+@test "help↔README flag parity: every --help long flag appears in README" {
+  local help_out flags flag
+  help_out=$(get_help_msg)
+
+  flags=$(printf '%s' "$help_out" | grep -oE -- '--[a-z][-a-z]+' | sort -u)
+
+  for flag in $flags; do
+    [[ "$flag" == "--name" ]] && continue
+    grep -qF -- "$flag" "${repo_dir}/README.md" \
+      || fail "Flag ${flag} appears in --help but not in README.md"
+  done
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -139,7 +139,7 @@ _clear_config_env() {
   # Force-set o+w; use 666 to bypass any umask stripping on macOS.
   chmod 666 "$rc"
   # Sanity-check the permission actually took (guards against weird FS).
-  [ "$(stat -f '%Lp' "$rc" 2>/dev/null || stat -c '%a' "$rc" 2>/dev/null)" = "666" ]
+  [ "$(stat -c '%a' "$rc" 2>/dev/null || stat -f '%Lp' "$rc" 2>/dev/null)" = "666" ]
 
   CLEANUP_CMDS+=("chmod 644 '$rc' 2>/dev/null || true")
 
@@ -159,7 +159,7 @@ _clear_config_env() {
   rc="$repo/.ver-bumprc"
   printf 'TAG_PREFIX=unsafe\n' > "$rc"
   chmod 664 "$rc"
-  [ "$(stat -f '%Lp' "$rc" 2>/dev/null || stat -c '%a' "$rc" 2>/dev/null)" = "664" ]
+  [ "$(stat -c '%a' "$rc" 2>/dev/null || stat -f '%Lp' "$rc" 2>/dev/null)" = "664" ]
 
   CLEANUP_CMDS+=("chmod 644 '$rc' 2>/dev/null || true")
 

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -74,7 +74,7 @@ load 'test_helper'
 
 @test "exit code: long opt missing value -> 2" {
   source ${profile_script}
-  run process-arguments --version
+  run process-arguments --push
   assert_failure 2
   assert_output --partial "requires an argument"
 }


### PR DESCRIPTION
## Summary

README was missing `--about`, `--completions`, and `--install-completions` from
the CLI synopsis and flag reference table, had no exit codes section, and did
not document the `SANDBOX_COMMITS` sandbox env var. The `-v`/`--version`
description also needed updating to reflect the bare-form version pill
(print-and-exit) behaviour added in 27014c7. A tilde-substitution bug in the
`install-completions` zsh hint is fixed along the way (bash `${var/#$HOME/~}`
is unreliable when `$HOME` is expanded as a pattern), and tests are updated to
match the new bare `-v`/`--version` semantics.

## Changes

**README.md**
- Add `--about`, `--completions <shell>`, `--install-completions [=<shell>]` to CLI synopsis and flag reference block.
- Update `-v, --version` description to document the bare form (print version pill and exit).
- Add *Exit codes* subsection (codes 0–5) under Options.
- Add `SANDBOX_COMMITS` to the Development section env-var table.

**lib/helpers.sh**
- Fix tilde substitution in `install-completions` zsh hint: replace unreliable `${dir/#$HOME/~}` pattern substitution with explicit prefix check + `${dir#"$HOME"}` strip.

**test/args.bats**
- Update bare `-v` test: now runs the full script (not `process-arguments` in isolation) and asserts success, matching the version-pill behaviour from 27014c7.
- Swap `--version` → `--push` in "rejects missing value for long option" test, since bare `--version` is now a valid command.
- Add `help↔README flag parity` test: extracts `--<flag>` tokens from `--help` output and asserts each appears in `README.md` (AC-7 one-liner guarantee).

**test/config.bats**
- Swap `stat -c` (GNU/Linux) before `stat -f` (BSD/macOS) in permission sanity checks so the native form is tried first in the Linux CI environment.

**test/errors.bats**
- Same `--version` → `--push` swap as args.bats for the "long opt missing value → exit 2" test.

## Behavioural notes

- No runtime behaviour changes beyond the `install-completions` tilde-display fix.
- The flag parity test skips `--name` (a prose example token from the `--help` footer, not an actual flag).
- Exit codes 0–5 documented in README match the canonical table in `fail()` header comment and the test coverage in `test/errors.bats`.

## Test coverage

- Files changed: `test/args.bats`, `test/config.bats`, `test/errors.bats`
- Full suite: 130/130.
- ShellCheck: clean.

## Deliverables

**Docs (README.md)**
- [x] `--about` documented in CLI synopsis and flag reference
- [x] `--completions <shell>` documented in CLI synopsis and flag reference
- [x] `--install-completions [=<shell>]` documented in CLI synopsis and flag reference
- [x] `-v, --version` description updated for bare-form version-pill behaviour
- [x] *Exit codes* subsection added (codes 0–5) under Options
- [x] `SANDBOX_COMMITS` row added to Development env-var table

**Code (lib/helpers.sh)**
- [x] `install-completions` zsh hint uses reliable `$HOME`-prefix strip instead of `${var/#$HOME/~}` pattern substitution

**Tests**
- [x] `test/args.bats`: bare `-v` test updated for version-pill behaviour
- [x] `test/args.bats`: missing-value test uses `--push` instead of `--version`
- [x] `test/args.bats`: new `help↔README flag parity` test (AC-7 guarantee)
- [x] `test/errors.bats`: long-opt-missing-value test uses `--push` instead of `--version`
- [x] `test/config.bats`: `stat -c` before `stat -f` for Linux CI ergonomics

**Quality gates**
- [x] Full bats suite: 130/130
- [x] ShellCheck: clean
- [x] Closes #33

Closes #33.