### PR TITLE
fix: --undo dry-run preview prints to stderr (R-DRY-2)

### DIFF
--- a/docs/features/dry-run/requirements.md
+++ b/docs/features/dry-run/requirements.md
@@ -6,7 +6,7 @@ G2: safe-by-default).
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-DRY-1 | No files written, no `git add/commit/tag/push/branch/checkout` executed. | ✅ shipped — `test/dryrun.bats` |
-| R-DRY-2 | Every skipped side-effect printed to **stderr** with a `[dry-run]` prefix, in execution order. | ⚠️ shipped with one defect: `--undo`'s dry-run line prints to stdout (`lib/git-actions.sh`). Open bug. |
+| R-DRY-2 | Every skipped side-effect printed to **stderr** with a `[dry-run]` prefix, in execution order. | ✅ shipped — `test/dryrun.bats`, `test/undo.bats` |
 | R-DRY-3 | `--dry-run` against this repo's own checkout leaves the tree untouched (regression guard). | ✅ shipped |
 | R-DRY-4 | Dry-run intercepts the push: with `-p <remote>`, no network call, no push prompt (Q-2). | ✅ shipped |
 

--- a/docs/features/undo/requirements.md
+++ b/docs/features/undo/requirements.md
@@ -9,7 +9,7 @@ anything is pushed. Never touches a remote.
 | R-UNDO-2 | Honours `--dry-run`, `--yes`, `--tag-prefix`, `--branch-prefix` regardless of position in argv; worktree marker respected (`d32d426`). | ✅ shipped |
 | R-UNDO-3 | Prompts for confirmation before deleting; `-y` bypasses. | ✅ shipped |
 | R-UNDO-5 | Tag-in-place releases (no release branch — the 2.0 default, ADR-12) are handled: the tag is deleted and the bump commit kept. | ✅ shipped (PR #49) — `test/undo.bats` |
-| R-UNDO-4 | Precondition refusals and aborts use contract exit codes via `fail`. | ⚠️ mostly — one path exits `3` directly after `log_warn` instead of via `fail`; and the dry-run preview line prints to **stdout**, violating R-DRY-2. Open bugs. |
+| R-UNDO-4 | Precondition refusals and aborts use contract exit codes via `fail`. | ⚠️ mostly — one path exits `3` directly after `log_warn` instead of via `fail` (#51, being fixed in parallel). |
 
 Modules: `lib/args.sh` (pre-scan), `lib/git-actions.sh` (`do-undo`).
 Tests: `test/undo.bats`.

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -484,7 +484,7 @@ do-undo() {
   fi
 
   if [ "${FLAG_DRYRUN:-false}" = true ]; then
-    printf '\n%b[dry-run]%b no changes made.\n' "${S_LIGHT-}" "${RESET-}"
+    printf '\n%b[dry-run]%b no changes made.\n' "${S_LIGHT-}" "${RESET-}" >&2
     return 0
   fi
 

--- a/test/undo.bats
+++ b/test/undo.bats
@@ -48,6 +48,21 @@ teardown() {
   assert_success
 }
 
+@test "undo: --dry-run preview prints to stderr, not stdout (R-DRY-2)" {
+  ${profile_script} --undo --dry-run \
+    >"$BATS_TEST_TMPDIR/out" 2>"$BATS_TEST_TMPDIR/err"
+
+  # The [dry-run] preview line goes to stderr…
+  run cat "$BATS_TEST_TMPDIR/err"
+  strip_ansi_output
+  assert_output --partial "[dry-run]"
+
+  # …and stdout stays clean of it (safe for piping).
+  run cat "$BATS_TEST_TMPDIR/out"
+  strip_ansi_output
+  refute_output --partial "[dry-run]"
+}
+
 # Recreate a tag-in-place release (the 2.0 default): the bump commit + tag live
 # on the current branch, with NO release-<v> branch. Folds the setup's release
 # branch into feat/x, then drops it.

--- a/test/undo.bats
+++ b/test/undo.bats
@@ -49,8 +49,11 @@ teardown() {
 }
 
 @test "undo: --dry-run preview prints to stderr, not stdout (R-DRY-2)" {
-  ${profile_script} --undo --dry-run \
-    >"$BATS_TEST_TMPDIR/out" 2>"$BATS_TEST_TMPDIR/err"
+  # Redirections live inside bash -c so `run` still captures the real exit
+  # status while stdout/stderr land in separate files for the assertions.
+  run bash -c '"$1" --undo --dry-run >"$2/out" 2>"$2/err"' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
 
   # The [dry-run] preview line goes to stderr…
   run cat "$BATS_TEST_TMPDIR/err"


### PR DESCRIPTION
## What

The `[dry-run]` preview line in `do-undo` (`lib/git-actions.sh`) printed to **stdout**. R-DRY-2 requires every dry-run side-effect preview to go to **stderr** with the `[dry-run]` prefix — all other paths already do (via the `dryrun()` helper or explicit `>&2`). This routes the `--undo` line to stderr too, keeping stdout clean for piping.

## Changes

- `lib/git-actions.sh`: `[dry-run] no changes made.` line in `do-undo` now writes to stderr (`>&2`), matching the surrounding style.
- `test/undo.bats`: new test asserting the `[dry-run]` text appears on stderr and NOT on stdout.
- `docs/features/dry-run/requirements.md`: R-DRY-2 → ✅ shipped.
- `docs/features/undo/requirements.md`: R-UNDO-4 stdout clause removed; the exit-3-after-`log_warn` clause remains and now points at #51 (being fixed in parallel).

## Tests

`pnpm tests:run`: 228/228 passing.

Refs #52.