### PR TITLE
fix: ESC abort + undo precondition exit via fail with contract codes

### DIFF
--- a/docs/features/exit-codes/requirements.md
+++ b/docs/features/exit-codes/requirements.md
@@ -13,15 +13,8 @@ Stable machine contract (PRD G4) so CI wrappers can branch on failure class.
 
 | ID | Requirement | Status |
 | --- | --- | --- |
-| R-EXIT-1 | Every user-visible error path exits with a contract code via `fail`, never bare `exit 1`. | ⚠️ shipped with known deviations (below) |
+| R-EXIT-1 | Every user-visible error path exits with a contract code via `fail`, never bare `exit 1`. | ✅ shipped — ESC at the version prompt and the `--undo` remote-artefacts precondition now exit via `fail` (`5` and `3`) |
 | R-EXIT-2 | Contract is versioned with the major release; must not shift between `2.x` patches. | ✅ documented here + `lib/errors.sh` |
-
-Known deviations (open bugs):
-
-- ESC at the version prompt exits `130` (`lib/version.sh`) instead of `5`,
-  and bypasses `fail`. The push-decline path correctly uses `fail 5`.
-- One `--undo` precondition path exits `3` directly after `log_warn`
-  (`lib/git-actions.sh`) instead of via `fail`.
 
 Modules: `lib/errors.sh` (`fail <code> <message> [hint]`).
 Tests: `test/errors.bats` (19) — every new `fail` site needs a case here.

--- a/docs/features/version-input/requirements.md
+++ b/docs/features/version-input/requirements.md
@@ -14,7 +14,7 @@ Prompt UX (shipped in 2.0, backfilled requirements):
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-VER-4 | The version prompt pre-fills the suggestion as an editable default. | ✅ shipped (`cd87052`) |
-| R-VER-5 | ESC at the prompt aborts the run with no mutation. | ⚠️ shipped, but exits `130` — the exit-code contract says user abort = `5`. Open bug; see [exit-codes](../exit-codes/requirements.md). |
+| R-VER-5 | ESC at the prompt aborts the run with no mutation. | ✅ shipped — exits `5` via `fail` per the [exit-code contract](../exit-codes/requirements.md); `test/errors.bats` |
 
 Modules: `lib/version.sh`, `lib/validate.sh`. Tests: `test/version.bats` (22),
 `test/versionfile.bats`, `test/bumpfile.bats`.

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -403,7 +403,6 @@ do-undo() {
   done < <(git remote)
 
   if (( ${#remote_hits[@]} > 0 )); then
-    log_warn "Refusing to undo — release artefacts are present on remote(s):"
     local hit
     for hit in "${remote_hits[@]}"; do
       log_trace "$hit"
@@ -412,7 +411,9 @@ do-undo() {
     log_trace "git push origin :refs/tags/${tag}      # delete remote tag"
     log_trace "git push origin --delete ${branch}    # delete remote branch"
     log_trace "git tag -d ${tag} && git branch -D ${branch}"
-    exit 3
+    fail 3 \
+      "Refusing to undo — release artefacts are present on remote(s): ${remote_hits[*]}." \
+      "Delete the remote tag/branch first (commands above), then re-run --undo."
   fi
 
   # Refuse if the release branch's tip has already been merged into another

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -88,8 +88,12 @@ process-version() {
     local _first
     IFS= read -rsn1 _first
     if [ "$_first" = $'\e' ]; then
-      printf '\n\n%b aborted %b\n' "${S_HDR_RED-}" "${S_HDR_END-}"
-      exit 130
+      # Terminate the (no-newline) prompt line, then abort via fail so the
+      # exit code honours the contract: user abort = 5, never a raw exit.
+      printf '\n'
+      fail 5 \
+        "version prompt aborted" \
+        "Re-run and enter a version (or <enter> for the suggestion), or pass -v <version> to skip the prompt."
     fi
     if [ -z "$_first" ]; then
       V_USR_INPUT=""

--- a/test/errors.bats
+++ b/test/errors.bats
@@ -187,6 +187,19 @@ SH
   assert_output --partial "--yes"
 }
 
+@test "exit code: ESC at the version prompt -> 5 via fail" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  V_TEST="1.2.3"
+  create_ver_file
+  # First byte on stdin is ESC — the prompt's single-keystroke pre-read
+  # detects it and must abort via `fail 5`, not a raw `exit 130`.
+  run process-version <<< $'\e'
+  assert_failure 5
+  assert_output --partial "version prompt aborted"
+  assert_output --partial "Hint:"
+}
+
 @test "exit code: do-push declining the prompt -> 5" {
   source ${profile_script}
   cd "$(scratch_repo)"

--- a/test/undo.bats
+++ b/test/undo.bats
@@ -130,8 +130,12 @@ _make_tag_in_place() {
   git push -q origin release-1.2.0 v1.2.0
   run ${profile_script} --undo --yes
   assert_failure 3
+  # Exits via `fail 3` (contract precondition), not a raw exit after log_warn.
+  assert_output --partial "Error:"
+  assert_output --partial "Refusing to undo"
   assert_output --partial "present on remote"
   assert_output --partial "git push origin :refs/tags/v1.2.0"
+  assert_output --partial "Hint:"
   rm -rf "$remote"
 }
 


### PR DESCRIPTION
Pressing ESC at the interactive version prompt exited with a raw `130`, violating the exit-code contract (user abort = `5`, always via `fail`). The same theme existed in `--undo`: the remote-artefacts precondition exited `3` directly after a `log_warn` instead of going through `fail`. Both paths now exit through `fail` with their contract codes, so CI wrappers can branch on failure class reliably.

- `lib/version.sh`: the ESC pre-read terminates the prompt line, then calls `fail 5 "version prompt aborted"` with a re-run hint — mirrors the push-decline `fail 5` style.
- `lib/git-actions.sh`: the `do-undo` remote-artefacts refusal ends in `fail 3` with the remote hits folded into the message and a delete-first hint; the manual-undo commands are still printed above it.
- `docs/features/version-input/requirements.md`: R-VER-5 marked shipped.
- `docs/features/exit-codes/requirements.md`: "Known deviations" removed; R-EXIT-1 marked shipped.

Behavioural note: `fail` prints a leading newline to stderr, so the unterminated prompt line only needs a single `printf '\n'` before it; the old red "aborted" banner is replaced by the standard `Error:`/`Hint:` block.

Tests: `test/errors.bats` +1 ("ESC at the version prompt -> 5 via fail", driven by injecting `$'\e'` on stdin like the existing prompt tests); `test/undo.bats` "refuses if pushed to remote" extended to assert code 3 plus the fail-styled `Error:`/`Hint:` output. Full suite: 228/228.

Refs #51.