### PR TITLE
feat(changelog): grouped conventional-commit changelog with commit/PR/compare links

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `REL_PREFIX` | `-B` / `--branch-prefix` | `release-` |
 | `PUSH_DEST` | `-p` / `--push` | `origin` |
 | `COMMIT_MSG_PREFIX` | *(no flag)* | `"chore: "` |
+| `CHANGELOG_STYLE` | *(no flag)* | `flat` |
 | `FLAG_BRANCH` | `--branch` | *unset* (tag in place) |
 | `PR_BASE` | `--base` | *(auto-detect)* |
 | `FLAG_NOCHANGELOG` | `-c` / `--no-changelog` | *unset* |
@@ -270,6 +271,44 @@ overrides both.
 **Security** — `ver-bump` *sources* this file as shell, so do not commit
 one you wouldn't execute. As a safeguard, `ver-bump` refuses to load a
 world-writable rc and exits with code 3; `chmod 644 .ver-bumprc` fixes it.
+
+#### Grouped changelog (`CHANGELOG_STYLE=grouped`)
+
+By default the CHANGELOG section is a flat list of commit subjects
+(unchanged since 1.x). Set `CHANGELOG_STYLE=grouped` — in `.ver-bumprc` or
+as an environment variable; there is no CLI flag — to group commits by
+Conventional Commit type instead, with commit, PR and compare links when
+the remote is on GitHub:
+
+```markdown
+## [1.1.0](https://github.com/acme/widget/compare/v1.0.0...v1.1.0) (2026-07-15)
+
+### Breaking Changes
+
+- drop node 14 ([2296697](https://github.com/acme/widget/commit/2296697))
+
+### Features
+
+- **api:** add endpoint (#12) ([a746a76](https://github.com/acme/widget/commit/a746a76))
+
+### Fixes
+
+- **net:** retry on 503 ([7a1ecc3](https://github.com/acme/widget/commit/7a1ecc3))
+
+### Other
+
+- updated package.json, updated CHANGELOG.md, bumped 1.0.0 -> 1.1.0
+- plain non-conventional message ([e0d3107](https://github.com/acme/widget/commit/e0d3107))
+```
+
+Sections appear in that order and empty ones are omitted. Breaking changes
+are detected from a `<type>!:` subject or a `BREAKING CHANGE:` footer;
+everything that isn't `feat`/`fix`/breaking — including commits that don't
+follow Conventional Commits at all — lands under **Other**, so nothing is
+ever dropped. Scopes render as a bold `**scope:**` prefix. With a
+non-GitHub remote (or no remote) the same grouping renders as plain text
+without links. Any other `CHANGELOG_STYLE` value behaves as `flat`, whose
+output stays byte-identical to previous releases.
 
 ```text
 -v, --version [<version>]     Without a value: print tool version and exit.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -221,7 +221,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | ID | Requirement |
 | --- | --- |
 | **R-CFG-1** | `.ver-bumprc` is discovered by walking up from `$PWD` to `/`. First match wins; absence is not an error. |
-| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
+| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
 | **R-CFG-3** | Precedence end-to-end: CLI > environment > `.ver-bumprc` > built-in default. |
 | **R-CFG-4** | `.ver-bumprc` is refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. |
 | **R-CFG-5** | `.ver-bumprc` is shell-sourced, not parsed. Failures in sourcing exit `3` with the shell error as context. |
@@ -354,7 +354,7 @@ All resolved for 2.0:
 
 ## 13. Future work (post-2.0)
 
-- **Grouped CHANGELOG** from Conventional Commits (the other major friction point vs. modern tools).
+- **Grouped CHANGELOG** from Conventional Commits (the other major friction point vs. modern tools). *Shipped post-2.0 as opt-in `CHANGELOG_STYLE=grouped` (issue #61; R-CHLOG-1..5 in [docs/features/changelog/requirements.md](features/changelog/requirements.md)); the flat default is unchanged — flipping it is a 3.0 decision.*
 - **Hook system** (exit code `4` is reserved): `pre-bump`, `post-tag`, `post-push`.
 - **Non-npm install paths** — Homebrew formula (deferred from 2.0; issue [#24](https://github.com/jv-k/ver-bump/issues/24)), `basher` ([#39](https://github.com/jv-k/ver-bump/issues/39)).
 - **GitHub Packages publishing docs** ([#40](https://github.com/jv-k/ver-bump/issues/40)).

--- a/docs/features/changelog/requirements.md
+++ b/docs/features/changelog/requirements.md
@@ -1,8 +1,10 @@
 # Changelog
 
-CHANGELOG.md update as part of the release flow. Deliberately simple in
-2.0: the `git log` dump format is preserved as-is (PRD §3.1 non-goal — a
-grouped, Conventional-Commit-aware changelog is post-2.0 future work).
+CHANGELOG.md update as part of the release flow. Two styles as of #61:
+the default `flat` git-log dump — byte-identical to 1.x, and staying the
+default for all of 2.x (flipping it is a 3.0 decision) — and the opt-in
+`CHANGELOG_STYLE=grouped` Conventional-Commit sections with commit/PR/
+compare links.
 
 Backfilled requirements (behaviour carried from 1.x, stabilized in 2.0):
 
@@ -13,6 +15,17 @@ Backfilled requirements (behaviour carried from 1.x, stabilized in 2.0):
 | R-LOG-3 | `-l` / `--pause-changelog` pauses before the commit so the user can hand-edit the generated section. | ✅ shipped |
 | R-LOG-4 | Changelog writing honours dry-run (R-DRY-1/2). | ✅ shipped |
 
-Modules: `lib/changelog.sh`. Tests: `test/changelog.bats`.
+Grouped changelog (issue #61):
 
-Future: grouped changelog from Conventional Commits — PRD §13.
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-CHLOG-1 | Opt-in via `CHANGELOG_STYLE=grouped` — a config/env key only (R-CFG-2/3 precedence), no CLI flag. Default remains `flat` and byte-identical to the legacy output; any other value behaves as flat. | ✅ shipped — `test/changelog-grouped.bats` (precedence trio), `test/changelog.bats` (flat byte-identity pin), `test/config.bats` (key round-trip, default) |
+| R-CHLOG-2 | Sections in fixed order: Breaking Changes (`<type>!:` subject or `BREAKING CHANGE:` footer), Features (`feat`), Fixes (`fix`), Other (everything else *including* non-conventional messages — nothing is ever dropped). Each commit lands in exactly one section (breaking wins). Scopes render as a bold `**scope:**` prefix; a parsed `type(scope):` prefix is stripped (the heading carries the type); non-conventional subjects render verbatim. Empty sections are omitted. | ✅ shipped — `test/changelog-grouped.bats` (full snapshot, footer routing, empty-section omission, `classify-commit` table) |
+| R-CHLOG-3 | Each entry links its short SHA to the commit as explicit markdown; `(#N)` PR refs stay verbatim (GitHub auto-links them when rendered); the version heading links the `prev...new` compare view when a previous tag exists. | ✅ shipped — `test/changelog-grouped.bats` (HTTPS/SSH link tests, no-tag heading test) |
+| R-CHLOG-4 | Forge base URL derived from `git remote get-url` (`PUSH_DEST`, falling back to `origin`), handling GitHub SSH (`git@github.com:o/r.git`, `ssh://`) and HTTPS forms. Non-GitHub remote or no remote → plain-text entries, no links, never a failure. | ✅ shipped — `test/changelog-grouped.bats` (`_forge-base-url` table, non-GitHub + no-remote snapshots) |
+| R-CHLOG-5 | Prepend-to-existing-file behaviour and the `-c` / `-l` flag semantics are unchanged in both styles; dry-run parity holds; the tool's own bump commit keeps its manual entry (classified like any commit, no SHA link since the commit happens after the write). | ✅ shipped — `test/changelog-grouped.bats` (prepend, `-c`, `-l`, dry-run) |
+
+Modules: `lib/changelog.sh` (rendering, `_forge-base-url`), `lib/version.sh`
+(`classify-commit`, shared with the R-BUMP-2 bump suggestion so the parsing
+rules can't drift), `lib/config.sh` (`CHANGELOG_STYLE` key + default).
+Tests: `test/changelog.bats`, `test/changelog-grouped.bats`.

--- a/docs/features/config-file/requirements.md
+++ b/docs/features/config-file/requirements.md
@@ -6,7 +6,7 @@ Repo- or home-level defaults without repeating flags. Shipped in 2.0
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-CFG-1 | Discovered by walking up from `$PWD` to `/`; first match wins; absence is not an error. | ✅ shipped — `_find-rc-upward` |
-| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
+| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
 | R-CFG-3 | Precedence: CLI > env > `.ver-bumprc` > built-in default, end-to-end. | ✅ shipped (`f6d66b4`) — `test/config-env.bats` |
 | R-CFG-4 | Refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. | ✅ shipped (`6a37077`) |
 | R-CFG-5 | Shell-sourced, not parsed; sourcing failures exit `3` with the shell error as context. | ✅ shipped |

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -40,6 +40,18 @@ _forge-base-url() {
   printf 'https://github.com/%s' "$owner_repo"
 }
 
+# Minimal URL-encoding for a git ref used as a path segment of a GitHub
+# compare URL: "%" first (so the escapes below aren't double-encoded),
+# then "/" — TAG_PREFIX may legitimately contain one (e.g. rel/), which
+# would otherwise break the compare path. Other ref-legal characters are
+# URL-safe in this position.
+_url-encode-ref() {
+  local ref=$1
+  ref=${ref//%/%25}
+  ref=${ref//\//%2F}
+  printf '%s' "$ref"
+}
+
 # Render one subject line for the grouped changelog. A Conventional Commit
 # "type(scope)!?:" prefix is stripped — the section heading already carries
 # the type — and the scope becomes a bold "**scope:**" prefix (R-CHLOG-2).
@@ -86,7 +98,9 @@ _changelog-grouped-section() {
   # tag and a recognised forge exist; otherwise the same text as flat.
   if [ -n "$range" ] && [ -n "$base_url" ]; then
     printf '## [%s](%s/compare/%s...%s) (%s)\n' \
-      "$V_NEW" "$base_url" "${TAG_PREFIX}${V_PREV}" "${TAG_PREFIX}${V_NEW}" "$NOW"
+      "$V_NEW" "$base_url" \
+      "$(_url-encode-ref "${TAG_PREFIX}${V_PREV}")" \
+      "$(_url-encode-ref "${TAG_PREFIX}${V_NEW}")" "$NOW"
   else
     printf '## %s (%s)\n' "$V_NEW" "$NOW"
   fi

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -13,14 +13,152 @@ capitalise() {
   echo "$(tr '[:lower:]' '[:upper:]' <<< "${1:0:1}")${1:1}"
 }
 
+# Resolve the https base URL of the GitHub remote, e.g.
+# https://github.com/owner/repo — used by the grouped changelog to build
+# commit and compare links (R-CHLOG-3). Prefers PUSH_DEST (where the
+# release lands), falling back to origin. Handles the SSH scp form
+# (git@github.com:o/r.git), ssh:// and https:// forms. Non-GitHub remote
+# or no remote → return 1; callers must render plain text instead of
+# links, never fail (R-CHLOG-4).
+_forge-base-url() {
+  local url owner_repo
+  url=$(git remote get-url "${PUSH_DEST:-origin}" 2>/dev/null) \
+    || url=$(git remote get-url origin 2>/dev/null) \
+    || return 1
+
+  case "$url" in
+    git@github.com:*)       owner_repo="${url#git@github.com:}" ;;
+    ssh://git@github.com/*) owner_repo="${url#ssh://git@github.com/}" ;;
+    https://github.com/*)   owner_repo="${url#https://github.com/}" ;;
+    http://github.com/*)    owner_repo="${url#http://github.com/}" ;;
+    *) return 1 ;;
+  esac
+
+  owner_repo="${owner_repo%.git}"
+  owner_repo="${owner_repo%/}"
+  [ -n "$owner_repo" ] || return 1
+  printf 'https://github.com/%s' "$owner_repo"
+}
+
+# Render one subject line for the grouped changelog. A Conventional Commit
+# "type(scope)!?:" prefix is stripped — the section heading already carries
+# the type — and the scope becomes a bold "**scope:**" prefix (R-CHLOG-2).
+# Anything that doesn't parse as a Conventional Commit renders verbatim, so
+# no message is ever dropped or truncated.
+_changelog-render-subject() {
+  local subject=$1 scope desc
+  local re='^[a-zA-Z]+(\(([^)]*)\))?!?:[[:space:]]*(.+)$'
+  if [[ "$subject" =~ $re ]]; then
+    scope="${BASH_REMATCH[2]}"
+    desc="${BASH_REMATCH[3]}"
+    if [ -n "$scope" ]; then
+      printf '**%s:** %s' "$scope" "$desc"
+    else
+      printf '%s' "$desc"
+    fi
+  else
+    printf '%s' "$subject"
+  fi
+}
+
+# Emit the grouped (Conventional-Commit-aware) section for V_NEW on stdout.
+#   $1 = git log records ("%h RS %s RS %b US" — the same RS/US record
+#        discipline as suggest-bump-level, so a body that quotes a subject
+#        can't split a record)
+#   $2 = synthetic entry for the tool's own bump commit (that commit is
+#        created after this write, so it has no SHA to link yet — same
+#        manual-entry behaviour as the flat format)
+#   $3 = the git-log range; non-empty exactly when the previous version's
+#        tag exists, which is also the compare-link condition (R-CHLOG-3)
+#
+# Sections render in fixed order — Breaking Changes, Features, Fixes,
+# Other — and empty sections are omitted. "Other" is the catch-all: any
+# commit that isn't breaking/feat/fix lands there, including
+# non-conventional messages, so nothing is ever dropped (R-CHLOG-2).
+_changelog-grouped-section() {
+  local records=$1 bump_entry=$2 range=$3
+  local base_url record sha subject body rest entry
+  local breaking="" feats="" fixes="" others=""
+
+  base_url=$(_forge-base-url) || base_url=""
+
+  # Version heading: link the prev...new compare view when both a previous
+  # tag and a recognised forge exist; otherwise the same text as flat.
+  if [ -n "$range" ] && [ -n "$base_url" ]; then
+    printf '## [%s](%s/compare/%s...%s) (%s)\n' \
+      "$V_NEW" "$base_url" "${TAG_PREFIX}${V_PREV}" "${TAG_PREFIX}${V_NEW}" "$NOW"
+  else
+    printf '## %s (%s)\n' "$V_NEW" "$NOW"
+  fi
+
+  # The bump commit is classified like any other commit (its section
+  # follows COMMIT_MSG_PREFIX — "chore: " lands in Other by default).
+  entry="- $(_changelog-render-subject "$bump_entry")"$'\n'
+  case "$(classify-commit "$bump_entry" "")" in
+    breaking) breaking+="$entry" ;;
+    feat)     feats+="$entry" ;;
+    fix)      fixes+="$entry" ;;
+    *)        others+="$entry" ;;
+  esac
+
+  while IFS= read -r -d $'\x1f' record; do
+    # Trim the newline git inserts between format records.
+    record="${record#$'\n'}"
+    [ -z "$record" ] && continue
+    sha="${record%%$'\x1e'*}"
+    rest="${record#*$'\x1e'}"
+    subject="${rest%%$'\x1e'*}"
+    if [[ "$rest" == *$'\x1e'* ]]; then
+      body="${rest#*$'\x1e'}"
+    else
+      body=""
+    fi
+
+    entry="- $(_changelog-render-subject "$subject")"
+    if [ -n "$base_url" ]; then
+      # Short SHA linked to its commit. "(#N)" PR refs stay verbatim in
+      # the subject — GitHub auto-links them in rendered markdown.
+      entry+=" ([${sha}](${base_url}/commit/${sha}))"
+    else
+      entry+=" (${sha})"
+    fi
+    entry+=$'\n'
+
+    case "$(classify-commit "$subject" "$body")" in
+      breaking) breaking+="$entry" ;;
+      feat)     feats+="$entry" ;;
+      fix)      fixes+="$entry" ;;
+      *)        others+="$entry" ;;
+    esac
+  done <<< "$records"
+
+  [ -n "$breaking" ] && printf '\n### Breaking Changes\n\n%s' "$breaking"
+  [ -n "$feats" ]    && printf '\n### Features\n\n%s' "$feats"
+  [ -n "$fixes" ]    && printf '\n### Fixes\n\n%s' "$fixes"
+  [ -n "$others" ]   && printf '\n### Other\n\n%s' "$others"
+  return 0
+}
+
 # Dump git log history to CHANGELOG.md
