### PR TITLE
feat(distribution): checksummed curl installer (install.sh + release tarball assets)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y shellcheck
 
-      - name: Test ./ver-bump.sh and ./lib/*.sh
-        run: shellcheck -x -e SC1017 ./ver-bump.sh ./lib/*.sh
+      - name: Test ./ver-bump.sh, ./install.sh and ./lib/*.sh
+        run: shellcheck -x -e SC1017 ./ver-bump.sh ./install.sh ./lib/*.sh
 
   tests:
     name: Run test suite on ${{ matrix.os }}
@@ -153,3 +153,50 @@ jobs:
       - run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release-assets:
+    name: Upload release tarball + sha256
+    needs: tests
+    if: github.event.action == 'published'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write   # gh release upload attaches assets to the release
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # The runtime file set for the curl installer (R-DIST-2, issue #66).
+      # package.json rides along because --about / --help read the tool's
+      # name + version from it (version_block in lib/ui.sh).
+      - name: Build runtime tarball + sha256
+        run: |
+          tar -czf ver-bump.tar.gz ver-bump.sh lib LICENSE package.json
+          sha256sum ver-bump.tar.gz > ver-bump.tar.gz.sha256
+
+      # Unversioned asset names keep install.sh's URLs stable:
+      #   latest: releases/latest/download/ver-bump.tar.gz
+      #   pinned: releases/download/v<x.y.z>/ver-bump.tar.gz
+      # --clobber makes a re-run of this job idempotent.
+      - name: Upload assets to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" ver-bump.tar.gz ver-bump.tar.gz.sha256 --clobber
+
+      # Cheap end-to-end proof that the published assets actually install
+      # (R-DIST-1/3/5 against the real release). Gates nothing else.
+      - name: Smoke-test install.sh against the uploaded assets
+        run: |
+          export VER_BUMP_INSTALL_VERSION="${GITHUB_REF_NAME#v}"
+          export VER_BUMP_PREFIX="$RUNNER_TEMP/smoke-prefix"
+          # Assets can take a moment to become downloadable after upload.
+          installed=false
+          for attempt in 1 2 3; do
+            if bash ./install.sh; then
+              installed=true
+              break
+            fi
+            echo "install attempt $attempt failed; retrying in 10s"
+            sleep 10
+          done
+          [ "$installed" = true ]
+          "$VER_BUMP_PREFIX/bin/ver-bump" --about

--- a/README.md
+++ b/README.md
@@ -164,6 +164,31 @@ In order to use `ver-bump` you need:
 install it whichever way suits you. `node`/`npm`/`pnpm` are only needed to
 install *from the registry* — never to run the tool.
 
+**curl (no Node required)** — downloads the latest GitHub release, verifies
+its published SHA-256 checksum, and installs to `~/.local`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jv-k/ver-bump/main/install.sh | bash
+```
+
+Re-running upgrades in place. `VER_BUMP_INSTALL_VERSION=x.y.z` pins a
+release; `VER_BUMP_PREFIX=<dir>` changes the prefix (layout:
+`<prefix>/share/ver-bump/` + a `<prefix>/bin/ver-bump` symlink — make sure
+`<prefix>/bin` is on your `$PATH`).
+
+> **Piping a script into your shell runs code you haven't read.** The
+> checksum protects the release *tarball*; it can't vet the installer
+> itself. If that trade-off isn't for you, download it first, read it (it's
+> short and boring on purpose), then run it:
+>
+> ```sh
+> curl -fsSLO https://raw.githubusercontent.com/jv-k/ver-bump/main/install.sh
+> less install.sh
+> bash install.sh
+> ```
+
+**npm / pnpm** — install from the registry:
+
 ```sh
 # pnpm (this repo's package manager)
 pnpm add -g ver-bump
@@ -172,7 +197,7 @@ pnpm add -g ver-bump
 npm install -g ver-bump
 ```
 
-**No Node?** Clone and symlink the script — `lib/` travels with it, so module
+**Manual** — clone and symlink the script; `lib/` travels with it, so module
 resolution still works:
 
 ```sh
@@ -180,7 +205,9 @@ git clone https://github.com/jv-k/ver-bump.git ~/.local/share/ver-bump
 ln -s ~/.local/share/ver-bump/ver-bump.sh ~/.local/bin/ver-bump   # ensure ~/.local/bin is on $PATH
 ```
 
-> A Homebrew tap is planned for a future release ([#24](https://github.com/jv-k/ver-bump/issues/24)).
+> **Homebrew** ([#24](https://github.com/jv-k/ver-bump/issues/24)) and
+> **basher** ([#39](https://github.com/jv-k/ver-bump/issues/39)) install
+> paths are tracked for a future release.
 
 ## Quickstart
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -24,3 +24,4 @@ contract); IDs added after the PRD are backfilled here first.
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |
+| [installer](./installer/requirements.md) | R-DIST | `install.bats` |

--- a/docs/features/installer/requirements.md
+++ b/docs/features/installer/requirements.md
@@ -27,9 +27,12 @@ Design notes:
   (2 usage / 3 missing tools / 1 failure) are mirrored from `lib/`.
 - `http_fetch` is the single network seam; tests stub it to serve local
   fixture files, so the bats suite never touches the network.
-- Install is stage-then-swap: the verified tree is staged next to
-  `share/ver-bump` and swapped in only after every earlier step succeeded,
-  so a failed run can never leave a half-written install.
+- Install is a rename swap with rollback: the verified tree is staged next
+  to `share/ver-bump` (same filesystem, so the swap is a plain rename), any
+  previous install is moved aside — not deleted — and only removed once the
+  new tree and symlink are in place. A failure mid-swap restores the
+  previous install; a backup that cannot be restored is preserved and named,
+  never deleted.
 
 Modules: `install.sh` (standalone), `publish-release-assets` in
 [.github/workflows/ci.yml](../../../.github/workflows/ci.yml).

--- a/docs/features/installer/requirements.md
+++ b/docs/features/installer/requirements.md
@@ -1,0 +1,36 @@
+# Curl installer (install.sh)
+
+Checksummed, no-Node install path built on GitHub release assets. Closes the
+gap between the "pure bash" pitch and the npm-only install (issue #66);
+complements the tracked Homebrew (#24) and basher (#39) paths.
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-DIST-1 | `install.sh` at the repo root downloads the latest GitHub release tarball (or a pinned one via `VER_BUMP_INSTALL_VERSION=x.y.z` / `--version`), verifies its published sha256, and unpacks `ver-bump.sh` + `lib/` under `${VER_BUMP_PREFIX:-$HOME/.local}` (`share/ver-bump/` + a `bin/ver-bump` symlink). | ✅ shipped — `test/install.bats` |
+| R-DIST-2 | The release workflow publishes `ver-bump.tar.gz` + `ver-bump.tar.gz.sha256` as release assets (`publish-release-assets` job in `ci.yml`, extends the existing publish CI). | ✅ shipped — smoke step installs from the freshly published release and runs `--about` |
+| R-DIST-3 | Installer needs only `bash`, `curl` (or `wget`), `tar`, and `sha256sum`/`shasum`; it is idempotent (re-run upgrades in place), prints the installed version, and suggests `ver-bump --install-completions`. | ✅ shipped — `test/install.bats` |
+| R-DIST-4 | README install section leads with the one-liner, with the pipe-to-shell caveat and the download-then-inspect alternative spelled out honestly. | ✅ shipped — README `Installation` |
+| R-DIST-5 | Checksum mismatch or download failure → non-zero exit, nothing installed, partial files cleaned up. | ✅ shipped — negative cases in `test/install.bats` |
+
+Design notes:
+
+- Assets use **unversioned names** so both URL forms stay static — no API
+  calls, no JSON parsing, no redirect scraping, identical behaviour under
+  `curl` and `wget`:
+  - latest: `releases/latest/download/ver-bump.tar.gz`
+  - pinned: `releases/download/v<x.y.z>/ver-bump.tar.gz`
+- The tarball carries `package.json` in addition to the runtime set
+  (`ver-bump.sh`, `lib/`, `LICENSE`) because `--about` / `--help` read the
+  tool's name + version from it (`version_block` in `lib/ui.sh`).
+- `install.sh` is standalone by design — it must not source `lib/` (nothing
+  is installed yet when it runs). `is_semver` and the exit-code contract
+  (2 usage / 3 missing tools / 1 failure) are mirrored from `lib/`.
+- `http_fetch` is the single network seam; tests stub it to serve local
+  fixture files, so the bats suite never touches the network.
+- Install is stage-then-swap: the verified tree is staged next to
+  `share/ver-bump` and swapped in only after every earlier step succeeded,
+  so a failed run can never leave a half-written install.
+
+Modules: `install.sh` (standalone), `publish-release-assets` in
+[.github/workflows/ci.yml](../../../.github/workflows/ci.yml).
+Tests: `test/install.bats`.

--- a/install.sh
+++ b/install.sh
@@ -17,8 +17,8 @@
 # on the last line, so a truncated download can never half-execute.
 #
 # Failure contract (R-DIST-5): any download, checksum, or install error exits
-# non-zero, leaves an existing install untouched, and cleans up temp files.
-# Exit codes mirror lib/errors.sh: 2 usage, 3 missing tools, 1 anything else.
+# non-zero, keeps (or restores) any existing install, and cleans up temp
+# files. Exit codes mirror lib/errors.sh: 2 usage, 3 missing tools, 1 else.
 
 REPO_SLUG="jv-k/ver-bump"
 ASSET_NAME="ver-bump.tar.gz"
@@ -32,6 +32,8 @@ BIN_DIR=""
 BIN_LINK=""
 WORK_DIR=""          # mktemp scratch dir, removed by the EXIT trap
 STAGED_DIR=""        # in-flight ${SHARE_DIR}.staged.$$, removed by the trap
+BACKUP_DIR=""        # previous install moved aside during the swap; removed
+                     # on success, restored (never deleted) on failure
 
 usage() {
   cat <<'EOF'
@@ -223,20 +225,59 @@ read-tree-version() {
   printf 'unknown\n'
 }
 
-# install-tree <src-dir> — stage next to the destination, then swap, so a
-# failed run can never leave a half-written install and a re-run upgrades
-# in place (R-DIST-3).
+# install-tree <src-dir> — rename swap with rollback. The verified tree is
+# staged next to the destination (same filesystem, so the swap is a plain
+# rename, never a partial cross-device copy), any previous install is moved
+# aside — not deleted — and only removed once the new tree and symlink are
+# in place. A failure mid-swap puts the previous install back (R-DIST-5);
+# a re-run upgrades in place (R-DIST-3).
 install-tree() {
   local src=$1
   mkdir -p "$BIN_DIR" "${SHARE_DIR%/*}" || return 1
+
   STAGED_DIR="${SHARE_DIR}.staged.$$"
   rm -rf "$STAGED_DIR" || return 1
   mv "$src" "$STAGED_DIR" || return 1
   chmod +x "$STAGED_DIR/ver-bump.sh" || return 1
-  rm -rf "$SHARE_DIR" || return 1
-  mv "$STAGED_DIR" "$SHARE_DIR" || return 1
+
+  # 1. Move any previous install aside, kept for rollback.
+  BACKUP_DIR=""
+  if [ -e "$SHARE_DIR" ]; then
+    BACKUP_DIR="${SHARE_DIR}.bak.$$"
+    rm -rf "$BACKUP_DIR" || return 1
+    mv "$SHARE_DIR" "$BACKUP_DIR" || return 1
+  fi
+
+  # 2.+3. Swap the new tree in and point the symlink at it.
+  if ! mv "$STAGED_DIR" "$SHARE_DIR" || \
+     ! ln -sfn "$SHARE_DIR/ver-bump.sh" "$BIN_LINK"; then
+    _restore-backup
+    return 1
+  fi
   STAGED_DIR=""
-  ln -sfn "$SHARE_DIR/ver-bump.sh" "$BIN_LINK" || return 1
+
+  # 4. Only now is the previous install gone.
+  if [ -n "$BACKUP_DIR" ]; then
+    rm -rf "$BACKUP_DIR"
+    BACKUP_DIR=""
+  fi
+}
+
+# Undo a failed swap: clear whatever half-state sits at SHARE_DIR and put
+# the moved-aside previous install back. Best-effort — this runs on the
+# failure path — but a backup that cannot be moved back is preserved and
+# named, never deleted.
+_restore-backup() {
+  rm -rf "$SHARE_DIR"
+  if [ -n "$BACKUP_DIR" ] && [ -e "$BACKUP_DIR" ]; then
+    if mv "$BACKUP_DIR" "$SHARE_DIR"; then
+      BACKUP_DIR=""
+      printf 'ver-bump install: swap failed — previous installation restored\n' >&2
+    else
+      printf 'ver-bump install: swap failed — previous installation preserved at %s\n' \
+        "$BACKUP_DIR" >&2
+    fi
+  fi
 }
 
 # Warn when the bin dir isn't on PATH — the most common "installed but
@@ -255,6 +296,8 @@ _path-hint() {
 cleanup() {
   [ -n "${WORK_DIR:-}" ] && rm -rf "$WORK_DIR"
   [ -n "${STAGED_DIR:-}" ] && rm -rf "$STAGED_DIR"
+  # BACKUP_DIR is deliberately not removed here: if a failed swap could not
+  # restore it, it is the user's previous install — never delete it.
   return 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+#
+# install.sh — checksummed installer for ver-bump (issue #66, R-DIST-1..5).
+#
+# Downloads a GitHub release tarball, verifies its published sha256, and
+# installs under ${VER_BUMP_PREFIX:-$HOME/.local}:
+#
+#   <prefix>/share/ver-bump/   the release tree (ver-bump.sh + lib/ + …)
+#   <prefix>/bin/ver-bump      symlink to share/ver-bump/ver-bump.sh
+#
+# Designed to be piped —
+#
+#   curl -fsSL https://raw.githubusercontent.com/jv-k/ver-bump/main/install.sh | bash
+#
+# so it is deliberately boring: no colour, no dependencies beyond bash + tar
+# + (curl|wget) + (sha256sum|shasum), and all real work happens inside main()
+# on the last line, so a truncated download can never half-execute.
+#
+# Failure contract (R-DIST-5): any download, checksum, or install error exits
+# non-zero, leaves an existing install untouched, and cleans up temp files.
+# Exit codes mirror lib/errors.sh: 2 usage, 3 missing tools, 1 anything else.
+
+REPO_SLUG="jv-k/ver-bump"
+ASSET_NAME="ver-bump.tar.gz"
+
+# Set by parse-args / install-paths; documented here as the integration
+# surface between steps (the repo's globals-between-phases convention).
+INSTALL_VERSION=""   # empty = latest stable release
+INSTALL_PREFIX=""
+SHARE_DIR=""
+BIN_DIR=""
+BIN_LINK=""
+WORK_DIR=""          # mktemp scratch dir, removed by the EXIT trap
+STAGED_DIR=""        # in-flight ${SHARE_DIR}.staged.$$, removed by the trap
+
+usage() {
+  cat <<'EOF'
+ver-bump installer — download a release, verify its sha256, install it.
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/jv-k/ver-bump/main/install.sh | bash
+  bash install.sh [--version <x.y.z>] [--prefix <dir>]
+
+Options:
+  --version <x.y.z>   Install a specific release (default: latest stable).
+  --prefix <dir>      Install prefix (default: ~/.local).
+  -h, --help          Show this help.
+
+Environment:
+  VER_BUMP_INSTALL_VERSION   Same as --version (a flag wins over the env var).
+  VER_BUMP_PREFIX            Same as --prefix.
+
+Layout:
+  <prefix>/share/ver-bump/   the release tree (ver-bump.sh + lib/)
+  <prefix>/bin/ver-bump      symlink to share/ver-bump/ver-bump.sh
+
+Re-running upgrades an existing install in place.
+EOF
+}
+
+# bail <code> <message> [hint] — error to stderr, then exit <code>. Mirrors
+# fail() in lib/errors.sh without depending on it: the installer runs before
+# anything is installed, so it must stay self-contained.
+bail() {
+  local code=$1
+  printf 'ver-bump install: error: %s\n' "$2" >&2
+  if [ -n "${3:-}" ]; then
+    printf '  hint: %s\n' "$3" >&2
+  fi
+  exit "$code"
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Keep in sync with is_semver in lib/validate.sh (copied, not sourced: the
+# installer must work before lib/ exists on the machine).
+is_semver() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]
+}
+
+# R-DIST-3: bash + tar + (curl|wget) + (sha256sum|shasum) is the entire
+# dependency surface. git/jq are ver-bump *runtime* deps — the tool checks
+# those itself on first run, deliberately not here.
+check-install-deps() {
+  local missing=()
+  have_cmd tar || missing+=("tar")
+  have_cmd curl || have_cmd wget || missing+=("curl (or wget)")
+  have_cmd sha256sum || have_cmd shasum || missing+=("sha256sum (or shasum)")
+  [ ${#missing[@]} -eq 0 ] || \
+    bail 3 "missing required tools: ${missing[*]}" \
+           "install them with your package manager, then re-run"
+}
+
+# Populate INSTALL_VERSION / INSTALL_PREFIX from flags, falling back to env
+# (CLI > env, matching the tool's config precedence). Accepts a leading "v"
+# on versions (tags are v-prefixed) but stores the bare x.y.z.
+parse-args() {
+  INSTALL_VERSION="${VER_BUMP_INSTALL_VERSION:-}"
+  INSTALL_PREFIX="${VER_BUMP_PREFIX:-$HOME/.local}"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --version=?*)
+        INSTALL_VERSION="${1#--version=}"
+        ;;
+      --version)
+        [ -n "${2:-}" ] || bail 2 "--version requires a value" "e.g. --version 2.0.0"
+        INSTALL_VERSION=$2
+        shift
+        ;;
+      --prefix=?*)
+        INSTALL_PREFIX="${1#--prefix=}"
+        ;;
+      --prefix)
+        [ -n "${2:-}" ] || bail 2 "--prefix requires a value" "e.g. --prefix \$HOME/.local"
+        INSTALL_PREFIX=$2
+        shift
+        ;;
+      --version=|--prefix=)
+        bail 2 "${1%=} requires a value"
+        ;;
+      *)
+        usage >&2
+        bail 2 "unknown option: $1"
+        ;;
+    esac
+    shift
+  done
+
+  INSTALL_VERSION="${INSTALL_VERSION#v}"
+  if [ -n "$INSTALL_VERSION" ] && ! is_semver "$INSTALL_VERSION"; then
+    bail 2 "not a valid SemVer version: ${INSTALL_VERSION}" \
+           "expected x.y.z, e.g. VER_BUMP_INSTALL_VERSION=2.0.0"
+  fi
+}
+
+install-paths() {
+  SHARE_DIR="${INSTALL_PREFIX}/share/ver-bump"
+  BIN_DIR="${INSTALL_PREFIX}/bin"
+  BIN_LINK="${BIN_DIR}/ver-bump"
+}
+
+# asset-url <file> — release-asset URL for <file>: GitHub's stable
+# latest-release alias when no version is pinned, the tag path when one is.
+# Both forms work identically with curl and wget — no API, no JSON, no
+# rate limits.
+asset-url() {
+  if [ -n "$INSTALL_VERSION" ]; then
+    printf 'https://github.com/%s/releases/download/v%s/%s\n' \
+      "$REPO_SLUG" "$INSTALL_VERSION" "$1"
+  else
+    printf 'https://github.com/%s/releases/latest/download/%s\n' \
+      "$REPO_SLUG" "$1"
+  fi
+}
+
+# http_fetch <url> <dest> — the single network seam. Tests stub this
+# function to serve local fixture files instead.
+http_fetch() {
+  if have_cmd curl; then
+    curl -fsSL --retry 2 -o "$2" "$1"
+  else
+    wget -q -O "$2" "$1"
+  fi
+}
+
+sha256_of() {
+  local line
+  if have_cmd sha256sum; then
+    line=$(sha256sum "$1") || return 1
+  else
+    line=$(shasum -a 256 "$1") || return 1
+  fi
+  printf '%s\n' "${line%% *}"
+}
+
+# verify_checksum <file> <sumfile> — compare <file>'s sha256 against the
+# first field of <sumfile> (`sha256sum` output format). A sumfile whose
+# first field isn't a 64-char hex digest is rejected outright — that is
+# what a mis-served HTML error page looks like.
+verify_checksum() {
+  local file=$1 sumfile=$2 expected actual rest
+  local hex_re='^[0-9a-fA-F]{64}$'
+  read -r expected rest < "$sumfile" || true
+  if ! [[ "$expected" =~ $hex_re ]]; then
+    printf 'ver-bump install: checksum file is malformed (expected a sha256 digest)\n' >&2
+    return 1
+  fi
+  actual=$(sha256_of "$file") || return 1
+  if [ "$actual" != "$expected" ]; then
+    printf 'ver-bump install: checksum mismatch for %s\n  expected: %s\n  actual:   %s\n' \
+      "${file##*/}" "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+# unpack-tarball <tarball> <dest-dir> — extract, then sanity-check the
+# layout so a wrong or truncated asset can never be swapped into place.
+unpack-tarball() {
+  tar -xzf "$1" -C "$2" || return 1
+  [ -f "$2/ver-bump.sh" ] && [ -d "$2/lib" ]
+}
+
+# read-tree-version <dir> — the "version" field of the unpacked
+# package.json, parsed with bash alone (jq is a ver-bump runtime dep, not
+# an installer one). Prints "unknown" rather than failing: version display
+# is cosmetic, the checksum is the integrity gate.
+read-tree-version() {
+  local line re='"version"[[:space:]]*:[[:space:]]*"([^"]+)"'
+  if [ -f "$1/package.json" ]; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ $re ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+      fi
+    done < "$1/package.json"
+  fi
+  printf 'unknown\n'
+}
+
+# install-tree <src-dir> — stage next to the destination, then swap, so a
+# failed run can never leave a half-written install and a re-run upgrades
+# in place (R-DIST-3).
+install-tree() {
+  local src=$1
+  mkdir -p "$BIN_DIR" "${SHARE_DIR%/*}" || return 1
+  STAGED_DIR="${SHARE_DIR}.staged.$$"
+  rm -rf "$STAGED_DIR" || return 1
+  mv "$src" "$STAGED_DIR" || return 1
+  chmod +x "$STAGED_DIR/ver-bump.sh" || return 1
+  rm -rf "$SHARE_DIR" || return 1
+  mv "$STAGED_DIR" "$SHARE_DIR" || return 1
+  STAGED_DIR=""
+  ln -sfn "$SHARE_DIR/ver-bump.sh" "$BIN_LINK" || return 1
+}
+
+# Warn when the bin dir isn't on PATH — the most common "installed but
+# command not found" support question.
+_path-hint() {
+  case ":$PATH:" in
+    *":${BIN_DIR}:"*) ;;
+    *)
+      printf 'Note: %s is not on your PATH. Add it, e.g.:\n' "$BIN_DIR"
+      # shellcheck disable=SC2016  # $PATH must stay literal in the shown command
+      printf '  export PATH="%s:$PATH"\n' "$BIN_DIR"
+      ;;
+  esac
+}
+
+cleanup() {
+  [ -n "${WORK_DIR:-}" ] && rm -rf "$WORK_DIR"
+  [ -n "${STAGED_DIR:-}" ] && rm -rf "$STAGED_DIR"
+  return 0
+}
+
+main() {
+  parse-args "$@"
+  check-install-deps
+  install-paths
+
+  trap cleanup EXIT
+  WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ver-bump-install.XXXXXX") || \
+    bail 1 "could not create a temporary directory"
+
+  printf 'Installing ver-bump (%s) to %s ...\n' \
+    "${INSTALL_VERSION:-latest}" "$INSTALL_PREFIX"
+
+  local url
+  url=$(asset-url "$ASSET_NAME")
+  http_fetch "$url" "$WORK_DIR/$ASSET_NAME" || \
+    bail 1 "download failed: $url" \
+           "releases before 2.0.0 have no install assets — pin one that does: VER_BUMP_INSTALL_VERSION=x.y.z"
+  url=$(asset-url "$ASSET_NAME.sha256")
+  http_fetch "$url" "$WORK_DIR/$ASSET_NAME.sha256" || \
+    bail 1 "download failed: $url" \
+           "the release is missing its .sha256 asset — refusing to install unverified"
+
+  verify_checksum "$WORK_DIR/$ASSET_NAME" "$WORK_DIR/$ASSET_NAME.sha256" || \
+    bail 1 "sha256 verification failed — nothing was installed" \
+           "re-run to retry; a persistent mismatch means the asset is corrupt or tampered with"
+
+  mkdir -p "$WORK_DIR/tree" || bail 1 "could not prepare the unpack directory"
+  unpack-tarball "$WORK_DIR/$ASSET_NAME" "$WORK_DIR/tree" || \
+    bail 1 "unexpected tarball layout (no ver-bump.sh + lib/) — nothing was installed"
+
+  local installed_version
+  installed_version=$(read-tree-version "$WORK_DIR/tree")
+  install-tree "$WORK_DIR/tree" || \
+    bail 1 "could not install to ${SHARE_DIR}" \
+           "check permissions, or point VER_BUMP_PREFIX at a writable prefix"
+
+  printf 'Installed ver-bump %s\n' "$installed_version"
+  printf '  %s -> %s\n' "$BIN_LINK" "$SHARE_DIR/ver-bump.sh"
+  _path-hint
+  printf "Tip: run 'ver-bump --install-completions' to set up shell completions.\n"
+}
+
+# Run main when executed or piped into bash; skip it when sourced (tests
+# source this file to drive the functions above directly). Unlike the
+# "$0" = "$BASH_SOURCE" guard in ver-bump.sh, this idiom also fires for
+# `curl … | bash`, where BASH_SOURCE is empty.
+if ! (return 0 2>/dev/null); then
+  main "$@"
+fi

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "release": "gh release create --notes \"$(npx jv-k/releasetool)\"",
     "tests:install": "./install_bats.sh",
     "tests:run": "./test/bats/bin/bats ./test/*.bats",
