### PR TITLE
fix(json): preserve original formatting when bumping version in JSON files

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -23,3 +23,4 @@ contract); IDs added after the PRD are backfilled here first.
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
+| [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/json-bump-formatting/requirements.md
+++ b/docs/features/json-bump-formatting/requirements.md
@@ -1,0 +1,40 @@
+# JSON bump formatting
+
+Bumping a version must not restyle the file it touches. `jq_inplace`
+re-serialises the whole document in jq's house style (2-space indent,
+normalised spacing/escapes), so hand-formatted, 4-space or tab-indented
+`package.json` / `-f` targets got whole-file diff churn in exactly the
+commit that should be minimal — a quiet 2.0 regression vs 1.x, which
+delegated to `npm version` (B-3 side effect). IDs backfilled per
+[docs/features/README.md](../README.md); originated in issue #70.
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-FMT-1 | Bumping a JSON file whose `version` member sits on its own line (the overwhelmingly common case) changes **only that line**; the rest of the file is byte-identical. | ✅ shipped — `json_set_version` (`lib/json.sh`); `test/json.bats` |
+| R-FMT-2 | Postconditions on every write path: result parses, `.version` == new value; on postcondition failure nothing is replaced (existing tmp/err cleanup discipline). | ✅ shipped — surgical path probes the tmp with `jq -e '.version == $V'` (parse + value in one check) before the atomic `mv`; the fallback path holds by construction (jq exit 0 + non-empty output ⇒ parseable, and the expression itself sets `.version`) |
+| R-FMT-3 | Fallback to full jq rewrite is allowed for ambiguous inputs and is logged, never silent. | ✅ shipped — `log_warn "… falling back to a full jq rewrite (formatting normalised)"`; `test/json.bats` |
+
+Design notes:
+
+- The surgical match is anchored on the **current** top-level value
+  (`jq -r '.version'`), so nested `version` members with other values
+  (lockfile entries, config blobs) never count as candidates. Anything
+  other than exactly one candidate line — minified file, duplicate keys,
+  a nested member holding the same value, the member sharing its line,
+  or no member yet — takes the logged fallback. A wrong-line rewrite
+  (same-value nested member while the top-level one is inline) is caught
+  by the R-FMT-2 postcondition and also falls back.
+- Preserved byte-for-byte on the surgical path: indentation (spaces or
+  tabs), key spacing, trailing comma, CRLF endings, and a missing final
+  newline.
+- `package-lock.json` stays on the plain `jq_inplace` path: it is
+  machine-generated (npm restyles it anyway) and needs a two-path update
+  (`.version` + `.packages[""].version`), which is ambiguous by
+  definition for the surgical rewrite. No fallback warning is emitted
+  for it — the surgical path is never attempted.
+- Runtime dependency surface is unchanged: bash string ops + `jq` only
+  (R-DEP-1).
+
+Modules: `lib/json.sh` (`json_set_version`, `jq_inplace`); call sites in
+`lib/version.sh` (`do-packagefile-bump`, `bump-json-files`). Tests:
+`test/json.bats` (15), `test/bumpfile.bats`.

--- a/docs/features/json-bump-formatting/requirements.md
+++ b/docs/features/json-bump-formatting/requirements.md
@@ -16,12 +16,14 @@ delegated to `npm version` (B-3 side effect). IDs backfilled per
 
 Design notes:
 