+#
+# Two styles (R-CHLOG-1): the default "flat" bullet dump, byte-identical
+# to the 1.x output, and the opt-in CHANGELOG_STYLE=grouped Conventional-
+# Commit sections. Both share the same temp-file build, prepend, dry-run,
+# pause and staging behaviour (R-CHLOG-5).
 do-changelog() {
   [ "$FLAG_NOCHANGELOG" = true ] && return
   local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP
 
   RANGE=$([ "$(git tag -l "${TAG_PREFIX}${V_PREV}")" ] && echo "${TAG_PREFIX}${V_PREV}..HEAD")
-  # shellcheck disable=SC2086
-  COMMITS_MSG=$( git log --pretty=format:"- %s" ${RANGE} 2>&1 ); LOG_RC=$?
+  if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then
+    # SHA + subject + body records for grouping — see
+    # _changelog-grouped-section for the separator discipline.
+    # shellcheck disable=SC2086
+    COMMITS_MSG=$( git log --format='%h%x1e%s%x1e%b%x1f' ${RANGE} 2>&1 ); LOG_RC=$?
+  else
+    # shellcheck disable=SC2086
+    COMMITS_MSG=$( git log --pretty=format:"- %s" ${RANGE} 2>&1 ); LOG_RC=$?
+  fi
   if [ "$LOG_RC" -ne 0 ]; then
     fail 1 \
       "Error getting commit history since last version bump for logging to CHANGELOG: ${COMMITS_MSG}" \
@@ -38,15 +176,21 @@ do-changelog() {
   # Build new CHANGELOG content in a temp file next to the target, so a
   # partial write can't leave garbage in the repo root.
   TMP=$(mktemp "./CHANGELOG.md.XXXXXX")
-  # Heading
-  echo "## $V_NEW ($NOW)" > "$TMP"
 
-  # Log the bumping commit:
+  # The bump commit's own entry:
   # - The final commit is done after do-changelog(), so we need to create the log entry for it manually:
   LOG_MSG="${GIT_MSG}$(get-commit-msg)"
-  echo "- ${COMMIT_MSG_PREFIX}${LOG_MSG}" >> "$TMP"
-  # Add previous commits
-  [ -n "$COMMITS_MSG" ] && echo "$COMMITS_MSG" >> "$TMP"
+
+  if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then
+    _changelog-grouped-section "$COMMITS_MSG" "${COMMIT_MSG_PREFIX}${LOG_MSG}" "$RANGE" > "$TMP"
+  else
+    # Heading
+    echo "## $V_NEW ($NOW)" > "$TMP"
+    # Log the bumping commit
+    echo "- ${COMMIT_MSG_PREFIX}${LOG_MSG}" >> "$TMP"
+    # Add previous commits
+    [ -n "$COMMITS_MSG" ] && echo "$COMMITS_MSG" >> "$TMP"
+  fi
 
   printf '\n' >> "$TMP"
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -13,7 +13,7 @@ true
 #   3. process-arguments     — CLI flags overwrite anything above
 #
 # Supported keys (1:1 with existing globals):
-#   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX
+#   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX  CHANGELOG_STYLE
 #   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
@@ -23,7 +23,7 @@ true
 
 # Config-able keys, in a plain indexed array so bash 3.2 is happy.
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
-              FLAG_BRANCH PR_BASE \
+              FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
@@ -123,4 +123,7 @@ apply-config-defaults() {
   REL_PREFIX="${REL_PREFIX:-release-}"
   PUSH_DEST="${PUSH_DEST:-origin}"
   COMMIT_MSG_PREFIX="${COMMIT_MSG_PREFIX:-chore: }"
+  # "flat" (default, 1.x-identical) or "grouped" (R-CHLOG-1). Any other
+  # value behaves as flat — same lenient contract as the FLAG_* keys.
+  CHANGELOG_STYLE="${CHANGELOG_STYLE:-flat}"
 }

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -129,21 +129,56 @@ process-version() {
   fi
 }
 
+# Classify a single commit per Conventional Commits. $1 = subject (first
+# line), $2 = body (may be empty / multi-line). Echoes exactly one of:
+# breaking | feat | fix | other. Shared by suggest-bump-level (bump
+# inference) and the grouped changelog (lib/changelog.sh) so the parsing
+# rules can never drift apart.
+#
+# Subject vs. body handling: only the subject is matched against the
+# "<type>:" / "<type>!:" patterns, so a commit body that quotes a prior
+# subject can't change the class. "BREAKING CHANGE:" /
+# "BREAKING-CHANGE:" is matched only when it appears as a footer —
+# start-of-line followed by the token and a colon.
+classify-commit() {
+  local subject=$1 body=${2-} line
+  local re_breaking_subject='^[a-zA-Z]+(\([^)]*\))?!:'
+  local re_feat='^feat(\([^)]*\))?:'
+  local re_fix='^fix(\([^)]*\))?:'
+  local re_breaking_footer='^BREAKING[ -]CHANGE:'
+
+  # Breaking change via "<type>!:" — subject only.
+  if [[ "$subject" =~ $re_breaking_subject ]]; then
+    echo "breaking"; return
+  fi
+
+  # Breaking change footer — anchored at start of a body line.
+  if [ -n "$body" ]; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ $re_breaking_footer ]]; then
+        echo "breaking"; return
+      fi
+    done <<< "$body"
+  fi
+
+  if [[ "$subject" =~ $re_feat ]]; then
+    echo "feat"; return
+  fi
+  if [[ "$subject" =~ $re_fix ]]; then
+    echo "fix"; return
+  fi
+  echo "other"
+}
+
 # Inspect commit messages since the previous version's tag and suggest the
 # appropriate bump per Conventional Commits:
 #   - BREAKING CHANGE / <type>! → major
 #   - feat:                     → minor
 #   - anything else             → patch
 # Falls back to patch if no tag for previous version exists, or if parsing fails.