-    "lint": "shellcheck -x -e SC1017 ./ver-bump.sh ./lib/*.sh",
+    "lint": "shellcheck -x -e SC1017 ./ver-bump.sh ./install.sh ./lib/*.sh",
     "screenshots": "./dev/capture-freeze.sh",
     "screenshots:help": "./dev/capture-freeze.sh help",
     "screenshots:demo": "./dev/screenshots.sh demo",

--- a/test/install.bats
+++ b/test/install.bats
@@ -214,8 +214,10 @@ make_release_fixture() {
   assert_output --partial "Installed ver-bump $(jsonfile_get_ver "$repo_dir/package.json")"
   assert_output --partial "ver-bump --install-completions"
 
-  # No temp leftovers on success either.
+  # No temp leftovers on success either — and no .staged/.bak next to the
+  # install.
   [ -z "$(ls -A "$SCRATCH_TMP")" ]
+  assert_equal "$(ls -A "$PREFIX/share")" "ver-bump"
 }
 
 @test "install: e2e re-run upgrades in place (idempotent)" {
@@ -235,6 +237,81 @@ make_release_fixture() {
 
   [ ! -e "$PREFIX/share/ver-bump/stale-file-from-old-version" ]
   [ -L "$PREFIX/bin/ver-bump" ]
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+  # The upgrade's backup of the old tree must not linger after success.
+  assert_equal "$(ls -A "$PREFIX/share")" "ver-bump"
+}
+
+@test "install: e2e failed swap restores the previous install" {
+  source "$installer"
+  make_release_fixture
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  # Existing install that must survive the failure.
+  mkdir -p "$PREFIX/share/ver-bump"
+  printf 'old\n' > "$PREFIX/share/ver-bump/sentinel-old-install"
+
+  # Fail only the swap: mv of the .staged tree into place. Staging (dest is
+  # .staged) and the rollback mv (source is .bak) still use the real mv.
+  mv() {
+    case "$1" in
+      *.staged.*) return 1 ;;
+    esac
+    command mv "$@"
+  }
+
+  run main --prefix "$PREFIX"
+  assert_failure 1
+  assert_output --partial "previous installation restored"
+
+  # R-DIST-5: the old install is back, byte for byte where it was.
+  [ -f "$PREFIX/share/ver-bump/sentinel-old-install" ]
+  [ ! -f "$PREFIX/share/ver-bump/ver-bump.sh" ]
+  # No .bak/.staged leftovers, no temp leftovers.
+  assert_equal "$(ls -A "$PREFIX/share")" "ver-bump"
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}
+
+@test "install: e2e failed symlink rolls back to the previous install" {
+  source "$installer"
+  make_release_fixture
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  mkdir -p "$PREFIX/share/ver-bump"
+  printf 'old\n' > "$PREFIX/share/ver-bump/sentinel-old-install"
+
+  # The swap succeeds but the symlink step fails: the new tree must be
+  # backed out and the previous install put back.
+  ln() { return 1; }
+
+  run main --prefix "$PREFIX"
+  assert_failure 1
+  assert_output --partial "previous installation restored"
+
+  [ -f "$PREFIX/share/ver-bump/sentinel-old-install" ]
+  [ ! -f "$PREFIX/share/ver-bump/ver-bump.sh" ]
+  [ ! -e "$PREFIX/bin/ver-bump" ]
+  assert_equal "$(ls -A "$PREFIX/share")" "ver-bump"
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}
+
+@test "install: e2e failed symlink on a fresh install leaves nothing behind" {
+  source "$installer"
+  make_release_fixture
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  ln() { return 1; }
+
+  run main --prefix "$PREFIX"
+  assert_failure 1
+
+  # No previous install to restore — the half-swapped tree must be gone.
+  [ ! -e "$PREFIX/share/ver-bump" ]
+  [ ! -e "$PREFIX/bin/ver-bump" ]
+  [ -z "$(ls -A "$PREFIX/share")" ]
   [ -z "$(ls -A "$SCRATCH_TMP")" ]
 }
 

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+# install.sh (R-DIST-1..5, issue #66): arg/env parsing, layout paths, asset
+# URLs, and checksum verification are driven as pure functions by sourcing
+# the installer. End-to-end runs stub http_fetch — the installer's single
+# network seam — with local fixture files, so no test touches the network.
+# Negative cases assert the R-DIST-5 contract: non-zero exit, nothing
+# installed, no partial files left behind.
+
+load 'test_helper'
+
+# Isolate HOME, the install prefix, and TMPDIR per test so failure cases can
+# assert "nothing installed" and "no temp leftovers" against empty dirs.
+setup() {
+  load './test_helper/bats-support/load'
+  load './test_helper/bats-assert/load'
+
+  repo_dir=$PWD
+  installer="$repo_dir/install.sh"
+
+  FAKE_HOME=$(mktemp -d)
+  export HOME="$FAKE_HOME"
+  PREFIX="$FAKE_HOME/.local"
+
+  FIXTURE_DIR=$(mktemp -d)
+  SCRATCH_TMP=$(mktemp -d)
+
+  F_TEMPS=()
+  CLEANUP_CMDS=( "rm -rf ${FAKE_HOME}" "rm -rf ${FIXTURE_DIR}" "rm -rf ${SCRATCH_TMP}" )
+}
+
+teardown() {
+  run_cleanup_cmds
+  unset FAKE_HOME PREFIX FIXTURE_DIR SCRATCH_TMP
+  unset VER_BUMP_INSTALL_VERSION VER_BUMP_PREFIX
+}
+
+# Build a fake "release" in $FIXTURE_DIR from the real working tree — the
+# same file set the publish workflow tars up — so fixtures can't drift from
+# what CI ships. Requires install.sh to be sourced (uses sha256_of).
+make_release_fixture() {
+  (cd "$repo_dir" && tar -czf "$FIXTURE_DIR/ver-bump.tar.gz" ver-bump.sh lib LICENSE package.json)
+  printf '%s  ver-bump.tar.gz\n' "$(sha256_of "$FIXTURE_DIR/ver-bump.tar.gz")" \
+    > "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+}
+
+# ── executed / piped entrypoint ─────────────────────────────────────────
+
+@test "install: --help prints usage on stdout and exits 0" {
+  run bash "$installer" --help
+  assert_success
+  assert_output --partial "VER_BUMP_INSTALL_VERSION"
+  assert_output --partial "--prefix <dir>"
+}
+
+@test "install: unknown option exits 2 with usage" {
+  run bash "$installer" --bogus
+  assert_failure 2
+  assert_output --partial "unknown option: --bogus"
+}
+
+@test "install: main also runs when piped into bash (curl | bash path)" {
+  # An invalid pinned version proves main ran (and bailed in parse-args,
+  # before any network or filesystem work).
+  run bash -c "VER_BUMP_INSTALL_VERSION=banana bash < '$installer'"
+  assert_failure 2
+  assert_output --partial "not a valid SemVer version"
+}
+
+# ── parse-args: flags, env, precedence ──────────────────────────────────
+
+@test "install: parse-args defaults to latest + \$HOME/.local" {
+  source "$installer"
+  parse-args
+  assert_equal "$INSTALL_VERSION" ""
+  assert_equal "$INSTALL_PREFIX" "$HOME/.local"
+}
+
+@test "install: parse-args reads VER_BUMP_INSTALL_VERSION and VER_BUMP_PREFIX" {
+  source "$installer"
+  export VER_BUMP_INSTALL_VERSION="v2.0.0"   # leading v is accepted + stripped
+  export VER_BUMP_PREFIX="/opt/ver-bump"
+  parse-args
+  assert_equal "$INSTALL_VERSION" "2.0.0"
+  assert_equal "$INSTALL_PREFIX" "/opt/ver-bump"
+}
+
+@test "install: flags win over env (CLI > env precedence)" {
+  source "$installer"
+  export VER_BUMP_INSTALL_VERSION="1.0.0"
+  export VER_BUMP_PREFIX="/from-env"
+  parse-args --version 2.0.0 --prefix /from-cli
+  assert_equal "$INSTALL_VERSION" "2.0.0"
+  assert_equal "$INSTALL_PREFIX" "/from-cli"
+}
+
+@test "install: --version=<v> equals form accepts a prerelease" {
+  source "$installer"
+  parse-args --version=2.0.0-rc.1
+  assert_equal "$INSTALL_VERSION" "2.0.0-rc.1"
+}
+
+@test "install: --version without a value exits 2" {
+  source "$installer"
+  run parse-args --version
+  assert_failure 2
+  assert_output --partial "--version requires a value"
+}
+
+@test "install: empty --version= / --prefix= exit 2" {
+  source "$installer"
+  run parse-args --version=
+  assert_failure 2
+  assert_output --partial "--version requires a value"
+  run parse-args --prefix=
+  assert_failure 2
+  assert_output --partial "--prefix requires a value"
+}
+
+@test "install: non-SemVer version exits 2 with hint" {
+  source "$installer"
+  run parse-args --version banana
+  assert_failure 2
+  assert_output --partial "not a valid SemVer version: banana"
+  assert_output --partial "VER_BUMP_INSTALL_VERSION"
+}
+
+# ── layout + asset URLs ─────────────────────────────────────────────────
+
+@test "install: install-paths derives share dir, bin dir and symlink from prefix" {
+  source "$installer"
+  INSTALL_PREFIX="/x"
+  install-paths
+  assert_equal "$SHARE_DIR" "/x/share/ver-bump"
+  assert_equal "$BIN_DIR" "/x/bin"
+  assert_equal "$BIN_LINK" "/x/bin/ver-bump"
+}
+
+@test "install: asset-url uses the latest-release alias when unpinned" {
+  source "$installer"
+  INSTALL_VERSION=""
+  run asset-url "ver-bump.tar.gz"
+  assert_success
+  assert_output "https://github.com/jv-k/ver-bump/releases/latest/download/ver-bump.tar.gz"
+}
+
+@test "install: asset-url uses the v-prefixed tag path when pinned" {
+  source "$installer"
+  INSTALL_VERSION="1.2.3"
+  run asset-url "ver-bump.tar.gz.sha256"
+  assert_success
+  assert_output "https://github.com/jv-k/ver-bump/releases/download/v1.2.3/ver-bump.tar.gz.sha256"
+}
+
+# ── dependency preflight ────────────────────────────────────────────────
+
+@test "install: missing tar is reported with exit 3" {
+  source "$installer"
+  # Shadow the probe for tar only; everything else resolves normally.
+  have_cmd() {
+    [ "$1" = tar ] && return 1
+    command -v "$1" >/dev/null 2>&1
+  }
+  run check-install-deps
+  assert_failure 3
+  assert_output --partial "missing required tools: tar"
+}
+
+# ── checksum verification (fixtures, no network) ────────────────────────
+
+@test "install: verify_checksum accepts a matching digest" {
+  source "$installer"
+  make_release_fixture
+  run verify_checksum "$FIXTURE_DIR/ver-bump.tar.gz" "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  assert_success
+}
+
+@test "install: verify_checksum rejects a wrong digest" {
+  source "$installer"
+  make_release_fixture
+  printf '%064d  ver-bump.tar.gz\n' 0 > "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  run verify_checksum "$FIXTURE_DIR/ver-bump.tar.gz" "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  assert_failure
+  assert_output --partial "checksum mismatch"
+}
+
+@test "install: verify_checksum rejects a malformed checksum file" {
+  source "$installer"
+  make_release_fixture
+  printf '<html>404 Not Found</html>\n' > "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  run verify_checksum "$FIXTURE_DIR/ver-bump.tar.gz" "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  assert_failure
+  assert_output --partial "malformed"
+}
+
+# ── end-to-end with a stubbed http_fetch ────────────────────────────────
+
+@test "install: e2e happy path installs tree + symlink and prints version" {
+  source "$installer"
+  make_release_fixture
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  run main --prefix "$PREFIX"
+  assert_success
+
+  [ -f "$PREFIX/share/ver-bump/ver-bump.sh" ]
+  [ -x "$PREFIX/share/ver-bump/ver-bump.sh" ]
+  [ -d "$PREFIX/share/ver-bump/lib" ]
+  [ -L "$PREFIX/bin/ver-bump" ]
+  assert_equal "$(readlink "$PREFIX/bin/ver-bump")" "$PREFIX/share/ver-bump/ver-bump.sh"
+
+  # R-DIST-3: prints the installed version + the completions suggestion.
+  assert_output --partial "Installed ver-bump $(jsonfile_get_ver "$repo_dir/package.json")"
+  assert_output --partial "ver-bump --install-completions"
+
+  # No temp leftovers on success either.
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}
+
+@test "install: e2e re-run upgrades in place (idempotent)" {
+  source "$installer"
+  make_release_fixture
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  # Seed a stale install: the swap must replace the whole tree, not merge.
+  mkdir -p "$PREFIX/share/ver-bump"
+  touch "$PREFIX/share/ver-bump/stale-file-from-old-version"
+
+  run main --prefix "$PREFIX"
+  assert_success
+  run main --prefix "$PREFIX"
+  assert_success
+
+  [ ! -e "$PREFIX/share/ver-bump/stale-file-from-old-version" ]
+  [ -L "$PREFIX/bin/ver-bump" ]
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}
+
+@test "install: e2e corrupted checksum exits 1, installs nothing, cleans up" {
+  source "$installer"
+  make_release_fixture
+  printf '%064d  ver-bump.tar.gz\n' 0 > "$FIXTURE_DIR/ver-bump.tar.gz.sha256"
+  http_fetch() { cp "$FIXTURE_DIR/${1##*/}" "$2"; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  run main --prefix "$PREFIX"
+  assert_failure 1
+  assert_output --partial "sha256 verification failed"
+
+  # R-DIST-5: nothing installed, no partial files anywhere.
+  [ ! -e "$PREFIX/share/ver-bump" ]
+  [ ! -e "$PREFIX/bin/ver-bump" ]
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}
+
+@test "install: e2e download failure exits 1 with pin hint, installs nothing" {
+  source "$installer"
+  http_fetch() { return 1; }
+  export TMPDIR="$SCRATCH_TMP"
+
+  run main --prefix "$PREFIX"
+  assert_failure 1
+  assert_output --partial "download failed"
+  assert_output --partial "VER_BUMP_INSTALL_VERSION"
+
+  [ ! -e "$PREFIX/share/ver-bump" ]
+  [ ! -e "$PREFIX/bin/ver-bump" ]
+  [ -z "$(ls -A "$SCRATCH_TMP")" ]
+}


### PR DESCRIPTION
## Summary

The pitch is "pure bash, no Node ecosystem lock-in", but until now the only install path was `npm -g`. This adds the cheapest no-Node path: a checksummed `install.sh` at the repo root, fed by tarball + sha256 assets that the release workflow now publishes. Complements the tracked Homebrew (#24) and basher (#39) paths — it ships first and stays useful alongside both.

Refs #66.

## Requirements

New `R-DIST` bucket, documented with test mapping in `docs/features/installer/requirements.md`:

- **R-DIST-1** — `install.sh` downloads the latest release tarball (or a pin via `VER_BUMP_INSTALL_VERSION=x.y.z` / `--version`), verifies its published sha256, unpacks under `${VER_BUMP_PREFIX:-$HOME/.local}` (`share/ver-bump/` + `bin/ver-bump` symlink).
- **R-DIST-2** — `publish-release-assets` job in `ci.yml` builds `ver-bump.tar.gz` + `ver-bump.tar.gz.sha256` and attaches them with `gh release upload`.
- **R-DIST-3** — deps limited to `bash` + `tar` + (`curl`|`wget`) + (`sha256sum`|`shasum`); idempotent re-runs upgrade in place via stage-then-swap; prints the installed version and suggests `ver-bump --install-completions`.
- **R-DIST-4** — README install section reordered: curl one-liner first with the pipe-to-shell caveat and a download-then-inspect alternative spelled out; npm/pnpm second; brew/basher noted as tracked. No new headings, so the doctoc TOC is untouched.
- **R-DIST-5** — checksum mismatch or download failure → non-zero exit, nothing installed, temp/staged files removed by an EXIT trap.

## Design notes

- **Unversioned asset names** keep both URL forms static (`releases/latest/download/…` and `releases/download/v<x.y.z>/…`) — no GitHub API, no JSON parsing, no rate limits, identical behaviour under curl and wget.
- The tarball carries `package.json` in addition to the sketched set (`ver-bump.sh`, `lib/`, `LICENSE`) because `--about`/`--help` read the tool's name + version from it (`version_block` in `lib/ui.sh`) — the issue's own smoke test runs `--about` from the installed path.
- `install.sh` is standalone by design (nothing is installed yet when it runs): `is_semver` and the exit-code contract (2 usage / 3 missing tools / 1 failure) are mirrored from `lib/`, not sourced.
- `main()` runs when executed **or piped** but not when sourced (all work happens on the last line, so a truncated `curl | bash` can never half-execute); `http_fetch` is the single network seam.

## Workflow change kept minimal

Only two touches to `ci.yml`: `install.sh` added to the existing shellcheck invocation, and one appended `publish-release-assets` job (`needs: tests`, `if: published`, mirroring the other publish jobs). No existing job is restructured or newly gated. The job reuses the SHA-pinned `actions/checkout` and adds only a job-scoped `contents: write`; its final step smoke-installs from the freshly uploaded assets (short retry for asset propagation) and runs `ver-bump --about` — cheap, and a failure there blocks nothing else.

## Test plan

- `test/install.bats` (21 new cases): arg/env parsing incl. CLI > env precedence and `=`-form flags, layout paths, asset URLs, dependency preflight, checksum verification against local fixtures, and stubbed end-to-end runs (fixtures built from the working tree; `http_fetch` stubbed — no network in tests).
- Negative coverage: corrupted digest, malformed (HTML) checksum file, and download failure → asserted exit codes, nothing installed under the prefix, and an empty TMPDIR afterwards.
- Idempotency: seeded stale file in `share/ver-bump` is gone after a re-run (swap, not merge).
- `pnpm lint` clean (now covers `install.sh`); full suite 275/275 on the rebased branch.
- The publish-time smoke step exercises the real download+verify+install path against the actual release assets on the next release.