-- The surgical match is anchored on the **current** top-level value
-  (`jq -r '.version'`), so nested `version` members with other values
-  (lockfile entries, config blobs) never count as candidates. Anything
-  other than exactly one candidate line — minified file, duplicate keys,
-  a nested member holding the same value, the member sharing its line,
-  or no member yet — takes the logged fallback. A wrong-line rewrite
+- The surgical match is anchored on the **current** top-level value,
+  strings only (`jq -r '.version | select(type == "string")'`), so nested
+  `version` members with other values (lockfile entries, config blobs)
+  never count as candidates and non-string values (`"version": 1`) skip
+  the surgical scan entirely. Anything other than exactly one candidate
+  line — minified file, duplicate keys, a nested member holding the same
+  value, the member sharing its line, or no member yet — takes the
+  logged fallback. A wrong-line rewrite
   (same-value nested member while the top-level one is inline) is caught
   by the R-FMT-2 postcondition and also falls back.
 - Preserved byte-for-byte on the surgical path: indentation (spaces or
@@ -37,4 +39,4 @@ Design notes:
 
 Modules: `lib/json.sh` (`json_set_version`, `jq_inplace`); call sites in
 `lib/version.sh` (`do-packagefile-bump`, `bump-json-files`). Tests:
-`test/json.bats` (15), `test/bumpfile.bats`.
+`test/json.bats` (17), `test/bumpfile.bats`.

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -58,8 +58,10 @@ json_set_version() {
   local re='^([[:space:]]*"version"[[:space:]]*:[[:space:]]*")([^"]*)("[[:space:]]*,?[[:space:]]*)$'
 
   # Current top-level value anchors the surgical match. Unparseable files or
-  # a missing/non-string .version yield "" and take the fallback below.
-  old=$(jq -r '.version // empty' "$file" 2>/dev/null)
+  # a missing/non-string .version yield "" and take the fallback below —
+  # select(type) keeps numeric/boolean values (e.g. "version": 1) out of the
+  # surgical scan entirely.
+  old=$(jq -r '.version | select(type == "string")' "$file" 2>/dev/null)
 
   if [ -n "$old" ]; then
     while [ "$eof" = false ]; do
@@ -85,8 +87,13 @@ json_set_version() {
         # file parses AND carries the new version (R-FMT-2).
         # shellcheck disable=SC2016 # $V is a jq variable, not a bash expansion
         if jq -e --arg V "$new" '.version == $V' "$tmp" >/dev/null 2>&1; then
-          mv -f "$tmp" "$file"
-          return 0
+          # mv can still fail (immutable target, permissions). Report it
+          # rather than falling through — the fallback's mv would fail too.
+          if mv -f "$tmp" "$file"; then
+            return 0
+          fi
+          rm -f "$tmp"
+          return 1
         fi
       fi
       rm -f "$tmp"

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -25,3 +25,78 @@ jq_inplace() {
   rm -f "$tmp" "$err"
   return 1
 }
+
+# Sets the top-level "version" member of a JSON file, preserving the file's
+# original formatting. Args: <file> <new-version>
+#
+# jq_inplace re-serialises the whole document in jq's house style, so any
+# hand-formatted / 4-space / tab-indented file gets whole-file diff churn in
+# exactly the commit that should be minimal (issue #70). Instead, when the
+# member sits alone on its own line with the current top-level value, only
+# that line is rewritten — indentation (spaces or tabs), key spacing, the
+# trailing comma, CRLF endings and a missing final newline all survive
+# byte-for-byte (R-FMT-1).
+#
+# Anchoring the match on the *current* value keeps nested "version" members
+# with other values (lockfile entries, config blobs) from counting as
+# candidates; a nested member holding the same value makes the match
+# ambiguous and is handled below.
+#
+# Postconditions before the atomic mv (R-FMT-2): the candidate output must
+# parse AND report .version == <new-version>. On any postcondition failure
+# the tmp file is discarded and nothing is replaced.
+#
+# Fallback (R-FMT-3): if there is not exactly one unambiguous candidate line
+# (minified file, duplicate keys, member sharing a line, no member yet) or a
+# postcondition fails, fall back to the full jq rewrite — correct but
+# format-normalising — and log the fallback, never silently.
+json_set_version() {
+  local file="$1" new="$2"
+  local old line="" out="" tmp matches=0 eof=false
+  # A line holding ONLY the version member: indent, "version", ':', a string
+  # value, then at most a comma and trailing whitespace (covers CR of CRLF).
+  local re='^([[:space:]]*"version"[[:space:]]*:[[:space:]]*")([^"]*)("[[:space:]]*,?[[:space:]]*)$'
+
+  # Current top-level value anchors the surgical match. Unparseable files or
+  # a missing/non-string .version yield "" and take the fallback below.
+  old=$(jq -r '.version // empty' "$file" 2>/dev/null)
+
+  if [ -n "$old" ]; then
+    while [ "$eof" = false ]; do
+      IFS= read -r line || eof=true
+      # Clean EOF right after a newline: nothing left to emit.
+      [ "$eof" = true ] && [ -z "$line" ] && break
+      if [[ $line =~ $re ]] && [ "${BASH_REMATCH[2]}" = "$old" ]; then
+        matches=$((matches + 1))
+        line=${BASH_REMATCH[1]}${new}${BASH_REMATCH[3]}
+      fi
+      if [ "$eof" = true ]; then
+        out+=$line # final line had no trailing newline — keep it that way
+      else
+        out+=$line$'\n'
+      fi
+    done < "$file"
+
+    if [ "$matches" -eq 1 ]; then
+      tmp=$(mktemp "${file}.XXXXXX") || return 1
+      if printf '%s' "$out" > "$tmp"; then
+        # Both postconditions in one probe: jq -e exits >1 if $tmp does not
+        # parse and 1 if the comparison is false; 0 only when the rewritten
+        # file parses AND carries the new version (R-FMT-2).
+        # shellcheck disable=SC2016 # $V is a jq variable, not a bash expansion
+        if jq -e --arg V "$new" '.version == $V' "$tmp" >/dev/null 2>&1; then
+          mv -f "$tmp" "$file"
+          return 0
+        fi
+      fi
+      rm -f "$tmp"
+    fi
+  fi
+
+  # R-FMT-3: the fallback is never silent. Postconditions hold by
+  # construction here: jq exit 0 + non-empty output ⇒ parseable JSON, and
+  # the expression itself sets .version to $V.
+  log_warn "<${S_VAL-}${file}${RESET-}>: no single \"version\" line found — falling back to a full jq rewrite (formatting normalised)."
+  # shellcheck disable=SC2016 # $V is a jq variable, not a bash expansion
+  jq_inplace "$file" '.version = $V' --arg V "$new"
+}

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -279,11 +279,9 @@ do-packagefile-bump() {
     echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package.json" >&2
     [ -f package-lock.json ] && echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package-lock.json" >&2
   else
-    # Bump package.json via jq (no npm dependency).
-    # Note: $V is a jq variable (set via --arg), not a bash expansion — single
-    # quotes on the jq program are correct.
-    # shellcheck disable=SC2016
-    if ! jq_inplace package.json '.version = $V' --arg V "$V_NEW"; then
+    # Bump package.json via jq (no npm dependency), preserving the file's
+    # own formatting where possible (R-FMT-1..3, lib/json.sh).
+    if ! json_set_version package.json "$V_NEW"; then
       fail 1 \
         "Error updating <package.json>." \
         "Check that package.json is valid JSON (run: jq . package.json) and that the file is writable."
@@ -334,8 +332,8 @@ bump-json-files() {
         echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in ${S_VAL}$FILE${RESET} (was ${S_VAL}$FILE_V_PREV${RESET})" >&2
         GIT_MSG+="updated $FILE, "
       else
-        # shellcheck disable=SC2016
-        if jq_inplace "$FILE" '.version = $V' --arg V "$V_NEW"; then
+        # Preserves the file's own formatting where possible (R-FMT-1..3).
+        if json_set_version "$FILE" "$V_NEW"; then
           log_success "Updated <${S_VAL}$FILE${RESET}>: ${S_VAL}$FILE_V_PREV${RESET} ${I_ARROW} ${S_VAL}$V_NEW${RESET}"
           # Add file change to commit message:
           GIT_MSG+="updated $FILE, "

--- a/test/json.bats
+++ b/test/json.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+
+# JSON write-path formatting: json_set_version (lib/json.sh) — R-FMT-1..3.
+#
+# The surgical path must leave every byte outside the top-level "version"
+# line untouched (R-FMT-1), enforce parse + value postconditions before the
+# atomic mv (R-FMT-2), and fall back to the full jq rewrite for ambiguous
+# inputs with a log line, never silently (R-FMT-3). Shared setup lives in
+# test/test_helper.bash.
+#
+# All tests run inside a fresh scratch_repo — byte-level fixtures must not
+# pollute the project checkout.
+
+load 'test_helper'
+
+# ── surgical path: byte-identical except the version line ──────────────
+
+@test "json_set_version: 2-space file — only the version line changes" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "name": "demo",\n  "version": "1.2.3",\n  "scripts": {\n    "test": "true"\n  }\n}\n' > in.json
+  printf '{\n  "name": "demo",\n  "version": "2.0.0",\n  "scripts": {\n    "test": "true"\n  }\n}\n' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+@test "json_set_version: 4-space file — only the version line changes" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n    "name": "demo",\n    "version": "1.2.3",\n    "dependencies": {\n        "a": "^1.0.0"\n    }\n}\n' > in.json
+  printf '{\n    "name": "demo",\n    "version": "2.0.0",\n    "dependencies": {\n        "a": "^1.0.0"\n    }\n}\n' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+@test "json_set_version: tab-indented file — only the version line changes" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n\t"version": "1.2.3",\n\t"name": "demo"\n}\n' > in.json
+  printf '{\n\t"version": "2.0.0",\n\t"name": "demo"\n}\n' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+@test "json_set_version: file without trailing newline stays newline-less" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "version": "1.2.3"\n}' > in.json
+  printf '{\n  "version": "2.0.0"\n}' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+@test "json_set_version: odd key spacing and trailing comma survive byte-for-byte" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n   "version"  :   "1.2.3" ,\n   "x": 1\n}\n' > in.json
+  printf '{\n   "version"  :   "2.0.0" ,\n   "x": 1\n}\n' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+@test "json_set_version: nested \"version\" with a different value does not block the surgical path" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n    "version": "1.2.3",\n    "deps": {\n        "left-pad": {\n            "version": "9.9.9"\n        }\n    }\n}\n' > in.json
+  printf '{\n    "version": "2.0.0",\n    "deps": {\n        "left-pad": {\n            "version": "9.9.9"\n        }\n    }\n}\n' > expected.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  refute_output --partial "falling back"
+
+  run cmp in.json expected.json
+  assert_success
+}
+
+# ── ambiguous inputs: logged fallback, correct top-level result ─────────
+
+@test "json_set_version: minified file takes the logged jq fallback" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{"name":"demo","version":"1.2.3","ok":true}' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+}
+
+@test "json_set_version: duplicate \"version\" keys take the fallback, top-level result correct" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "version": "1.2.3",\n  "version": "1.2.3"\n}\n' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+}
+
+@test "json_set_version: nested-only \"version\" takes the fallback and only adds the top-level member" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "package": {\n    "version": "1.2.3"\n  }\n}\n' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+  run jq -r '.package.version' in.json
+  assert_output "1.2.3"
+}
+
+@test "json_set_version: nested \"version\" with the same value is ambiguous — fallback, top-level only" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "version": "1.2.3",\n  "meta": {\n    "version": "1.2.3"\n  }\n}\n' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+  run jq -r '.meta.version' in.json
+  assert_output "1.2.3"
+}
+
+@test "json_set_version: version member sharing its line takes the fallback" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "name": "demo", "version": "1.2.3",\n  "ok": true\n}\n' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+}
+
+# ── postcondition / failure discipline ──────────────────────────────────
+
+@test "json_set_version: invalid JSON fails and replaces nothing" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{ this is not json\n' > in.json
+  cp in.json before.json
+
+  run json_set_version in.json 2.0.0
+  assert_failure
+
+  run cmp in.json before.json
+  assert_success
+}
+
+# ── call-site integration ───────────────────────────────────────────────
+
+@test "do-packagefile-bump: 4-space package.json keeps its formatting; lock file still bumped" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n    "name": "demo",\n    "version": "1.2.3"\n}\n' > package.json
+  printf '{\n    "name": "demo",\n    "version": "2.0.0"\n}\n' > expected.json
+  printf '{\n  "version": "1.2.3",\n  "packages": {\n    "": { "version": "1.2.3" }\n  }\n}\n' > package-lock.json
+
+  V_PREV="1.2.3"
+  V_NEW="2.0.0"
+  run do-packagefile-bump
+  strip_ansi_output
+  assert_success
+  assert_output --partial "Bumped version in <package.json> and <package-lock.json>"
+  refute_output --partial "falling back"
+
+  run cmp package.json expected.json
+  assert_success
+  run jq -r '.version' package-lock.json
+  assert_output "2.0.0"
+  run jq -r '.packages[""].version' package-lock.json
+  assert_output "2.0.0"
+}
+
+@test "bump-json-files: tab-indented -f target keeps its formatting" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n\t"version": "1.2.3",\n\t"name": "demo"\n}\n' > other.json
+  printf '{\n\t"version": "2.0.0",\n\t"name": "demo"\n}\n' > expected.json
+
+  V_NEW="2.0.0"
+  JSON_FILES=( other.json )
+  run bump-json-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "1.2.3 → 2.0.0"
+  refute_output --partial "falling back"
+
+  run cmp other.json expected.json
+  assert_success
+}
+
+@test "bump-json-files: minified -f target bumps via the logged fallback" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{"version":"1.2.3","name":"demo"}' > other.json
+
+  V_NEW="2.0.0"
+  JSON_FILES=( other.json )
+  run bump-json-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+  assert_output --partial "1.2.3 → 2.0.0"
+
+  run jq -r '.version' other.json
+  assert_output "2.0.0"
+}

