### PR TITLE
docs: document Windows support status (Git Bash / WSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ In order to use `ver-bump` you need:
 - Have `git` and `jq` installed in your environment
 - `npm` / `node` are *optional* — only required if you want to install `ver-bump` from the npm registry, not at run time
 
+**Platform support** — `ver-bump` is pure bash, so it runs wherever bash does:
+
+- **Tested in CI:** Linux and macOS — the full test suite runs on both for every change.
+- **Expected to work:** WSL — it's just Linux underneath, with the same `bash` + `git` + `jq`.
+- **Best effort, untested:** Git Bash / MSYS2 — should work, but nothing in CI verifies it; if something breaks, CRLF line endings are the usual suspect.
+- **Unsupported:** native `cmd` / PowerShell — there's no bash there to run the script.
+
 ## Installation
 
 `ver-bump` is bash with `git` + `jq` as its only runtime dependencies, so
@@ -497,23 +504,18 @@ This project uses [bats](https://github.com/bats-core/bats-core) to test the fun
 
 To run the tests, first install the pre-requisites:
 
-Linux/MacOS: 
-
 ```sh
-$ npm run tests:install
-```
-
-Windows:
-
-```sh
-$ npm run tests:install:windows
+$ pnpm tests:install
 ```
 
 And finally, run the test suite:
 
 ```sh
-$ npm run tests:run
+$ pnpm tests:run
 ```
+
+> **On Windows?** Run the suite under [WSL](https://learn.microsoft.com/en-us/windows/wsl/) — bats can't run natively on
+> Windows (see [Requirements](#requirements) for the full platform-support picture).
 
 The suite covers short/long option parsing, SemVer validation (including
 prerelease and build metadata), prerelease counter bumping, conventional-commit

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -45,6 +45,9 @@ already in the tree — new code should match, not invent.
   only with a comment explaining why. Never blanket-disable at file scope
   unless the suppression applies to every line (e.g. `SC2034` in
   [lib/styles.sh](../lib/styles.sh) because vars are exported for call sites).
+- **Line endings:** LF only — [`.gitattributes`](../.gitattributes) pins
+  `*.sh` / `*.bash` / `*.bats` to `eol=lf`; don't override it with
+  `core.autocrlf`, because CRLF breaks shellcheck parsing and the bats suite.
 
 ### UI / colour discipline
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "release": "gh release create --notes \"$(npx jv-k/releasetool)\"",
     "tests:install": "./install_bats.sh",
     "tests:run": "./test/bats/bin/bats ./test/*.bats",
-    "tests:install:windows": "sh ./install_bats.sh",
-    "tests:run:windows": "sh ./test/bats/bin/bats ./test/*.bats",
     "lint": "shellcheck -x -e SC1017 ./ver-bump.sh ./lib/*.sh",
     "screenshots": "./dev/capture-freeze.sh",
     "screenshots:help": "./dev/capture-freeze.sh help",


### PR DESCRIPTION
Windows was dropped from the CI matrix (CRLF made shellcheck results meaningless there), but the decision was invisible to users: `package.json` still shipped `tests:*:windows` scripts and the README said nothing about platform support. This PR makes the support status explicit and removes the scripts that implied a support level CI no longer backs.

## Changes

- **README › Requirements** — new **Platform support** tier statement: tested in CI (Linux, macOS), expected to work (WSL), best effort/untested (Git Bash / MSYS2), unsupported (native cmd / PowerShell). Added as a plain list so the doctoc TOC markers stay untouched.
- **README › Tests** — dropped the Windows-specific install instructions, switched the examples to `pnpm` (the repo's package manager), and added a callout pointing Windows users at WSL (bats can't run natively on Windows).
- **package.json** — **removed the `tests:install:windows` and `tests:run:windows` scripts.** Grepped README, `docs/`, and `.github/` — nothing else references them. The removal is called out in the `chore(ralph:pkg)` commit message so it lands in the generated changelog at release time.
- **docs/CODE_STYLE.md** — one-line contributor note: `.gitattributes` pins `*.sh` / `*.bash` / `*.bats` to LF; don't override with `core.autocrlf`, CRLF breaks shellcheck and bats.

## Issue checklist

- [x] README **Requirements** section gains a support-tier statement (CI-tested / expected / best-effort / unsupported)
- [x] Decide the fate of the `tests:*:windows` npm scripts — **removed** (`package.json`-only change, called out in the commit for the changelog)
- [x] Contributor note about keeping LF endings (`.gitattributes`) so shellcheck/bats behave

Tests: no behaviour change; full suite green locally, 237/237.

Refs #71.