-#
-# Subject vs. body handling: we split every commit into its subject (first
-# line) and body (rest) via a record-separator/unit-separator format. Only
-# the subject is matched against the "<type>:" / "<type>!:" patterns, so a
-# commit body that quotes a prior subject can't trigger a spurious bump.
-# "BREAKING CHANGE:" / "BREAKING-CHANGE:" is matched only when it appears as
-# a footer — start-of-line followed by the token and a colon.
+# Parsing rules (subject-vs-body discipline) live in classify-commit above.
 suggest-bump-level() {
-  local prev_tag log level="patch" record subject body line
+  local prev_tag log level="patch" record subject body
   prev_tag="${TAG_PREFIX}${1}"
 
   if ! git rev-parse --verify "refs/tags/${prev_tag}" >/dev/null 2>&1; then
@@ -156,10 +191,6 @@ suggest-bump-level() {
     echo "patch"; return
   }
 
-  local re_breaking_subject='^[a-zA-Z]+(\([^)]*\))?!:'
-  local re_feat='^feat(\([^)]*\))?:'
-  local re_breaking_footer='^BREAKING[ -]CHANGE:'
-
   while IFS= read -r -d $'\x1f' record; do
     # Trim the newline git inserts between format records.
     record="${record#$'\n'}"
@@ -171,24 +202,10 @@ suggest-bump-level() {
       body=""
     fi
 
-    # Breaking change via "<type>!:" — subject only.
-    if [[ "$subject" =~ $re_breaking_subject ]]; then
-      echo "major"; return
-    fi
-
-    # Breaking change footer — anchored at start of a body line.
-    if [ -n "$body" ]; then
-      while IFS= read -r line; do
-        if [[ "$line" =~ $re_breaking_footer ]]; then
-          echo "major"; return
-        fi
-      done <<< "$body"
-    fi
-
-    # feat: → minor (subject only; never downgrade).
-    if [[ "$subject" =~ $re_feat ]]; then
-      level="minor"
-    fi
+    case "$(classify-commit "$subject" "$body")" in
+      breaking) echo "major"; return ;;
+      feat)     level="minor" ;;  # never downgrade
+    esac
   done <<< "$log"
 
   echo "$level"