--- a/test/json.bats
+++ b/test/json.bats
@@ -177,6 +177,23 @@ load 'test_helper'
   assert_output "1.2.3"
 }
 
+@test "json_set_version: non-string version value takes the logged fallback" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "version": 1,\n  "name": "demo"\n}\n' > in.json
+
+  run json_set_version in.json 2.0.0
+  strip_ansi_output
+  assert_success
+  assert_output --partial "falling back to a full jq rewrite"
+
+  run jq -r '.version | type' in.json
+  assert_output "string"
+  run jq -r '.version' in.json
+  assert_output "2.0.0"
+}
+
 @test "json_set_version: version member sharing its line takes the fallback" {
   source ${profile_script}
   cd "$(scratch_repo)"
@@ -206,6 +223,31 @@ load 'test_helper'
 
   run cmp in.json before.json
   assert_success
+}
+
+@test "json_set_version: surgical mv failure cleans up the tmp and returns non-zero" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  # Simulate a rename(2) failure on the target while the directory stays
+  # writable (so mktemp + the postcondition probe still succeed): macOS
+  # user-immutable flag. Skip where chflags is unavailable (Linux CI).
+  command -v chflags >/dev/null 2>&1 || skip "requires chflags (macOS immutable flag)"
+
+  printf '{\n  "version": "1.2.3"\n}\n' > in.json
+  cp in.json before.json
+  chflags uchg in.json 2>/dev/null || skip "cannot set immutable flag here"
+
+  run json_set_version in.json 2.0.0
+  chflags nouchg in.json # always unlock before asserting so teardown can clean up
+
+  assert_failure
+
+  run cmp in.json before.json
+  assert_success
+  # No stray tmp files left behind next to the target.
+  run bash -c 'ls in.json.* 2>/dev/null'
+  assert_output ""
 }
 
 # ── call-site integration ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`jq_inplace` re-serialises the whole document in jq's house style (2-space indent, normalised spacing/escapes), so any hand-formatted, 4-space, or tab-indented `package.json` / `-f` target got whole-file diff churn on every release — noise in exactly the commit that should be minimal, and a quiet 2.0 regression vs 1.x, which delegated to `npm version` and kept the file's indent style.

