### PR TITLE
chore(sandcastle): swap integration branch feat/v2.0 → develop

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -11,7 +11,7 @@
 //                     Each implementer is followed by a reviewer that may
 //                     refine the diff and opens the PR.
 // Phase 3 (Merge):    a single merger agent integrates all branches that
-//                     produced commits back into `feat/v2.0`, resolving
+//                     produced commits back into `develop`, resolving
 //                     conflicts and verifying tests + shellcheck after each.
 //
 // The planner refuses to schedule any issue whose touched files overlap

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -4,7 +4,7 @@
 
 @.sandcastle/CODING_STANDARDS.md
 
-## Branches to merge into `feat/v2.0`
+## Branches to merge into `develop`
 
 {{BRANCHES}}
 
@@ -19,7 +19,7 @@
 # Task
 
 You are the **Merger**. Integrate the listed `sandcastle/*` branches
-into `feat/v2.0` in order, resolving any conflicts intelligently.
+into `develop` in order, resolving any conflicts intelligently.
 
 ## Pre-flight
 
@@ -36,7 +36,7 @@ and re-trigger.
 
 For each branch (in the order listed):
 
-1. `git checkout feat/v2.0` and confirm clean.
+1. `git checkout develop` and confirm clean.
 2. `git merge <branch> --no-edit`.
 3. If the merge succeeds: continue to verification.
 4. If conflicts arise:
@@ -56,7 +56,7 @@ For each branch (in the order listed):
    - `npm run tests:run` — full bats suite, expect 100%.
    - `shellcheck -x -e SC1017 ./ver-bump.sh ./lib/helpers.sh ./lib/styles.sh ./lib/icons.sh`
    - If either fails: investigate, fix, re-run. Do NOT proceed to the
-     next branch with a broken `feat/v2.0`.
+     next branch with a broken `develop`.
 6. If verification can't be made green for a branch, **abort the merge
    for that branch only** (`git reset --hard ORIG_HEAD`), leave a
    comment on its issue explaining why, and continue with the
@@ -65,7 +65,7 @@ For each branch (in the order listed):
 ## Final commit
 
 After all attempted branches are processed (merged or aborted), if any
-were merged, make **one** summary commit on `feat/v2.0`:
+were merged, make **one** summary commit on `develop`:
 
     chore(ralph-merge): integrate <N> sandcastle branch(es)
 

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -12,7 +12,7 @@
 
 !`gh issue list --state open --label ready-for-agent --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
 
-## Host working-tree state (paths with uncommitted changes on `feat/v2.0`)
+## Host working-tree state (paths with uncommitted changes on `develop`)
 
 These paths are dirty on the host and MUST NOT overlap with any issue you
 schedule this iteration. If a candidate issue would touch any of these
@@ -56,7 +56,7 @@ Issue B is blocked by issue A if **any** of the following hold:
 - **Issues missing acceptance criteria** in their body: defer (the
   implementer needs concrete done-conditions).
 - **Issues already in flight on a `sandcastle/*` branch** with commits
-  ahead of `feat/v2.0`: skip; their merger run hasn't completed.
+  ahead of `develop`: skip; their merger run hasn't completed.
 
 ## Branch naming
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -24,13 +24,13 @@ trailer; do not re-derive the number from commit messages.
 
 ## Branch overview
 
-Diff stat against the integration branch (`feat/v2.0`):
+Diff stat against the integration branch (`develop`):
 
-!`git diff --stat feat/v2.0...{{BRANCH}}`
+!`git diff --stat develop...{{BRANCH}}`
 
 Commits added by the implementer:
 
-!`git log feat/v2.0..{{BRANCH}} --oneline`
+!`git log develop..{{BRANCH}} --oneline`
 
 ## Reviewing the actual change
 
@@ -39,9 +39,9 @@ it would exceed the OS argv limit and crash the agent invocation
 (observed E2BIG on docs-only branch with `pnpm-lock.yaml` in the host
 tree). Read what you need on demand:
 
-- `git diff feat/v2.0...{{BRANCH}} -- <path>` to read a single file's diff.
+- `git diff develop...{{BRANCH}} -- <path>` to read a single file's diff.
 - `git show <sha>` to read one commit at a time.
-- `git diff feat/v2.0...{{BRANCH}} --name-only` to enumerate touched files.
+- `git diff develop...{{BRANCH}} --name-only` to enumerate touched files.
 
 Skip auto-generated lockfiles (`pnpm-lock.yaml`, `package-lock.json`)
 unless the issue is specifically about dependency changes.


### PR DESCRIPTION
## Why

\`feat/v2.0\` was just merged into \`develop\` (no-ff, commit \`f9ae091\`) and \`develop\` is now the integration branch for the 2.0.0-alpha cycle. The sandcastle pipeline's hardcoded \`feat/v2.0\` references are stale.

## Changes

- [x] [.sandcastle/plan-prompt.md](.sandcastle/plan-prompt.md) — host-state header + in-flight rule
- [x] [.sandcastle/review-prompt.md](.sandcastle/review-prompt.md) — integration-branch diff hint, all five \`git diff feat/v2.0...{{BRANCH}}\` examples
- [x] [.sandcastle/merge-prompt.md](.sandcastle/merge-prompt.md) — checkout target, summary-commit branch
- [x] [.sandcastle/main.mts](.sandcastle/main.mts) — Phase 3 comment header

13 hits across 4 files, all replaced with \`develop\`.

## Intentionally untouched

- \`docs/v2.0-release-plan.md\` — describes the historical \`feat/v2.0\` → \`develop\` → \`main\` flow that this commit completes. Rewriting it would distort the narrative; doc updates for the alpha cycle deserve their own pass.

## Test plan

- [ ] Next \`pnpm sandcastle\` run: planner reports host-state against \`develop\`, in-flight check uses \`develop\` as base
- [ ] Reviewer agent's diff-stat / diff hints all resolve against \`develop\`
- [ ] Merger agent successfully \`git checkout develop\` and integrates implementer branches
- [ ] No leftover \`feat/v2.0\` strings in active sandcastle prompts: \`grep -rn 'feat/v2\\.0' .sandcastle/ | grep -v logs\` is empty (verified locally)