--- a/test/changelog-grouped.bats
+++ b/test/changelog-grouped.bats
@@ -176,6 +176,32 @@ _grouped_fixture() {
   assert_output --partial "- initial (["
 }
 
+@test "grouped: slashed TAG_PREFIX is URL-encoded in the compare link, plain heading untouched" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  git tag rel/1.0.0
+  git commit --allow-empty -qm "feat: shiny"
+  git remote add origin https://github.com/acme/widget.git
+
+  TAG_PREFIX="rel/"
+  V_PREV="1.0.0"; V_NEW="1.1.0"; CHANGELOG_STYLE="grouped"
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "## [1.1.0](https://github.com/acme/widget/compare/rel%2F1.0.0...rel%2F1.1.0) ($NOW)"
+
+  # No remote → plain heading with no refs at all, so nothing gets encoded.
+  git remote remove origin
+  rm CHANGELOG.md
+  run do-changelog <<< ""
+  assert_success
+  run cat CHANGELOG.md
+  assert_output --partial "## 1.1.0 ($NOW)"
+  refute_output --partial "%2F"
+}
+
 # _forge-base-url unit table ##################################################
 
 @test "_forge-base-url: GitHub URL forms parse; non-GitHub and no-remote return 1 silently" {

--- a/test/changelog-grouped.bats
+++ b/test/changelog-grouped.bats
@@ -1,0 +1,332 @@
+#!/usr/bin/env bats
+
+# CHANGELOG_STYLE=grouped — Conventional-Commit-aware changelog sections
+# with commit/PR/compare links (R-CHLOG-1..5, issue #61). Shared setup
+# lives in test/test_helper.bash.
+#
+# All tests run inside a fresh scratch_repo. Snapshot tests interpolate
+# each fixture commit's real short SHA so the comparison is byte-exact
+# without fragile normalisation.
+
+load 'test_helper'
+
+# Fixture: one commit of every class since v1.0.0. Callers must have
+# sourced ${profile_script} first. Sets sha_* globals and the do-changelog
+# inputs (V_PREV/V_NEW, grouped style, deterministic prefix).
+_grouped_fixture() {
+  cd "$(scratch_repo)"
+  git tag v1.0.0
+
+  git commit --allow-empty -qm "feat(api): add endpoint (#12)"
+  sha_feat=$(git rev-parse --short HEAD)
+  git commit --allow-empty -qm "fix(net): retry on 503"
+  sha_fix=$(git rev-parse --short HEAD)
+  git commit --allow-empty -qm "feat!: drop node 14"
+  sha_breaking=$(git rev-parse --short HEAD)
+  git commit --allow-empty -qm "chore(deps): bump lodash"
+  sha_chore=$(git rev-parse --short HEAD)
+  git commit --allow-empty -qm "plain non-conventional message"
+  sha_plain=$(git rev-parse --short HEAD)
+
+  V_PREV="1.0.0"
+  V_NEW="1.1.0"
+  GIT_MSG=""
+  COMMIT_MSG_PREFIX="chore: "
+  CHANGELOG_STYLE="grouped"
+}
+
+# R-CHLOG-2: full snapshot ####################################################
+
+@test "grouped: snapshot — section order, bold scopes, nothing dropped, plain text without a remote" {
+  source ${profile_script}
+  _grouped_fixture
+
+  run do-changelog <<< ""
+  strip_ansi_output
+  assert_success
+  assert_output -p "Created [CHANGELOG.md]"
+
+  # Byte-exact expectation: Breaking > Features > Fixes > Other; scopes
+  # bolded; the plain commit lands in Other verbatim; no links (no remote);
+  # the tool's own bump entry has no SHA (its commit doesn't exist yet).
+  printf '%s\n' \
+    "## 1.1.0 ($NOW)" \
+    "" \
+    "### Breaking Changes" \
+    "" \
+    "- drop node 14 (${sha_breaking})" \
+    "" \
+    "### Features" \
+    "" \
+    "- **api:** add endpoint (#12) (${sha_feat})" \
+    "" \
+    "### Fixes" \
+    "" \
+    "- **net:** retry on 503 (${sha_fix})" \
+    "" \
+    "### Other" \
+    "" \
+    "- created CHANGELOG.md, bumped 1.0.0 -> 1.1.0" \
+    "- plain non-conventional message (${sha_plain})" \
+    "- **deps:** bump lodash (${sha_chore})" \
+    "" > expected.md
+
+  run diff expected.md CHANGELOG.md
+  assert_success
+}
+
+@test "grouped: BREAKING CHANGE footer routes a commit to Breaking Changes" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  git tag v1.0.0
+  git commit --allow-empty -qm "refactor: rework config loader" -m "BREAKING CHANGE: rc keys renamed"
+
+  V_PREV="1.0.0"; V_NEW="2.0.0"; CHANGELOG_STYLE="grouped"
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "### Breaking Changes"
+  assert_output --partial "- rework config loader ("
+  refute_output --partial "### Features"
+  refute_output --partial "### Fixes"
+}
+
+@test "grouped: empty sections are omitted" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  git tag v1.0.0
+  git commit --allow-empty -qm "fix: solve crash"
+
+  V_PREV="1.0.0"; V_NEW="1.0.1"; COMMIT_MSG_PREFIX="chore: "; CHANGELOG_STYLE="grouped"
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "### Fixes"
+  assert_output --partial "### Other" # the tool's own bump entry
+  refute_output --partial "### Features"
+  refute_output --partial "### Breaking Changes"
+}
+
+# R-CHLOG-3/4: links per remote form ##########################################
+
+@test "grouped: GitHub HTTPS remote — SHA links, compare heading, (#N) kept verbatim" {
+  source ${profile_script}
+  _grouped_fixture
+  git remote add origin https://github.com/acme/widget.git
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "## [1.1.0](https://github.com/acme/widget/compare/v1.0.0...v1.1.0) ($NOW)"
+  assert_output --partial "- **api:** add endpoint (#12) ([${sha_feat}](https://github.com/acme/widget/commit/${sha_feat}))"
+  assert_output --partial "- drop node 14 ([${sha_breaking}](https://github.com/acme/widget/commit/${sha_breaking}))"
+}
+
+@test "grouped: GitHub SSH remote resolves to the same https links" {
+  source ${profile_script}
+  _grouped_fixture
+  git remote add origin git@github.com:acme/widget.git
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "## [1.1.0](https://github.com/acme/widget/compare/v1.0.0...v1.1.0) ($NOW)"
+  assert_output --partial "- **net:** retry on 503 ([${sha_fix}](https://github.com/acme/widget/commit/${sha_fix}))"
+}
+
+@test "grouped: non-GitHub remote falls back to plain text entries without failing" {
+  source ${profile_script}
+  _grouped_fixture
+  git remote add origin git@gitlab.com:acme/widget.git
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "## 1.1.0 ($NOW)"
+  assert_output --partial "- **api:** add endpoint (#12) (${sha_feat})"
+  refute_output --partial "]("
+}
+
+@test "grouped: no previous tag — no compare link, full history listed" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  git remote add origin https://github.com/acme/widget.git
+  git commit --allow-empty -qm "feat: first feature"
+
+  V_PREV="0.1.0" # intentionally NO v0.1.0 tag in this repo
+  V_NEW="1.0.0"
+  CHANGELOG_STYLE="grouped"
+
+  run do-changelog <<< ""
+  assert_success
+
+  run cat CHANGELOG.md
+  assert_output --partial "## 1.0.0 ($NOW)"
+  refute_output --partial "compare/"
+  # Commit links still render, and the scratch repo's root commit is
+  # included — grouped keeps flat's full-history fallback.
+  assert_output --partial "- first feature (["
+  assert_output --partial "- initial (["
+}
+
+# _forge-base-url unit table ##################################################
+
+@test "_forge-base-url: GitHub URL forms parse; non-GitHub and no-remote return 1 silently" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  git remote add origin git@github.com:owner/repo.git
+  assert_equal "$(_forge-base-url)" "https://github.com/owner/repo"
+
+  git remote set-url origin ssh://git@github.com/owner/repo.git
+  assert_equal "$(_forge-base-url)" "https://github.com/owner/repo"
+
+  git remote set-url origin https://github.com/owner/repo.git
+  assert_equal "$(_forge-base-url)" "https://github.com/owner/repo"
+
+  git remote set-url origin https://github.com/owner/repo
+  assert_equal "$(_forge-base-url)" "https://github.com/owner/repo"
+
+  git remote set-url origin git@gitlab.com:owner/repo.git
+  run _forge-base-url
+  assert_failure
+  refute_output
+
+  git remote remove origin
+  run _forge-base-url
+  assert_failure
+  refute_output
+}
+
+# R-CHLOG-5: prepend, -c/-l semantics, dry-run parity #########################
+
+@test "grouped: prepends to an existing CHANGELOG.md, old entries intact" {
+  source ${profile_script}
+  _grouped_fixture
+  printf '## 1.0.0 (2020-01-01)\n- old entry\n\n' > CHANGELOG.md
+
+  run do-changelog <<< ""
+  strip_ansi_output
+  assert_success
+  assert_output -p "Updated [CHANGELOG.md]"
+
+  run cat CHANGELOG.md
+  assert_output --partial "### Features"
+  assert_output --partial "- old entry"
+  # The new section is prepended: line 1 is the new heading.
+  assert_equal "$(head -1 CHANGELOG.md)" "## 1.1.0 ($NOW)"
+}
+
+@test "grouped: FLAG_NOCHANGELOG (-c) still skips the changelog entirely" {
+  source ${profile_script}
+  _grouped_fixture
+  FLAG_NOCHANGELOG=true
+
+  run do-changelog
+  assert_success
+  refute_output
+  [ ! -f CHANGELOG.md ]
+}
+
+@test "grouped: FLAG_CHANGELOG_PAUSE (-l) still pauses for hand edits" {
+  source ${profile_script}
+  _grouped_fixture
+  FLAG_CHANGELOG_PAUSE=true
+
+  run do-changelog <<< ""
+  strip_ansi_output
+  assert_success
+  assert_output --partial "Make adjustments"
+  [ -f CHANGELOG.md ]
+}
+
+@test "grouped: dry-run previews the grouped section and writes nothing" {
+  source ${profile_script}
+  _grouped_fixture
+  FLAG_DRYRUN=true
+
+  [ ! -f CHANGELOG.md ]
+  run do-changelog <<< ""
+  strip_ansi_output
+  assert_success
+  assert_output --partial "[dry-run]"
+  assert_output --partial "### Features"
+  [ ! -f CHANGELOG.md ]
+}
+
+# R-CHLOG-1: opt-in + R-CFG-3 precedence (end-to-end, mirrors config-env.bats)
+
+@test "precedence: env CHANGELOG_STYLE=grouped beats .ver-bumprc flat (end-to-end dry-run)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'CHANGELOG_STYLE=flat\n' > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+  git commit --allow-empty -qm "feat: shiny"
+
+  CHANGELOG_STYLE=grouped run ${profile_script} -d -b -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "### Features"
+  refute_output --partial "- feat: shiny"
+}
+
+@test "precedence: .ver-bumprc CHANGELOG_STYLE=grouped beats the flat default (end-to-end dry-run)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'CHANGELOG_STYLE=grouped\n' > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+  git commit --allow-empty -qm "feat: shiny"
+
+  unset CHANGELOG_STYLE
+  run ${profile_script} -d -b -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "### Features"
+}
+
+@test "precedence: default stays flat when nothing sets CHANGELOG_STYLE (end-to-end dry-run)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+  git commit --allow-empty -qm "feat: shiny"
+
+  unset CHANGELOG_STYLE
+  run ${profile_script} -d -b -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "- feat: shiny"
+  refute_output --partial "### Features"
+}
+
+# classify-commit unit table (shared helper backing R-CHLOG-2 and R-BUMP-2)
+
+@test "classify-commit: table of subject/body classifications" {
+  source ${profile_script}
+
+  assert_equal "$(classify-commit 'feat: add thing' '')"                    "feat"
+  assert_equal "$(classify-commit 'feat(api): add thing' '')"               "feat"
+  assert_equal "$(classify-commit 'fix: squash bug' '')"                    "fix"
+  assert_equal "$(classify-commit 'fix(net): squash bug' '')"               "fix"
+  assert_equal "$(classify-commit 'feat!: breaking thing' '')"              "breaking"
+  assert_equal "$(classify-commit 'refactor(core)!: rewrite' '')"           "breaking"
+  assert_equal "$(classify-commit 'refactor: rework' 'BREAKING CHANGE: x')" "breaking"
+  assert_equal "$(classify-commit 'refactor: rework' 'BREAKING-CHANGE: x')" "breaking"
+  assert_equal "$(classify-commit 'chore: tidy' '')"                        "other"
+  assert_equal "$(classify-commit 'docs(readme): typo' '')"                 "other"
+  assert_equal "$(classify-commit 'plain message, no type' '')"             "other"
+  # A body that merely QUOTES a breaking subject must not escalate.
+  assert_equal "$(classify-commit 'chore: notes' 'see "feat!: dropped" above')" "other"
+  # feature/fixture words that only PREFIX the type must not match.
+  assert_equal "$(classify-commit 'feature: not conventional feat' '')"     "other"
+  assert_equal "$(classify-commit 'fixture: not a fix' '')"                 "other"
+}

