### PR TITLE
fix(sandcastle): planner ignores branches whose issue is closed

### DIFF
--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -58,6 +58,14 @@ Issue B is blocked by issue A if **any** of the following hold:
 - **Issues already in flight on a `sandcastle/*` branch** with commits
   ahead of `feat/v2.0`: skip; their merger run hasn't completed.
 
+  **Stale-branch rule.** Before treating a `sandcastle/issue-<N>-*`
+  branch as "in flight," confirm issue #N is still open. If issue #N
+  is closed (shipped via another PR, superseded, or manually closed),
+  ignore the branch entirely — do not count it as in-flight and do
+  not let it block other issues via the file-set collision rule.
+  Such branches are residue; the operator is expected to prune them,
+  but the planner must not wedge itself waiting.
+
 ## Branch naming
 
 For each selected issue, assign:

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -58,13 +58,22 @@ Issue B is blocked by issue A if **any** of the following hold:
 - **Issues already in flight on a `sandcastle/*` branch** with commits
   ahead of `feat/v2.0`: skip; their merger run hasn't completed.
 
-  **Stale-branch rule.** Before treating a `sandcastle/issue-<N>-*`
-  branch as "in flight," confirm issue #N is still open. If issue #N
-  is closed (shipped via another PR, superseded, or manually closed),
-  ignore the branch entirely — do not count it as in-flight and do
-  not let it block other issues via the file-set collision rule.
-  Such branches are residue; the operator is expected to prune them,
-  but the planner must not wedge itself waiting.
+  **Stale-branch rule.** For every `sandcastle/issue-<N>-*` branch
+  with commits ahead of `feat/v2.0`, run `gh issue view <N> --json
+  state --jq .state` to determine the issue's current state. Do
+  **not** infer state from the open-issues list above — that list is
+  filtered by the `ready-for-agent` label, so an open-but-unlabeled
+  issue would falsely appear "absent" and produce a false-negative
+  in-flight detection.
+
+  - State exactly `CLOSED` → branch is residue. Ignore it: do not
+    count as in-flight, do not let it block other issues via the
+    file-set collision rule. (The operator is expected to prune
+    such branches, but the planner must not wedge itself waiting.)
+  - Any other result (`OPEN`, error, network failure, unknown
+    issue number) → treat the branch as in-flight. Conservative
+    default: false positives cost an idle iteration, false negatives
+    cost a merge conflict.
 
 ## Branch naming
 


### PR DESCRIPTION
## Problem

After merging #46, `pnpm sandcastle` still returned \`{"issues": []}\`:

> Every v2.0 issue is in-flight. The sole non-in-flight candidate (#38) modifies \`lib/helpers.sh\`, which in-flight #44 will delete and split into 11 modules — any implementation now would be against a file that no longer exists post-merge.

## Root cause

The in-flight rule in [.sandcastle/plan-prompt.md:58-59](.sandcastle/plan-prompt.md#L58-L59) keyed on branch-state (`sandcastle/issue-<N>-*` has commits ahead) without checking whether issue #N is still open.

Several issues (#33, #34, #41, #42) were shipped via other paths (PR #45 merged to \`feat/v2.0\`, or direct commits on \`feat/v2.0\`). Their sandcastle branches stayed on disk as residue, and because the planner's file-set collision rule uses those branches as an "in-flight" signal, they blocked every open issue they overlapped with. The planner couldn't unwedge itself.

Compounding this, \`Closes #N\` didn't auto-close the issues because #45 merged into \`feat/v2.0\`, not \`main\` (the default branch) — that automation only fires on merges to default.

## Changes

- [x] \`.sandcastle/plan-prompt.md\` — add the **Stale-branch rule** under **Exclusions**: before treating a \`sandcastle/issue-<N>-*\` branch as in-flight, confirm issue #N is still open. Closed → ignore the branch entirely.

## Housekeeping done alongside

- [x] Closed #33 (shipped via PR #45 / 4d157ab)
- [x] Closed #34 (shipped on feat/v2.0; FLAG_YES wired through lib/helpers.sh; commit 9b54771)
- [x] Closed #41 (shipped on feat/v2.0 across 110734d, 2b6a130, ef2903f, 051b46d, 9144cab, 988fa8c)
- [x] Closed #42 (shipped on feat/v2.0 in e555d3f, commit title references (#42))

## Out of scope / follow-up

- [ ] Delete the 6 stale worktrees (\`.sandcastle/worktrees/sandcastle-issue-*\`)
- [ ] Delete the 6 local \`sandcastle/issue-*\` branches (4 are now for closed issues; 2 for still-open #43 #44)
- [ ] Delete the 5 orphan \`sandcastle/implementer/20260424-*\` scratch branches
- [ ] Decide per branch whether to PR the implementer's work for still-open #43 and #44 or restart them
- [ ] Consider auto-closing on merges to \`feat/v2.0\` (prompt-level: ask the merger to \`gh issue close\` when its commit body references \`Closes #N\`)

## Test plan

- [ ] On next \`pnpm sandcastle\` run, planner evaluates the surviving in-flight branches only against still-open issues
- [ ] Planner no longer blocks #38 (\`lib/helpers.sh\`) solely because \`sandcastle/issue-44-*\` exists, *if* #44 is closed in the future
- [ ] With all shipped-issue branches tied to closed issues, planner selects fresh work next iteration