This PR takes the issue's preferred path: a surgical single-line rewrite with validated postconditions, falling back to the full jq rewrite (logged, never silent) for ambiguous inputs.

## Design decisions — surgical vs fallback

- **Surgical path** (`json_set_version`, `lib/json.sh`): when the top-level `"version"` member sits alone on its own line with the current value, only that line is rewritten. Indentation (spaces or tabs), key spacing, trailing comma, CRLF endings, and a missing final newline all survive byte-for-byte. Pure bash string ops — the runtime dependency surface stays exactly `bash`/`git`/`jq` (R-DEP-1).
- **Value-anchored matching**: candidate lines must carry the *current* top-level value (read via `jq -r '.version'`), so nested `version` members with other values (lockfile entries, config blobs) never block the surgical path.
- **Postconditions before the atomic `mv`** (existing tmp-file + `mv -f` + stderr-separation discipline kept): the candidate output must parse **and** report `.version` == new value — one `jq -e --arg V … '.version == $V'` probe covers both. On failure the tmp is discarded and nothing is replaced. This also catches the wrong-line rewrite case (a same-value nested member matching while the top-level member is inline).
- **Fallback** to the full `jq_inplace` rewrite for anything but exactly one unambiguous candidate line — minified file, duplicate keys, same-value nested member, member sharing its line, or no member yet — and it is logged via `log_warn`, never silent.
- **`package-lock.json` stays on plain `jq_inplace`**: machine-generated (npm restyles it anyway), and its two-path update (`.version` + `.packages[""].version`) is ambiguous by definition for a surgical rewrite. No fallback warning is emitted for it since the surgical path is never attempted.

