### PR TITLE
feat: tag-in-place default + --pr release-PR workflow (2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased — 2.0 (breaking)
+- **BREAKING:** tag-in-place is now the default workflow. ver-bump 1.x always cut a `release-<version>` branch; 2.0 commits + tags the current branch in place. Pass `--branch` to keep the old behaviour.
+- feat: `--pr` opens a release pull request via the `gh` CLI (branch + push + PR). Base resolves to `--base <branch>`, else `PR_BASE`, else the invocation branch, else the remote default branch.
+- feat: `--branch` opts into the `release-<version>` branch workflow; `--base <branch>` sets the `--pr` PR base.
+- feat(config): `.ver-bumprc` gains `FLAG_BRANCH` and `PR_BASE` keys.
+- deprecate: `-b` / `--no-branch` is now a no-op (kept for back-compat) and prints a deprecation notice.
+
 ## 1.1.8 (August 23, 2023)
 - chore: updated package.json, updated package-lock.json, updated CHANGELOG.md, bumped 1.1.7 -> 1.1.8
 - bug: fixed change that caused CI #94

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ver-bump
 
-An opinionated release tool for Git projects with a `package.json` (Node / JS / TS, or any repo that follows SemVer via `-f <file>.json`). Automates SemVer bumps, CHANGELOG updates, release branching, tagging, and pushing — driven by Conventional Commits. Single-file bash at runtime; `git` + `jq` only.
+An opinionated release tool for Git projects with a `package.json` (Node / JS / TS, or any repo that follows SemVer via `-f <file>.json`). Automates SemVer bumps, CHANGELOG updates, tagging, and pushing — driven by Conventional Commits. Tags in place by default, or cut a release branch (`--branch`) and open a pull request (`--pr`). Single-file bash at runtime; `git` + `jq` only.
 
 <p>
   <img src="https://raw.githubusercontent.com/jv-k/ver-bump/main/img/demo.gif?raw=true" alt="Animated demo: ver-bump reads commits, suggests a SemVer bump, updates package.json + CHANGELOG, creates a release branch, tags, and pushes.">
@@ -12,13 +12,13 @@ An opinionated release tool for Git projects with a `package.json` (Node / JS / 
 
 It does several things that are typically required for releasing a Git repository:
 
-- Create a release branch from your current branch (should be a feature or develop branch, following the [Git branch-based workflow](https://nvie.com/posts/a-successful-git-branching-model/), and [tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) the release
+- Three release [workflows](#workflows): **tag-in-place** (default — commit + [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) the current branch), **release branch** (`--branch`, following the [Git branch-based workflow](https://nvie.com/posts/a-successful-git-branching-model/)), or **release PR** (`--pr` — branch, push, and open a pull request via `gh`)
 - Enforces [Semantic Versioning](https://semver.org/) specification — inputs are validated against SemVer 2.0 (including `-prerelease` and `+build` metadata)
 - Smart bump suggestion: reads [Conventional Commits](https://www.conventionalcommits.org/) between the previous tag and `HEAD` to propose **major**/**minor**/**patch**; bumps the trailing counter on prereleases like `4.0.0-dev.6 → 4.0.0-dev.7`
 - Avoid potential mistakes associated with manual releases, such as forgetting a step
 - Create and update a changelog file automatically
 - Pushes release to a remote
-- Leaves merging the release branch to the development branch to the user
+- Opens a release pull request for you with `--pr` (or leaves the merge to you in plain `--branch` mode)
 - **Dry-run mode** (`-d` / `--dry-run`) prints every side-effect — file write, git add, commit, tag, push — without executing any of them, so you can preview a release end-to-end
 - Shell completion scripts for **bash**, **zsh**, and **fish** built in (`ver-bump --completions <shell>`)
 - Pure-bash runtime with only `git` + `jq` as dependencies — no Node/npm required at run time
@@ -182,6 +182,26 @@ ver-bump --dry-run   # preview a release end-to-end — prints every step, chang
 ver-bump             # cut it for real: reads commits, suggests a bump, prompts before pushing
 ```
 
+## Workflows
+
+ver-bump supports three release workflows. Pick one per-run with a flag, or set
+a default in `.ver-bumprc`.
+
+| Workflow | How | What it does |
+| --- | --- | --- |
+| **Tag-in-place** *(default)* | `ver-bump` | Bumps files, writes CHANGELOG, commits, and tags **the current branch**. No branch is created. |
+| **Release branch** | `ver-bump --branch` | Cuts a `release-<version>` branch (the [Git branch-based workflow](https://nvie.com/posts/a-successful-git-branching-model/)), commits + tags there, and leaves the merge back to you. |
+| **Release PR** | `ver-bump --pr` | Like `--branch`, then pushes and opens a pull request via the [`gh`](https://cli.github.com) CLI. Implies a push to `origin` (override with `-p <remote>`). |
+
+The `--pr` base branch resolves in this order: `--base <branch>` › `PR_BASE`
+from `.ver-bumprc` › the branch you ran ver-bump from › the remote's default
+branch.
+
+> **Migrating from 1.x:** the default changed. ver-bump 1.x always cut a
+> `release-<version>` branch; 2.0 **tags the current branch in place** by
+> default. Pass `--branch` to keep the old behaviour. The old `-b` /
+> `--no-branch` flag is now a no-op (kept so existing scripts don't break).
+
 ## Usage
 
 ### Pre-requisites
@@ -197,6 +217,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
+           [--branch] [--pr] [--base <branch>] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
@@ -224,7 +245,8 @@ Supported keys (each maps 1:1 to an existing global):
 | `REL_PREFIX` | `-B` / `--branch-prefix` | `release-` |
 | `PUSH_DEST` | `-p` / `--push` | `origin` |
 | `COMMIT_MSG_PREFIX` | *(no flag)* | `"chore: "` |
-| `FLAG_NOBRANCH` | `-b` / `--no-branch` | *unset* |
+| `FLAG_BRANCH` | `--branch` | *unset* (tag in place) |
+| `PR_BASE` | `--base` | *(auto-detect)* |
 | `FLAG_NOCHANGELOG` | `-c` / `--no-changelog` | *unset* |
 | `FLAG_CHANGELOG_PAUSE` | `-l` / `--pause-changelog` | *unset* |
 
@@ -260,7 +282,7 @@ world-writable rc and exits with code 3; `chmod 644 .ver-bumprc` fixes it.
 -d, --dry-run                 Print every side-effect (file write, git add, commit,
                               tag, push) without executing any of them.
 -n, --no-commit               Disable commit (also skips tag + push).
--b, --no-branch               Don't create an automatic release-<version> branch.
+-b, --no-branch               (deprecated) No-op — tag-in-place is the default now.
 -c, --no-changelog            Disable updating CHANGELOG.md automatically.
 -l, --pause-changelog         Pause before commit so CHANGELOG.md can be hand-edited.
 -y, --yes                     Skip interactive confirmation prompts.
@@ -273,6 +295,13 @@ world-writable rc and exits with code 3; `chmod 644 .ver-bumprc` fixes it.
                               before bumping the stable component.
     --minor                   Force a minor bump (see --major for semantics).
     --patch                   Force a patch bump (see --major for semantics).
+    --branch                  Cut a release-<version> branch (the pre-2.0 default).
+                              Otherwise ver-bump tags the current branch in place.
+    --pr                      Create the release branch, push it, then open a pull
+                              request via the `gh` CLI. Implies a push to origin
+                              (override the remote with -p). Base resolves to --base,
+                              else the branch you ran ver-bump from.
+    --base <branch>           Base branch for the --pr pull request.
     --release                 After pushing, publish a GitHub release for the new tag.
                               Requires -p / --push <remote> and the `gh` CLI. Notes are
                               read from $VER_BUMP_RELEASE_NOTES_CMD (default

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -150,6 +150,49 @@ normalize-long-opts() {
         "Drop the '=<value>' — --release is a boolean flag."
     fi
 
+    # --pr — long-only boolean: open a release PR via `gh`. A PR needs its head
+    # branch on the remote, so --pr implies a release branch (--branch) and a
+    # push (-p origin by default; override the remote with -p). --pr=value rejected.
+    if [ "$arg" = "--pr" ]; then
+      DO_PR=true
+      FLAG_BRANCH=true
+      FLAG_PUSH=true
+      continue
+    elif [[ "$arg" == "--pr="* ]]; then
+      fail 2 \
+        "Option --pr doesn't take a value." \
+        "Drop the '=<value>' — --pr is a boolean flag (use --base <branch> to set the PR target)."
+    fi
+
+    # --branch — long-only boolean: opt into cutting a release-<v> branch (the
+    # pre-2.0 default). Without it (or --pr), ver-bump tags the current branch.
+    if [ "$arg" = "--branch" ]; then
+      FLAG_BRANCH=true
+      continue
+    elif [[ "$arg" == "--branch="* ]]; then
+      fail 2 \
+        "Option --branch doesn't take a value." \
+        "Drop the '=<value>' — --branch is a boolean flag (did you mean --branch-prefix=?)."
+    fi
+
+    # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
+    # value flag (no short form), captured here like --undo so it needs no getopts slot.
+    if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then
+      if [[ "$arg" == "--base="* ]]; then
+        PR_BASE="${arg#--base=}"
+        [ -z "$PR_BASE" ] && fail 2 \
+          "--base= requires a branch name." \
+          "Pass a base branch: --base <branch> or --base=<branch>."
+      elif (( $# )) && [ "${1:0:1}" != "-" ]; then
+        PR_BASE="$1"; shift
+      else
+        fail 2 \
+          "Option --base requires a branch name." \
+          "Pass a base branch: --base <branch> or --base=<branch>."
+      fi
+      continue
+    fi
+
     # --major / --minor / --patch — long-only boolean bump-level switches.
     # Mutually exclusive with each other; the -v / --version conflict is
     # caught later when getopts processes -v (BUMP_LEVEL is already set
@@ -241,6 +284,7 @@ process-arguments() {
   # .ver-bumprc assignment (load-config sources the rc as raw shell) — can't
   # silently force a bump or publish a release with no flag on the command line.
   DO_RELEASE=false
+  DO_PR=false
   BUMP_LEVEL=
 
   normalize-long-opts "$@"
@@ -300,8 +344,9 @@ process-arguments() {
         echo -e "\n${S_LIGHT}Option set:${RESET} disable commit (and tag + push) after bumping files."
       ;;
       b )
-        FLAG_NOBRANCH=true
-        echo -e "\n${S_LIGHT}Option set:${RESET} disable creating a new release-x.x.x branch."
+        # Deprecated as of 2.0: tag-in-place is the default, so -b/--no-branch is
+        # a no-op. Kept so existing scripts/CI don't hard-fail. Use --branch to opt in.
+        echo -e "\n${S_LIGHT}Note:${RESET} -b/--no-branch is deprecated — tag-in-place is the default now; use --branch to cut a release branch." >&2
       ;;
       c )
         FLAG_NOCHANGELOG=true

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -142,15 +142,15 @@ _ver_bump() {
             return 0
             ;;
         # Options that take a free-form argument — no completion
-        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo)
+        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo|--base)
             return 0
             ;;
     esac
 
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
-          --yes --undo --major --minor --patch --release --help --completions \
-          --install-completions --about \
+          --yes --undo --branch --pr --base --major --minor --patch --release \
+          --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
@@ -181,6 +181,9 @@ _ver_bump() {
     '(-h --help)'{-h,--help}'[show help]' \
     '(-y --yes)'{-y,--yes}'[skip interactive confirmation prompts]' \
     '--undo[locally delete release branch + tag for <version>]::version:' \
+    '--branch[cut a release-x.x.x branch (else tag in place)]' \
+    '--pr[branch + push + open a release PR via gh]' \
+    '--base[base branch for --pr]:branch:' \
     '(--major --minor --patch -v --version)--major[force a major bump from the current version]' \
     '(--major --minor --patch -v --version)--minor[force a minor bump from the current version]' \
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
@@ -212,6 +215,9 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd -s h -l help           -d 'Show help'
     complete -c $_cmd -s y -l yes            -d 'Skip interactive confirmation prompts'
     complete -c $_cmd      -l undo           -d 'Locally delete release branch + tag for <version>'
+    complete -c $_cmd      -l branch         -d 'Cut a release-x.x.x branch (else tag in place)'
+    complete -c $_cmd      -l pr             -d 'Branch + push + open a release PR via gh'
+    complete -c $_cmd      -l base           -r -d 'Base branch for --pr'
     complete -c $_cmd      -l major          -d 'Force a major bump from the current version'
     complete -c $_cmd      -l minor          -d 'Force a minor bump from the current version'
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -14,7 +14,8 @@ true
 #
 # Supported keys (1:1 with existing globals):
 #   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX
-#   FLAG_NOBRANCH  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
+#   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
+#   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
 # user and not group- or world-writable. Any violation is refused with exit
@@ -22,6 +23,7 @@ true
 
 # Config-able keys, in a plain indexed array so bash 3.2 is happy.
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
+              FLAG_BRANCH PR_BASE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -13,7 +13,7 @@ dryrun() {
 }
 
 do-branch() {
-  [ "$FLAG_NOBRANCH" = true ] && return
+  [ "$FLAG_BRANCH" = true ] || return 0
 
   local BRANCH_MSG
 
@@ -32,7 +32,7 @@ do-branch() {
   else
     fail 1 \
       "Failed to create release branch: ${BRANCH_MSG}" \
-      "Resolve the git branch error above, or pass -b/--no-branch to skip branch creation."
+      "Resolve the git branch error above, or drop --branch/--pr to tag in place instead."
   fi
 }
 
@@ -103,10 +103,10 @@ do-push() {
   case "$CONFIRM" in
     [yY][eE][sS]|[yY] )
       echo -e "\nPushing branch + tag to <${S_VAL}${PUSH_DEST}${RESET}>..."
-      if [ "$FLAG_NOBRANCH" = true ]; then
-        REMOTE_REF=$(git rev-parse --abbrev-ref HEAD)
-      else
+      if [ "$FLAG_BRANCH" = true ]; then
         REMOTE_REF="${REL_PREFIX}${V_NEW}"
+      else
+        REMOTE_REF=$(git rev-parse --abbrev-ref HEAD)
       fi
 
       if [ "$FLAG_DRYRUN" = true ]; then
@@ -169,6 +169,57 @@ check-release-deps() {
     fail 3 \
       "--release requires an authenticated GitHub CLI, but 'gh auth status' failed." \
       "Run 'gh auth login' (or set GH_TOKEN) and retry."
+  fi
+}
+
+# Validate --pr preconditions and resolve the PR base branch. No-op unless
+# DO_PR=true. Mirrors check-release-deps (needs a commit + an authenticated gh).
+# Must run AFTER process-version (needs V_NEW) but BEFORE do-branch, while HEAD
+# is still the invocation branch — so the auto-detected base is the branch the
+# release was cut from. Resolution order: --base / PR_BASE (env/.ver-bumprc) >
+# invocation branch > remote default (<remote>/HEAD).
+check-pr-deps() {
+  [ "${DO_PR:-false}" = true ] || return 0
+
+  if [ "${FLAG_NOCOMMIT:-false}" = true ]; then
+    fail 2 \
+      "--pr is incompatible with -n / --no-commit (a PR needs a commit to propose)." \
+      "Drop -n / --no-commit, or drop --pr."
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    fail 3 \
+      "--pr requires the GitHub CLI (gh), but it isn't on PATH." \
+      "Install gh (https://cli.github.com) or drop --pr."
+  fi
+
+  # As with --release: gh on PATH isn't enough — an unauthenticated gh only
+  # fails at `gh pr create`, after the branch is already pushed. Fail fast.
+  # Skipped under --dry-run (a preview shouldn't require live credentials).
+  if [ "${FLAG_DRYRUN:-false}" != true ] && ! gh auth status >/dev/null 2>&1; then
+    fail 3 \
+      "--pr requires an authenticated GitHub CLI, but 'gh auth status' failed." \
+      "Run 'gh auth login' (or set GH_TOKEN) and retry."
+  fi
+
+  if [ -z "${PR_BASE:-}" ]; then
+    PR_BASE=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  fi
+  if [ -z "${PR_BASE:-}" ]; then
+    PR_BASE=$(git symbolic-ref --quiet --short "refs/remotes/${PUSH_DEST}/HEAD" 2>/dev/null || true)
+    PR_BASE="${PR_BASE#"${PUSH_DEST}/"}"
+  fi
+  if [ -z "${PR_BASE:-}" ]; then
+    fail 3 \
+      "--pr could not determine a base branch (detached HEAD and no ${PUSH_DEST}/HEAD)." \
+      "Pass one explicitly: --base <branch>."
+  fi
+
+  # The PR head is the release branch; a PR into itself is invalid.
+  if [ "$PR_BASE" = "${REL_PREFIX}${V_NEW}" ]; then
+    fail 2 \
+      "--pr base branch '${PR_BASE}' is the same as the release branch head." \
+      "Pass a different base: --base <branch>."
   fi
 }
 
@@ -236,9 +287,55 @@ do-github-release() {
   log_success "Published GitHub release: ${gh_msg}"
 }
 
-# do-undo [<version>] — locally undo the artefacts of a prior ver-bump run:
-# delete the release branch and tag for <version>. Refuses if the working
-# tree is dirty, if the tag/branch were pushed, or if the branch was merged.
+# Open a GitHub pull request for the release branch (head = release-<v>,
+# base = $PR_BASE resolved by check-pr-deps). No-op unless DO_PR=true. Like
+# do-github-release, it needs a commit and a successful push (the head branch
+# must be on the remote). Honours FLAG_DRYRUN by printing the resolved
+# `gh pr create` invocation instead of executing it.
+do-pr() {
+  [ "${DO_PR:-false}" = true ] || return 0
+  # No commit → no release branch content to propose.
+  [ "${FLAG_NOCOMMIT:-false}" = true ] && return 0
+  # The push must have reached the remote; otherwise the head branch isn't there.
+  if [ "${PUSH_OK:-true}" != true ]; then
+    log_warn "Skipping release PR — the push did not succeed, so the branch isn't on the remote."
+    log_trace "Fix the push, then run: gh pr create --head ${REL_PREFIX}${V_NEW} --base ${PR_BASE}"
+    return 0
+  fi
+
+  local head title body RANGE
+  head="${REL_PREFIX}${V_NEW}"
+  title="Release ${TAG_PREFIX}${V_NEW}"
+  # Body mirrors the changelog entry: commits since the previous tag (same range
+  # do-changelog uses), so the PR description is useful even when -c was passed.
+  RANGE=$([ "$(git tag -l "${TAG_PREFIX}${V_PREV}")" ] && echo "${TAG_PREFIX}${V_PREV}..HEAD")
+  # shellcheck disable=SC2086
+  body=$( git log --pretty=format:"- %s" ${RANGE} 2>/dev/null )
+  [ -z "$body" ] && body="Release ${TAG_PREFIX}${V_NEW} (${V_PREV} → ${V_NEW})."
+
+  echo -e "\nOpening release PR..."
+
+  if [ "${FLAG_DRYRUN:-false}" = true ]; then
+    echo -e "${S_LIGHT}[dry-run]${RESET} would run: gh pr create --head ${S_VAL}${head}${RESET} --base ${S_VAL}${PR_BASE}${RESET} --title '${title}'" >&2
+    log_success "(dry-run) release PR prepared: ${S_VAL}${head}${RESET} → ${S_VAL}${PR_BASE}${RESET}"
+    return
+  fi
+
+  local pr_msg pr_rc
+  pr_msg=$( gh pr create --head "$head" --base "$PR_BASE" --title "$title" --body "$body" 2>&1 ); pr_rc=$?
+  if [ "$pr_rc" -ne 0 ]; then
+    fail 1 \
+      "gh pr create failed: ${pr_msg}" \
+      "The branch + tag were pushed; re-run 'gh pr create --head ${head} --base ${PR_BASE}' once the issue is fixed."
+  fi
+  log_success "Opened release PR: ${pr_msg}"
+}
+
+# do-undo [<version>] — locally undo the artefacts of a prior ver-bump run.
+# Branch-mode release: delete the release branch + tag. Tag-in-place release
+# (no branch, the 2.0 default): delete the tag and leave the bump commit in
+# place. Refuses if the working tree is dirty, if the tag/branch were pushed,
+# or if the branch was merged.
 # Honours FLAG_DRYRUN (print plan only) and FLAG_YES (skip confirmation).
 #
 # Resolution order for <version>:
@@ -285,9 +382,13 @@ do-undo() {
     "Tag '${tag}' does not exist locally — nothing to undo." \
     "Check 'git tag -l ${TAG_PREFIX}*' for what's available."
 
-  git rev-parse --verify --quiet "refs/heads/${branch}" >/dev/null || fail 3 \
-    "Branch '${branch}' does not exist locally — nothing to undo." \
-    "Check 'git branch --list ${REL_PREFIX}*' for what's available."
+  # The release branch is optional: tag-in-place releases (the 2.0 default) have
+  # a tag but no release branch. Branch present → full undo (delete branch + tag);
+  # branch absent → tag-only undo (delete the tag; the bump commit stays put).
+  local branch_exists=false
+  if git rev-parse --verify --quiet "refs/heads/${branch}" >/dev/null; then
+    branch_exists=true
+  fi
 
   # Pushed-state check across all remotes. If either the tag or the branch
   # exists on any remote, refuse and print the manual cleanup commands.
@@ -338,39 +439,49 @@ do-undo() {
       "Use 'git revert' on the merge or bump commit instead — undo would lose history."
   fi
 
-  # Pick a parent branch to switch to before deleting. Strategy:
-  #   1. reflog — the branch checked out immediately before 'release-X.Y.Z'
-  #   2. fallback — first non-release branch containing the bump's parent
-  parent_branch=$(
-    git reflog show --pretty='%gs' HEAD 2>/dev/null \
-      | awk -v b="$branch" '
-          /^checkout: moving from / {
-            from=$4; to=$6
-            if (to==b && from!=b) { print from; exit }
-          }'
-  )
-  if [ -z "$parent_branch" ] || ! git rev-parse --verify --quiet "refs/heads/${parent_branch}" >/dev/null; then
-    local parent_sha
-    parent_sha=$(git rev-parse "${branch}^" 2>/dev/null) || parent_sha=""
-    if [ -n "$parent_sha" ]; then
-      while read -r b; do
-        b="${b## }"; b="${b#\* }"; b="${b#+ }"
-        [[ -z "$b" || "$b" == "$branch" || "$b" == "${REL_PREFIX}"* ]] && continue
-        parent_branch="$b"; break
-      done < <(git branch --contains "$parent_sha" 2>/dev/null)
+  # Branch-mode only: find a branch to switch to before deleting the release
+  # branch. Skipped for tag-in-place (there's no branch to leave or delete).
+  if [ "$branch_exists" = true ]; then
+    # Pick a parent branch to switch to before deleting. Strategy:
+    #   1. reflog — the branch checked out immediately before 'release-X.Y.Z'
+    #   2. fallback — first non-release branch containing the bump's parent
+    parent_branch=$(
+      git reflog show --pretty='%gs' HEAD 2>/dev/null \
+        | awk -v b="$branch" '
+            /^checkout: moving from / {
+              from=$4; to=$6
+              if (to==b && from!=b) { print from; exit }
+            }'
+    )
+    if [ -z "$parent_branch" ] || ! git rev-parse --verify --quiet "refs/heads/${parent_branch}" >/dev/null; then
+      local parent_sha
+      parent_sha=$(git rev-parse "${branch}^" 2>/dev/null) || parent_sha=""
+      if [ -n "$parent_sha" ]; then
+        while read -r b; do
+          b="${b## }"; b="${b#\* }"; b="${b#+ }"
+          [[ -z "$b" || "$b" == "$branch" || "$b" == "${REL_PREFIX}"* ]] && continue
+          parent_branch="$b"; break
+        done < <(git branch --contains "$parent_sha" 2>/dev/null)
+      fi
     fi
-  fi
-  if [ -z "$parent_branch" ]; then
-    fail 3 \
-      "Could not determine which branch to switch to before deleting '${branch}'." \
-      "Checkout your intended branch first, then re-run --undo."
+    if [ -z "$parent_branch" ]; then
+      fail 3 \
+        "Could not determine which branch to switch to before deleting '${branch}'." \
+        "Checkout your intended branch first, then re-run --undo."
+    fi
   fi
 
   section "Undo"
   log_info "Plan:"
-  log_trace "git checkout ${parent_branch}"
-  log_trace "git branch -D ${branch}"
+  if [ "$branch_exists" = true ]; then
+    log_trace "git checkout ${parent_branch}"
+    log_trace "git branch -D ${branch}"
+  fi
   log_trace "git tag -d ${tag}"
+  if [ "$branch_exists" != true ]; then
+    log_info "Tag-in-place release: the version-bump commit stays on your current branch."
+    log_trace "git reset --hard HEAD~1   # also drop the bump commit — only if it's HEAD and unpushed"
+  fi
 
   if [ "${FLAG_DRYRUN:-false}" = true ]; then
     printf '\n%b[dry-run]%b no changes made.\n' "${S_LIGHT-}" "${RESET-}"
@@ -386,17 +497,23 @@ do-undo() {
     esac
   fi
 
-  git checkout "$parent_branch" >/dev/null 2>&1 || fail 1 \
-    "Failed to checkout '${parent_branch}'." \
-    "Resolve the issue manually, then re-run --undo."
+  if [ "$branch_exists" = true ]; then
+    git checkout "$parent_branch" >/dev/null 2>&1 || fail 1 \
+      "Failed to checkout '${parent_branch}'." \
+      "Resolve the issue manually, then re-run --undo."
 
-  git branch -D "$branch" >/dev/null 2>&1 || fail 1 \
-    "Failed to delete branch '${branch}'." \
-    "Delete it manually with: git branch -D ${branch}"
+    git branch -D "$branch" >/dev/null 2>&1 || fail 1 \
+      "Failed to delete branch '${branch}'." \
+      "Delete it manually with: git branch -D ${branch}"
+  fi
 
   git tag -d "$tag" >/dev/null 2>&1 || fail 1 \
     "Failed to delete tag '${tag}'." \
     "Delete it manually with: git tag -d ${tag}"
 
-  log_success "Undid release ${S_VAL}${ver}${RESET-} — back on ${S_VAL}${parent_branch}${RESET-}"
+  if [ "$branch_exists" = true ]; then
+    log_success "Undid release ${S_VAL}${ver}${RESET-} — back on ${S_VAL}${parent_branch}${RESET-}"
+  else
+    log_success "Undid release ${S_VAL}${ver}${RESET-} — deleted tag ${S_VAL}${tag}${RESET-} (bump commit left in place)."
+  fi
 }

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -14,11 +14,11 @@ check-commits-exist() {
 
 #
 check-branch-notexist() {
-  [ "$FLAG_NOBRANCH" = true ] && return
+  [ "$FLAG_BRANCH" = true ] || return 0
   if git rev-parse --verify "${REL_PREFIX}${V_NEW}" &> /dev/null; then
     fail 3 \
       "Branch <${REL_PREFIX}${V_NEW}> already exists." \
-      "Delete the existing branch (git branch -D ${REL_PREFIX}${V_NEW}), pick a different version, or pass -b/--no-branch to skip branch creation."
+      "Delete the existing branch (git branch -D ${REL_PREFIX}${V_NEW}), pick a different version, or drop --branch/--pr to tag in place instead."
   fi
 }
 

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -46,7 +46,7 @@ usage() {
   printf '\n%bUSAGE %b\n' "${S_HDR_CYAN-}" "${S_HDR_END-}"
   printf '  %b%s%b [-v <version>] [-m <message>] [-f <file.json>]... [-p <remote>] [-t <tag-prefix>] [-B <branch-prefix>] [-d] [-n] [-b] [-c] [-l] [-h]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
-  printf '  %b%s%b [--major | --minor | --patch] [--release] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
+  printf '  %b%s%b [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
 
   # Column width for label + 2-space gutter. Longest label is
@@ -114,7 +114,7 @@ usage() {
   print-opt-row "-B" "--branch-prefix" "<prefix>"    "Override branch prefix (default: release-)."
   print-opt-row "-d" "--dry-run"       ""            "Dry-run: print every side-effect without executing."
   print-opt-row "-n" "--no-commit"     ""            "Disable commit (and tag + push) after bumping files."
-  print-opt-row "-b" "--no-branch"     ""            "Disable creating a new release-x.x.x branch."
+  print-opt-row "-b" "--no-branch"     ""            "(deprecated) Tag-in-place is the default now; this is a no-op."
   print-opt-row "-c" "--no-changelog"  ""            "Disable updating CHANGELOG.md automatically."
   print-opt-row "-l" "--pause-changelog" ""          "Pause before commit so CHANGELOG.md can be edited."
   print-opt-row "-h" "--help"          ""            "Show this help message."
@@ -123,6 +123,9 @@ usage() {
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
   print-opt-row ""   "--patch"              ""            "Force a patch bump from the current version (mutually exclusive)."
+  print-opt-row ""   "--branch"             ""            "Cut a release-x.x.x branch (pre-2.0 default); otherwise tag in place."
+  print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (implies push to origin)."
+  print-opt-row ""   "--base"               "<branch>"    "Base branch for --pr (default: the branch you ran ver-bump from)."
   print-opt-row ""   "--release"            ""            "Publish a GitHub release for the new tag (requires -p; uses 'gh')."
   print-opt-row ""   "--about"              ""            "Print name, version, author, and homepage; then exit."
   print-opt-row ""   "--completions"        "<shell>"     "Emit completion script for bash, zsh, or fish."
@@ -134,6 +137,7 @@ usage() {
   print-example-row "${SCRIPT_NAME} -v 2.0.0"              "Non-interactive, explicit version."
   print-example-row "${SCRIPT_NAME} --dry-run"             "Preview every side-effect without executing."
   print-example-row "${SCRIPT_NAME} -p origin"             "Push the release branch + tag when done."
+  print-example-row "${SCRIPT_NAME} --pr"                  "Branch, push, and open a release PR (needs gh)."
   print-example-row "${SCRIPT_NAME} -t release/"           "Use a custom tag prefix (e.g. release/1.2.3)."
   print-example-row "${SCRIPT_NAME} -f composer.json"      "Also bump version in an extra JSON file."
   print-example-row "${SCRIPT_NAME} --about"               "Show branded version info."

--- a/test/args.bats
+++ b/test/args.bats
@@ -81,12 +81,41 @@ load 'test_helper'
 
 @test "long options: boolean flags set corresponding globals" {
   source ${profile_script}
-  process-arguments --dry-run --no-commit --no-branch --no-changelog --pause-changelog
+  process-arguments --dry-run --no-commit --no-changelog --pause-changelog
   assert_equal "${FLAG_DRYRUN}" "true"
   assert_equal "${FLAG_NOCOMMIT}" "true"
-  assert_equal "${FLAG_NOBRANCH}" "true"
   assert_equal "${FLAG_NOCHANGELOG}" "true"
   assert_equal "${FLAG_CHANGELOG_PAUSE}" "true"
+}
+
+@test "long options: --branch sets FLAG_BRANCH" {
+  source ${profile_script}
+  process-arguments --branch
+  assert_equal "${FLAG_BRANCH}" "true"
+}
+
+@test "long options: --pr implies branch + push and sets DO_PR" {
+  source ${profile_script}
+  process-arguments --pr
+  assert_equal "${DO_PR}" "true"
+  assert_equal "${FLAG_BRANCH}" "true"
+  assert_equal "${FLAG_PUSH}" "true"
+}
+
+@test "long options: --base sets PR_BASE (space and = forms)" {
+  source ${profile_script}
+  process-arguments --base develop
+  assert_equal "${PR_BASE}" "develop"
+  process-arguments --base=release/x
+  assert_equal "${PR_BASE}" "release/x"
+}
+
+@test "long options: --pr=value and --base without value are rejected" {
+  source ${profile_script}
+  run process-arguments --pr=foo
+  assert_failure 2
+  run process-arguments --base
+  assert_failure 2
 }
 
 @test "long options: --push <remote> sets push flag + dest" {
@@ -235,14 +264,15 @@ load 'test_helper'
   assert_output --partial "disable commit (and tag + push) after bumping files."
 }
 
-@test "process-arguments: -b: set flag to disable creating a release branch" {
+@test "process-arguments: -b / --no-branch is a deprecated no-op" {
   source ${profile_script}
   process-arguments -b
-  assert_equal "${FLAG_NOBRANCH}" "true"
+  # Tag-in-place is the default as of 2.0, so -b no longer cuts a branch.
+  assert_equal "${FLAG_BRANCH:-false}" "false"
 
   run process-arguments -b
   strip_ansi_output
-  assert_output --partial "disable creating a new release-x.x.x branch."
+  assert_output --partial "deprecated"
 }
 
 @test "process-arguments: -c: set flag to disable creating/updating CHANGELOG.md" {

--- a/test/e2e-live.bats
+++ b/test/e2e-live.bats
@@ -21,7 +21,7 @@ load 'test_helper'
   CLEANUP_CMDS+=("rm -rf ${remote}")
   git init -q --bare "${remote}"
 
-  run ${profile_script} -v 1.3.0 -p "${remote}" -y
+  run ${profile_script} -v 1.3.0 -p "${remote}" -y --branch
   assert_success
 
   # 1. release branch created AND checked out

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -149,6 +149,7 @@ load 'test_helper'
   source ${profile_script}
   cd "$(scratch_repo)"
   V_NEW="1.2.3"
+  FLAG_BRANCH=true
   git branch "${REL_PREFIX}${V_NEW}"
   run check-branch-notexist
   assert_failure 3

--- a/test/git-ops.bats
+++ b/test/git-ops.bats
@@ -14,7 +14,7 @@ load 'test_helper'
   source ${profile_script}
   cd "$(scratch_repo)"
 
-  local V_NEW="123.456.7"
+  local FLAG_BRANCH=true V_NEW="123.456.7"
   git branch "${REL_PREFIX}${V_NEW}"
 
   run check-branch-notexist
@@ -25,7 +25,7 @@ load 'test_helper'
   source ${profile_script}
   cd "$(scratch_repo)"
 
-  local V_NEW="123.456.78338834"
+  local FLAG_BRANCH=true V_NEW="123.456.78338834"
 
   run check-branch-notexist
   assert_success
@@ -35,10 +35,28 @@ load 'test_helper'
   source ${profile_script}
   cd "$(scratch_repo)"
 
-  local V_NEW="123.456.7"
+  local FLAG_BRANCH=true V_NEW="123.456.7"
 
   run do-branch
   assert_success
+
+  run git rev-parse --abbrev-ref HEAD
+  assert_output "${REL_PREFIX}123.456.7"
+}
+
+@test "do-branch: is a no-op in tag-in-place mode (FLAG_BRANCH unset)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  local V_NEW="123.456.7" start
+  start="$(git rev-parse --abbrev-ref HEAD)"
+
+  run do-branch
+  assert_success
+
+  # No release branch created; still on the original branch.
+  run git rev-parse --abbrev-ref HEAD
+  assert_output "${start}"
 }
 
 @test "do-tag: create a tag" {

--- a/test/pr.bats
+++ b/test/pr.bats
@@ -1,0 +1,201 @@
+#!/usr/bin/env bats
+
+# --pr flag: after the branch + tag are pushed, open a GitHub pull request for
+# the release branch via the `gh` CLI (head = release-<v>, base = $PR_BASE).
+# --pr implies --branch and a push, and — like --release — only needs `gh` when
+# it's passed; the default ver-bump path stays bash + git + jq only. Mirrors the
+# gh-shim-on-PATH pattern from release.bats.
+
+load 'test_helper'
+
+# Write a fake `gh` onto a fresh PATH dir. `gh auth …` succeeds; every other
+# call echoes "GH-CALL: <args>" so tests can assert the exact invocation.
+_gh_shim() {
+  local shim
+  shim=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${shim}")
+  cat > "${shim}/gh" <<'SH'
+#!/bin/sh
+[ "$1" = "auth" ] && exit 0
+echo "GH-CALL: $*"
+exit 0
+SH
+  chmod +x "${shim}/gh"
+  printf '%s' "$shim"
+}
+
+@test "pr: --pr but gh missing exits 3" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local shim
+  shim=$(mktemp -d); CLEANUP_CMDS+=("rm -rf ${shim}")
+  # git on PATH but no gh
+  cat > "${shim}/git" <<'SH'
+#!/bin/sh
+exec /usr/bin/env git "$@"
+SH
+  chmod +x "${shim}/git"
+
+  DO_PR=true V_NEW=1.2.3 PATH="${shim}" run check-pr-deps
+  assert_failure 3
+  assert_output --partial "gh"
+}
+
+@test "pr: --pr with -n / --no-commit exits 2" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  run ${profile_script} --pr -n -v 1.0.1
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "incompatible with -n"
+}
+
+@test "pr: gh present but unauthenticated exits 3" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local shim
+  shim=$(mktemp -d); CLEANUP_CMDS+=("rm -rf ${shim}")
+  cat > "${shim}/gh" <<'SH'
+#!/bin/sh
+[ "$1" = "auth" ] && exit 1
+exit 0
+SH
+  chmod +x "${shim}/gh"
+
+  DO_PR=true FLAG_DRYRUN=false V_NEW=1.2.3 PATH="${shim}:$PATH" run check-pr-deps
+  assert_failure 3
+  assert_output --partial "authenticated"
+}
+
+@test "pr: --dry-run skips the gh auth check" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local shim
+  shim=$(mktemp -d); CLEANUP_CMDS+=("rm -rf ${shim}")
+  cat > "${shim}/gh" <<'SH'
+#!/bin/sh
+[ "$1" = "auth" ] && exit 1
+exit 0
+SH
+  chmod +x "${shim}/gh"
+
+  DO_PR=true FLAG_DRYRUN=true V_NEW=1.2.3 PATH="${shim}:$PATH" run check-pr-deps
+  assert_success
+}
+
+@test "pr: --base equal to the release head is rejected" {
+  local repo shim
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+  shim="$(_gh_shim)"
+
+  PATH="${shim}:$PATH" run ${profile_script} --pr -d -c -v 1.2.3 --base release-1.2.3
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "same as the release branch head"
+}
+
+@test "pr: --pr --dry-run prints resolved gh pr create with head + base" {
+  local repo shim
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+  shim="$(_gh_shim)"
+
+  PATH="${shim}:$PATH" run ${profile_script} --pr -d -c -v 1.2.3 --base main
+  assert_success
+  strip_ansi_output
+  assert_output --partial "[dry-run]"
+  assert_output --partial "gh pr create --head release-1.2.3 --base main"
+}
+
+@test "pr: base auto-detects the invocation branch when --base omitted" {
+  local repo shim
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+  git checkout -q -b develop
+  shim="$(_gh_shim)"
+
+  PATH="${shim}:$PATH" run ${profile_script} --pr -d -c -v 1.2.3
+  assert_success
+  strip_ansi_output
+  assert_output --partial "gh pr create --head release-1.2.3 --base develop"
+}
+
+@test "pr: --pr --dry-run leaves the working tree byte-identical" {
+  local repo shim before after
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+  shim="$(_gh_shim)"
+
+  before=$(git status --porcelain)
+  PATH="${shim}:$PATH" run ${profile_script} --pr -d -c -v 1.2.3 --base main
+  assert_success
+  after=$(git status --porcelain)
+  assert_equal "$before" "$after"
+}
+
+@test "pr: a failed push skips the release PR" {
+  local repo shim
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+  shim="$(_gh_shim)"
+
+  # 'origin' is not configured, so the push fails. Live run (no -d).
+  PATH="${shim}:$PATH" run ${profile_script} --pr -p origin -c -v 1.2.5 --base main
+  strip_ansi_output
+  assert_output --partial "Push failed"
+  assert_output --partial "Skipping release PR"
+  refute_output --partial "GH-CALL: pr create"
+}
+
+@test "pr: live path runs gh pr create with head + base" {
+  local repo remote shim
+  repo="$(scratch_repo)"; cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed"
+
+  remote=$(mktemp -d); CLEANUP_CMDS+=("rm -rf ${remote}")
+  git init -q --bare "${remote}"
+  shim="$(_gh_shim)"
+
+  PATH="${shim}:$PATH" run ${profile_script} --pr -p "${remote}" -c -v 1.2.5 --base main
+  strip_ansi_output
+  assert_output --partial "GH-CALL: pr create --head release-1.2.5 --base main"
+  assert_output --partial "Opened release PR"
+}
+
+@test "pr: do-pr noop when DO_PR unset" {
+  source ${profile_script}
+  unset DO_PR
+  run do-pr
+  assert_success
+  refute_output --partial "gh pr create"
+}
+
+@test "completions: bash completion lists --pr / --branch / --base" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial "--pr"
+  assert_output --partial "--branch"
+  assert_output --partial "--base"
+}
+
+@test "completions: zsh completion lists --pr" {
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial "--pr"
+}
+
+@test "completions: fish completion lists --pr" {
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial "-l pr"
+}

--- a/test/prefixes.bats
+++ b/test/prefixes.bats
@@ -37,6 +37,7 @@ load 'test_helper'
   source ${profile_script}
   cd "$(scratch_repo)"
 
+  FLAG_BRANCH=true
   REL_PREFIX="hotfix-"
   V_NEW="9.9.9"
 

--- a/test/ui.bats
+++ b/test/ui.bats
@@ -38,10 +38,11 @@ load 'test_helper'
   # ($S_LIGHT) and the narrative body is plain.
   run grep -rh --include='*.sh' -c 'S_LIGHT}Option set:${RESET}' "${repo_dir}/lib"
   assert_success
-  # At least the 10 option handlers (-m, -f, -p, -t, -B, -d, -n, -b, -c, -l).
+  # At least the 9 option handlers that still emit a set-banner (-m, -f, -p,
+  # -t, -B, -d, -n, -c, -l). -b/--no-branch is a deprecation note as of 2.0.
   local total=0 line
   while IFS= read -r line; do total=$((total + line)); done <<< "${output}"
-  [ "${total}" -ge 10 ]
+  [ "${total}" -ge 9 ]
 }
 
 @test "UI: dry-run lines keep [dry-run] dim marker" {

--- a/test/undo.bats
+++ b/test/undo.bats
@@ -48,6 +48,47 @@ teardown() {
   assert_success
 }
 
+# Recreate a tag-in-place release (the 2.0 default): the bump commit + tag live
+# on the current branch, with NO release-<v> branch. Folds the setup's release
+# branch into feat/x, then drops it.
+_make_tag_in_place() {
+  git checkout -q feat/x
+  git reset -q --hard v1.2.0
+  git branch -D release-1.2.0
+}
+
+@test "undo: tag-in-place (no release branch) deletes the tag, keeps the commit" {
+  _make_tag_in_place
+
+  run ${profile_script} --undo 1.2.0 --yes
+  assert_success
+  strip_ansi_output
+  assert_output --partial "deleted tag v1.2.0"
+
+  # Tag gone…
+  run git tag -l v1.2.0
+  assert_output ""
+  # …but the bump commit stays on the current branch, and we didn't switch away.
+  run git log -1 --pretty=%s
+  assert_output --partial "bumped 1.0.0 -> 1.2.0"
+  run git symbolic-ref --short HEAD
+  assert_output "feat/x"
+}
+
+@test "undo: tag-in-place --dry-run shows a tag-only plan and changes nothing" {
+  _make_tag_in_place
+
+  run ${profile_script} --undo 1.2.0 --dry-run
+  assert_success
+  strip_ansi_output
+  assert_output --partial "git tag -d v1.2.0"
+  refute_output --partial "git branch -D"
+  assert_output --partial "version-bump commit stays"
+  # Tag untouched.
+  run git tag -l v1.2.0
+  assert_output "v1.2.0"
+}
+
 @test "undo: --yes deletes branch + tag and switches to parent" {
   run ${profile_script} --undo --yes
   assert_success

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -80,6 +80,7 @@ main() {
   process-version
   check-branch-notexist
   check-tag-exists
+  check-pr-deps
 
   section "Release"
   do-packagefile-bump
@@ -90,6 +91,7 @@ main() {
   do-commit
   do-tag
   do-push
+  do-pr
   do-github-release
 
   section "Done"


### PR DESCRIPTION
## Why

ver-bump's gitflow `release-<v>` branch was the *forced* default — a workflow most teams have moved away from. This demotes it to one of three selectable workflows and adds the modern **release-PR** flow (the release-please / changesets pattern) that ver-bump was missing. It came out of a design review of where ver-bump sits vs. the field; net-new, with no pre-existing tracking issue. Relates to the v2.0 line (#37).

## What

Three workflows, picked per-run or via `.ver-bumprc`:

| Workflow | How | Result |
| --- | --- | --- |
| **Tag-in-place** *(new default)* | `ver-bump` | commit + tag the current branch |
| **Release branch** | `ver-bump --branch` | cut `release-<v>`, leave the merge to you |
| **Release PR** | `ver-bump --pr` | branch + push origin + `gh pr create` |

- `--pr` base resolves `--base` › `PR_BASE` (env / `.ver-bumprc`) › invocation branch › `<remote>/HEAD`
- `check-pr-deps` + `do-pr` mirror the existing `check-release-deps` / `do-github-release` machinery
- `FLAG_NOBRANCH` → positive `FLAG_BRANCH`; `-b` / `--no-branch` kept as a deprecated no-op
- `--undo` now handles tag-in-place releases (deletes the tag, keeps the bump commit)
- `.ver-bumprc` gains `FLAG_BRANCH` + `PR_BASE`; help text, completions (bash/zsh/fish), README *Workflows* section, and CHANGELOG updated

## ⚠️ Breaking

Bare `ver-bump` now **tags the current branch in place** instead of always cutting a `release-<v>` branch. Pass `--branch` for the old behaviour, or set `FLAG_BRANCH=true` in `.ver-bumprc` to make it the team default. `-b` / `--no-branch` still parses (no-op + deprecation notice), so existing scripts don't hard-fail.

## Tests

- New `test/pr.bats` (15 tests, `gh` shimmed on PATH) + tag-in-place `--undo` tests
- Default-flip fallout fixed across `e2e-live` / `args` / `git-ops` / `prefixes` / `ui` / `errors`
- **227 bats pass**, `shellcheck -x` clean, sandbox `--pr` dry-run verified end-to-end