--- a/test/changelog.bats
+++ b/test/changelog.bats
@@ -55,6 +55,42 @@ load 'test_helper'
 
 # N3: no-prev-tag range — when V_PREV has no tag, list every reachable commit #
 
+# R-CHLOG-1 regression pin: the default (flat) format must stay
+# byte-identical to the pre-CHANGELOG_STYLE output (#61). ###################
+
+@test "do-changelog: default flat output is byte-identical to the legacy format" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  git tag v1.0.0
+  git commit --allow-empty -qm "feat(api): add endpoint (#12)"
+  git commit --allow-empty -qm "fix: solve crash"
+  git commit --allow-empty -qm "plain non-conventional message"
+
+  V_PREV="1.0.0"
+  V_NEW="1.1.0"
+  GIT_MSG=""
+  COMMIT_MSG_PREFIX="chore: "
+  # Prove the unset default is flat, not just CHANGELOG_STYLE=flat.
+  unset CHANGELOG_STYLE
+
+  run do-changelog <<< ""
+  assert_success
+
+  # Hand-built byte-for-byte copy of the legacy flat format: heading,
+  # synthetic bump entry, commits newest-first, one trailing blank line.
+  printf '%s\n' \
+    "## 1.1.0 ($NOW)" \
+    "- chore: created CHANGELOG.md, bumped 1.0.0 -> 1.1.0" \
+    "- plain non-conventional message" \
+    "- fix: solve crash" \
+    "- feat(api): add endpoint (#12)" \
+    "" > expected.md
+
+  run diff expected.md CHANGELOG.md
+  assert_success
+}
+
 @test "do-changelog: uses full history when no tag exists for V_PREV" {
   source ${profile_script}
   cd "$(scratch_repo)"

--- a/test/config.bats
+++ b/test/config.bats
@@ -13,7 +13,7 @@ load 'test_helper'
 # itself, so our tests can assert "default" paths deterministically. Does NOT
 # unset the generic shell-inherited ones (those never are).
 _clear_config_env() {
-  unset TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
+  unset TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX CHANGELOG_STYLE \
         FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE
 }
 
@@ -102,6 +102,7 @@ _clear_config_env() {
   assert_equal "$REL_PREFIX" "release-"
   assert_equal "$PUSH_DEST" "origin"
   assert_equal "$COMMIT_MSG_PREFIX" "chore: "
+  assert_equal "$CHANGELOG_STYLE" "flat"
 }
 
 @test "ver-bump.sh: CLI -t beats .ver-bumprc TAG_PREFIX (end-to-end dry-run)" {
@@ -216,6 +217,7 @@ TAG_PREFIX=rel/
 REL_PREFIX=hotfix-
 PUSH_DEST=upstream
 COMMIT_MSG_PREFIX="release: "
+CHANGELOG_STYLE=grouped
 FLAG_NOBRANCH=true
 FLAG_NOCHANGELOG=true
 FLAG_CHANGELOG_PAUSE=true
@@ -226,6 +228,7 @@ EOF
   assert_equal "$REL_PREFIX" "hotfix-"
   assert_equal "$PUSH_DEST" "upstream"
   assert_equal "$COMMIT_MSG_PREFIX" "release: "
+  assert_equal "$CHANGELOG_STYLE" "grouped"
   assert_equal "$FLAG_NOBRANCH" "true"
   assert_equal "$FLAG_NOCHANGELOG" "true"
   assert_equal "$FLAG_CHANGELOG_PAUSE" "true"

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -58,6 +58,7 @@ FLAG_DRYRUN=false
 : "${TAG_PREFIX:=v}"
 : "${COMMIT_MSG_PREFIX:=chore: }" # Commit msg prefix for the file changes this script makes
 : "${PUSH_DEST:=origin}"
+: "${CHANGELOG_STYLE:=flat}" # CHANGELOG.md style: flat (1.x-identical, default) | grouped
 
 JSON_FILES=()
 


### PR DESCRIPTION
Grouped, Conventional-Commit-aware changelog behind an opt-in `CHANGELOG_STYLE=grouped` config/env key (no CLI flag). The flat default is untouched — pinned byte-identical by a regression test — so nothing changes for existing users. Grouping reuses the same commit classifier that already drives the bump suggestion (factored into a shared `classify-commit` in `lib/version.sh`), so the parsing rules for `feat`/`fix`/`<type>!:`/`BREAKING CHANGE:` footers can never drift between the two features. Pure bash + git + jq (R-DEP-1); no node-based generator.

## Example output (`CHANGELOG_STYLE=grouped`, GitHub remote)

```markdown
## [1.1.0](https://github.com/acme/widget/compare/v1.0.0...v1.1.0) (2026-07-15)

### Breaking Changes

- rework loader ([a367f85](https://github.com/acme/widget/commit/a367f85))
- drop node 14 ([2296697](https://github.com/acme/widget/commit/2296697))

### Features

- **api:** add endpoint (#12) ([a746a76](https://github.com/acme/widget/commit/a746a76))

### Fixes

- **net:** retry on 503 ([7a1ecc3](https://github.com/acme/widget/commit/7a1ecc3))

### Other

- created CHANGELOG.md, bumped 1.0.0 -> 1.1.0
- plain non-conventional message ([e0d3107](https://github.com/acme/widget/commit/e0d3107))
- **deps:** bump lodash ([c14a851](https://github.com/acme/widget/commit/c14a851))
```

With a non-GitHub remote (or none) the same grouping renders with plain `(shortsha)` suffixes and an unlinked heading — no failure. Without a previous tag the heading has no compare link and the full history is listed, matching flat's fallback.

## Changes

- `lib/version.sh` — `classify-commit` factored out of `suggest-bump-level` (returns `breaking|feat|fix|other`); the suggester now consumes it, preserving the RS/US subject-vs-body discipline (a body quoting `feat!:` still can't escalate).
- `lib/changelog.sh` — `_forge-base-url` (PUSH_DEST → origin; GitHub scp-SSH / `ssh://` / HTTPS forms), `_changelog-render-subject` (strips `type(scope)!?:`, bolds scope, verbatim fallback so nothing is dropped), `_changelog-grouped-section`. `do-changelog` branches only on the section build — the temp-file write, prepend, dry-run preview, `-c`/`-l` semantics and staging are shared by both styles (R-CHLOG-5).
- `lib/config.sh` / `ver-bump.sh` — `CHANGELOG_STYLE` added to `_CONFIG_KEYS` and defaults (`flat`); env > rc > default per R-CFG-3. Any other value behaves as flat (same lenient contract as the `FLAG_*` keys).
- Docs — README `.ver-bumprc` table + grouped example; `docs/features/changelog/requirements.md` gains the R-CHLOG bucket with test mapping; R-CFG-2 key lists updated in PRD + config-file requirements; PRD §13 notes the ship.

## Behavioural notes

- Each commit lands in exactly one section, breaking wins (`<type>!:` subject or footer). Sections render in fixed order; empty sections are omitted.
- `(#N)` PR refs stay verbatim — GitHub autolinks them in rendered markdown; the SHA link is explicit markdown (R-CHLOG-3).
- The tool's own bump commit remains a manual entry (its commit happens after the write, so no SHA); it is classified like any other commit, so the default `chore: ` prefix lands it in Other.
- The compare link targets `TAG_PREFIX + V_NEW`, which is created later in the same run — standard changelog-generator behaviour.

## Requirements

R-CHLOG-1, R-CHLOG-2, R-CHLOG-3, R-CHLOG-4, R-CHLOG-5 — each mapped to tests in `docs/features/changelog/requirements.md`. R-CFG-2/3 extended with the new key. R-DEP-1 holds (bash + git + jq only).

## Test plan

- Before: 237/237 · After: **254/254** (`pnpm lint` zero warnings, shellcheck `-x`)
- New: `test/changelog-grouped.bats` (16) — byte-exact grouped snapshot; BREAKING-footer routing; empty-section omission; GitHub HTTPS + SSH link fixtures; non-GitHub + no-remote + no-previous-tag fallbacks; `_forge-base-url` URL-form table; prepend/`-c`/`-l`/dry-run parity; env>rc>default precedence end-to-end; `classify-commit` table.
- `test/changelog.bats` +1 — flat default pinned byte-identical (with `CHANGELOG_STYLE` unset).
- `test/config.bats` — `CHANGELOG_STYLE` in round-trip + defaults cases.

Refs #61.