## Requirements

Backfilled as a new bucket in `docs/features/json-bump-formatting/requirements.md` (indexed in `docs/features/README.md`; PRD untouched per the backfill convention):

- **R-FMT-1** — own-line `version` member: only that line changes; rest of the file byte-identical.
- **R-FMT-2** — postconditions on every write path (parses + `.version` == new); on failure nothing is replaced.
- **R-FMT-3** — fallback to full jq rewrite allowed for ambiguous inputs, always logged.

## Test plan

New `test/json.bats` (15 cases): **237 → 252 tests, 252/252 passing**; `pnpm lint` (shellcheck -x) clean.

- Byte-identity (`cmp` against exact expected bytes): 2-space, 4-space, tab-indented, no-trailing-newline, odd key spacing/trailing comma, nested-different-value fixtures.
- Logged fallback + correct top-level result: minified, duplicate `"version"` keys, nested-only `"version"`, same-value nested member, member sharing its line.
- Failure discipline: invalid JSON fails and replaces nothing.
- Call-site integration: `do-packagefile-bump` keeps a 4-space `package.json`'s formatting while still bumping `package-lock.json`; `bump-json-files` preserves a tab-indented `-f` target and takes the logged fallback for a minified one.
- Existing suite unchanged and green; also spot-verified end-to-end under macOS system bash 3.2 (the shebang target).

Refs #70.