### PR TITLE
feat(checks): safety preflights — dirty tree, branch guard, remote sync, no-op detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
-           [--branch] [--pr] [--base <branch>] [--allow-dirty] \
+           [--branch] [--pr] [--base <branch>] [--allow-dirty] [--no-fetch] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
@@ -286,6 +286,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `FLAG_NOCHANGELOG` | `-c` / `--no-changelog` | *unset* |
 | `FLAG_CHANGELOG_PAUSE` | `-l` / `--pause-changelog` | *unset* |
 | `ALLOW_DIRTY` | `--allow-dirty` | *unset* (dirty tree refuses) |
+| `NO_FETCH` | `--no-fetch` | *unset* (fetch + behind-upstream check) |
 | `RELEASE_BRANCHES` | *(no flag)* | *unset* (release from any branch) |
 
 Example:
@@ -386,6 +387,10 @@ output stays byte-identical to previous releases.
                               uncommitted changes to tracked files. Untracked files
                               never trigger the check. Also available as the
                               ALLOW_DIRTY config/env key.
+    --no-fetch                Skip the remote-sync preflight: no 'git fetch <remote>
+                              --tags' and no behind-upstream check before releasing.
+                              Remote-only tag collisions then surface at push time
+                              instead. Also available as the NO_FETCH config/env key.
     --branch                  Cut a release-<version> branch (the pre-2.0 default).
                               Otherwise ver-bump tags the current branch in place.
     --pr                      Create the release branch, push it, then open a pull

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `FLAG_NOCHANGELOG` | `-c` / `--no-changelog` | *unset* |
 | `FLAG_CHANGELOG_PAUSE` | `-l` / `--pause-changelog` | *unset* |
 | `ALLOW_DIRTY` | `--allow-dirty` | *unset* (dirty tree refuses) |
+| `RELEASE_BRANCHES` | *(no flag)* | *unset* (release from any branch) |
 
 Example:
 
@@ -296,6 +297,17 @@ REL_PREFIX="hotfix-"
 PUSH_DEST="upstream"
 COMMIT_MSG_PREFIX="release: "
 FLAG_NOCHANGELOG=true
+RELEASE_BRANCHES="main develop release/*"
+```
+
+`RELEASE_BRANCHES` is a space-separated list of glob patterns naming the
+branches a release may be cut from. When set, running ver-bump from any
+other branch (or from a detached HEAD) exits with code 3 — it is a guard,
+not a prompt, so `--yes` does not bypass it. Clear it for a single run
+with an empty environment override (env beats the file):
+
+```sh
+RELEASE_BRANCHES= ver-bump …
 ```
 
 **Precedence** — highest to lowest: **CLI flag** > **environment variable**

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
-           [--branch] [--pr] [--base <branch>] \
+           [--branch] [--pr] [--base <branch>] [--allow-dirty] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
@@ -285,6 +285,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `PR_BASE` | `--base` | *(auto-detect)* |
 | `FLAG_NOCHANGELOG` | `-c` / `--no-changelog` | *unset* |
 | `FLAG_CHANGELOG_PAUSE` | `-l` / `--pause-changelog` | *unset* |
+| `ALLOW_DIRTY` | `--allow-dirty` | *unset* (dirty tree refuses) |
 
 Example:
 
@@ -369,6 +370,10 @@ output stays byte-identical to previous releases.
                               before bumping the stable component.
     --minor                   Force a minor bump (see --major for semantics).
     --patch                   Force a patch bump (see --major for semantics).
+    --allow-dirty             Skip the clean-working-tree check and release with
+                              uncommitted changes to tracked files. Untracked files
+                              never trigger the check. Also available as the
+                              ALLOW_DIRTY config/env key.
     --branch                  Cut a release-<version> branch (the pre-2.0 default).
                               Otherwise ver-bump tags the current branch in place.
     --pr                      Create the release branch, push it, then open a pull

--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
-           [--branch] [--pr] [--base <branch>] [--allow-dirty] [--no-fetch] \
+           [--branch] [--pr] [--base <branch>] \
+           [--allow-dirty] [--allow-empty] [--no-fetch] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
@@ -387,6 +388,11 @@ output stays byte-identical to previous releases.
                               uncommitted changes to tracked files. Untracked files
                               never trigger the check. Also available as the
                               ALLOW_DIRTY config/env key.
+    --allow-empty             Release even when there are no new commits since the
+                              previous tag. Without it, such a run prints a notice
+                              (a stdout line starting with "no-release") and exits 0
+                              without changing anything — safe to run unconditionally
+                              in CI.
     --no-fetch                Skip the remote-sync preflight: no 'git fetch <remote>
                               --tags' and no behind-upstream check before releasing.
                               Remote-only tag collisions then surface at push time

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -221,7 +221,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | ID | Requirement |
 | --- | --- |
 | **R-CFG-1** | `.ver-bumprc` is discovered by walking up from `$PWD` to `/`. First match wins; absence is not an error. |
-| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, `RELEASE_BRANCHES`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
+| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, `NO_FETCH`, `RELEASE_BRANCHES`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
 | **R-CFG-3** | Precedence end-to-end: CLI > environment > `.ver-bumprc` > built-in default. |
 | **R-CFG-4** | `.ver-bumprc` is refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. |
 | **R-CFG-5** | `.ver-bumprc` is shell-sourced, not parsed. Failures in sourcing exit `3` with the shell error as context. |
@@ -385,6 +385,7 @@ Exactly the flags shipping in `2.0.0`:
 | — | `--about` | | Branded info block; exit 0 (§5.4 R-OPT-8) |
 | — | `--major` / `--minor` / `--patch` | | Force bump level; mutually exclusive (§5.12) |
 | — | `--allow-dirty` | | Skip the clean-working-tree preflight (R-SAFE-2, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
+| — | `--no-fetch` | | Skip the remote-sync preflight (R-SAFE-8, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
 | — | `--branch` | | Cut a `release-<version>` branch (pre-2.0 default) instead of tagging in place (§5.14) |
 | — | `--pr` | | Branch + push + open a release PR via `gh`; implies push to `origin` (§5.14) |
 | — | `--base` | ✓ | Base branch for `--pr` (default: resolution chain in R-FLOW-2) |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -322,7 +322,7 @@ Each requirement has an ID so tests and PRs can reference it.
 
 ## 10. Testing strategy
 
-- **Unit level** — one `.bats` file per feature under `test/` (`args.bats`, `version.bats`, `release.bats`, `pr.bats`, `undo.bats`, `sandbox.bats`, …) covers every requirement in §5. Currently **237 tests** across 22 files — every `R-*` bucket now has coverage (AC-1 holds).
+- **Unit level** — one `.bats` file per feature under `test/` (`args.bats`, `version.bats`, `release.bats`, `pr.bats`, `undo.bats`, `sandbox.bats`, …) covers every requirement in §5. Currently **347 tests** across 29 files — every `R-*` bucket now has coverage (AC-1 holds), including the `R-SAFE` safety preflights (`worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats`).
 - **Contract level** — exit-code table is asserted per branch in `fail()` unit tests (`test/errors.bats`).
 - **Regression** — running the test suite must not mutate the host repo: anything touching git state runs inside a `scratch_repo` throwaway (`test/test_helper.bash`).
 - **Emitted artefacts** — every completion script is syntax-checked (`bash -n` / `zsh -n` / `fish --no-execute`) in `test/completions-syntax.bats`.
@@ -385,6 +385,7 @@ Exactly the flags shipping in `2.0.0`:
 | — | `--about` | | Branded info block; exit 0 (§5.4 R-OPT-8) |
 | — | `--major` / `--minor` / `--patch` | | Force bump level; mutually exclusive (§5.12) |
 | — | `--allow-dirty` | | Skip the clean-working-tree preflight (R-SAFE-2, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
+| — | `--allow-empty` | | Release even with no new commits since the previous tag (R-SAFE-16) |
 | — | `--no-fetch` | | Skip the remote-sync preflight (R-SAFE-8, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
 | — | `--branch` | | Cut a `release-<version>` branch (pre-2.0 default) instead of tagging in place (§5.14) |
 | — | `--pr` | | Branch + push + open a release PR via `gh`; implies push to `origin` (§5.14) |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -221,7 +221,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | ID | Requirement |
 | --- | --- |
 | **R-CFG-1** | `.ver-bumprc` is discovered by walking up from `$PWD` to `/`. First match wins; absence is not an error. |
-| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
+| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, `RELEASE_BRANCHES`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
 | **R-CFG-3** | Precedence end-to-end: CLI > environment > `.ver-bumprc` > built-in default. |
 | **R-CFG-4** | `.ver-bumprc` is refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. |
 | **R-CFG-5** | `.ver-bumprc` is shell-sourced, not parsed. Failures in sourcing exit `3` with the shell error as context. |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -221,7 +221,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | ID | Requirement |
 | --- | --- |
 | **R-CFG-1** | `.ver-bumprc` is discovered by walking up from `$PWD` to `/`. First match wins; absence is not an error. |
-| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
+| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
 | **R-CFG-3** | Precedence end-to-end: CLI > environment > `.ver-bumprc` > built-in default. |
 | **R-CFG-4** | `.ver-bumprc` is refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. |
 | **R-CFG-5** | `.ver-bumprc` is shell-sourced, not parsed. Failures in sourcing exit `3` with the shell error as context. |
@@ -384,6 +384,7 @@ Exactly the flags shipping in `2.0.0`:
 | `-h` | `--help` | | Help output |
 | — | `--about` | | Branded info block; exit 0 (§5.4 R-OPT-8) |
 | — | `--major` / `--minor` / `--patch` | | Force bump level; mutually exclusive (§5.12) |
+| — | `--allow-dirty` | | Skip the clean-working-tree preflight (R-SAFE-2, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
 | — | `--branch` | | Cut a `release-<version>` branch (pre-2.0 default) instead of tagging in place (§5.14) |
 | — | `--pr` | | Branch + push + open a release PR via `gh`; implies push to `origin` (§5.14) |
 | — | `--base` | ✓ | Base branch for `--pr` (default: resolution chain in R-FLOW-2) |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,7 +21,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
-| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats` |
+| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,7 +21,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
-| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats` |
+| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,6 +21,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
+| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,7 +21,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
-| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats` |
+| [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/config-file/requirements.md
+++ b/docs/features/config-file/requirements.md
@@ -6,7 +6,7 @@ Repo- or home-level defaults without repeating flags. Shipped in 2.0
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-CFG-1 | Discovered by walking up from `$PWD` to `/`; first match wins; absence is not an error. | ✅ shipped — `_find-rc-upward` |
-| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
+| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), `RELEASE_BRANCHES` (R-SAFE-10), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
 | R-CFG-3 | Precedence: CLI > env > `.ver-bumprc` > built-in default, end-to-end. | ✅ shipped (`f6d66b4`) — `test/config-env.bats` |
 | R-CFG-4 | Refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. | ✅ shipped (`6a37077`) |
 | R-CFG-5 | Shell-sourced, not parsed; sourcing failures exit `3` with the shell error as context. | ✅ shipped |

--- a/docs/features/config-file/requirements.md
+++ b/docs/features/config-file/requirements.md
@@ -6,7 +6,7 @@ Repo- or home-level defaults without repeating flags. Shipped in 2.0
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-CFG-1 | Discovered by walking up from `$PWD` to `/`; first match wins; absence is not an error. | ✅ shipped — `_find-rc-upward` |
-| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), `RELEASE_BRANCHES` (R-SAFE-10), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
+| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), `NO_FETCH` (R-SAFE-8), `RELEASE_BRANCHES` (R-SAFE-10), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
 | R-CFG-3 | Precedence: CLI > env > `.ver-bumprc` > built-in default, end-to-end. | ✅ shipped (`f6d66b4`) — `test/config-env.bats` |
 | R-CFG-4 | Refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. | ✅ shipped (`6a37077`) |
 | R-CFG-5 | Shell-sourced, not parsed; sourcing failures exit `3` with the shell error as context. | ✅ shipped |

--- a/docs/features/config-file/requirements.md
+++ b/docs/features/config-file/requirements.md
@@ -6,7 +6,7 @@ Repo- or home-level defaults without repeating flags. Shipped in 2.0
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-CFG-1 | Discovered by walking up from `$PWD` to `/`; first match wins; absence is not an error. | ✅ shipped — `_find-rc-upward` |
-| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
+| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
 | R-CFG-3 | Precedence: CLI > env > `.ver-bumprc` > built-in default, end-to-end. | ✅ shipped (`f6d66b4`) — `test/config-env.bats` |
 | R-CFG-4 | Refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. | ✅ shipped (`6a37077`) |
 | R-CFG-5 | Shell-sourced, not parsed; sourcing failures exit `3` with the shell error as context. | ✅ shipped |

--- a/docs/features/safety-preflights/requirements.md
+++ b/docs/features/safety-preflights/requirements.md
@@ -1,0 +1,23 @@
+# Safety preflights
+
+Preflight guards in `main()`'s Verify section that stop a release before any
+mutation when the repo state looks wrong. Safety-preflight set:
+[#57](https://github.com/jv-k/ver-bump/issues/57) (dirty tree) ·
+[#58](https://github.com/jv-k/ver-bump/issues/58) (remote sync) ·
+[#59](https://github.com/jv-k/ver-bump/issues/59) (branch guard) ·
+[#60](https://github.com/jv-k/ver-bump/issues/60) (no-op detection).
+
+All guard failures exit `3` (precondition) via `fail` — the frozen 2.x exit
+contract (R-EXIT-2) is untouched.
+
+## Dirty working tree (#57)
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-SAFE-1 | When a commit will happen (i.e. not `-n`/`--no-commit`), a non-empty `git status --porcelain --untracked-files=no` (modified tracked files or a non-empty index) exits `3` **before any mutation**, naming the offending paths (first few + count). Untracked files are ignored. | ✅ `check-worktree-clean` | `worktree-clean.bats` |
+| R-SAFE-2 | `--allow-dirty` (boolean, long-only) and the `ALLOW_DIRTY` config/env key (precedence per R-CFG-3) bypass the guard. | ✅ | `worktree-clean.bats`, `args.bats` |
+| R-SAFE-3 | Under `--dry-run` the check still runs (read-only) and fails with the same exit `3`, so the preview is honest about what a real run would do. | ✅ | `worktree-clean.bats` |
+| R-SAFE-4 | Skipped under `-n`/`--no-commit` (nothing is committed, nothing can be swept). | ✅ | `worktree-clean.bats` |
+
+Modules: `lib/git-checks.sh` (`check-worktree-clean`), `lib/args.sh`,
+`lib/config.sh`.

--- a/docs/features/safety-preflights/requirements.md
+++ b/docs/features/safety-preflights/requirements.md
@@ -19,5 +19,14 @@ contract (R-EXIT-2) is untouched.
 | R-SAFE-3 | Under `--dry-run` the check still runs (read-only) and fails with the same exit `3`, so the preview is honest about what a real run would do. | ✅ | `worktree-clean.bats` |
 | R-SAFE-4 | Skipped under `-n`/`--no-commit` (nothing is committed, nothing can be swept). | ✅ | `worktree-clean.bats` |
 
-Modules: `lib/git-checks.sh` (`check-worktree-clean`), `lib/args.sh`,
-`lib/config.sh`.
+## Release-branch guard (#59)
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-SAFE-10 | Config/env key `RELEASE_BRANCHES`: space-separated glob list (e.g. `"main develop release/*"`). Unset/empty (default) = no guard — zero behaviour change for existing users (regression-pinned). | ✅ `check-release-branch` | `release-branch-guard.bats` |
+| R-SAFE-11 | When set and the current branch matches no pattern: exit `3` naming the branch and the allowed list. **Not** bypassed by `--yes` — it's a guard, not a prompt; the one-shot bypass is `RELEASE_BRANCHES= ver-bump …` (env beats rc per R-CFG-3). | ✅ | `release-branch-guard.bats` |
+| R-SAFE-12 | Detached HEAD with the guard active → exit `3` (can't match a branch you're not on). | ✅ | `release-branch-guard.bats` |
+| R-SAFE-13 | Applies to the release flow only; `--undo`, `--completions`, `--about`, `--help` are unaffected (they exit before the Verify section). | ✅ | `release-branch-guard.bats` |
+
+Modules: `lib/git-checks.sh` (`check-worktree-clean`,
+`check-release-branch`), `lib/args.sh`, `lib/config.sh`.

--- a/docs/features/safety-preflights/requirements.md
+++ b/docs/features/safety-preflights/requirements.md
@@ -38,5 +38,23 @@ contract (R-EXIT-2) is untouched.
 | R-SAFE-12 | Detached HEAD with the guard active → exit `3` (can't match a branch you're not on). | ✅ | `release-branch-guard.bats` |
 | R-SAFE-13 | Applies to the release flow only; `--undo`, `--completions`, `--about`, `--help` are unaffected (they exit before the Verify section). | ✅ | `release-branch-guard.bats` |
 
+## Nothing-to-release no-op (#60)
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-SAFE-14 | During Verify, when a previous tag `${TAG_PREFIX}${V_PREV}` exists and `git rev-list --count ${TAG_PREFIX}${V_PREV}..HEAD` is `0`: print a clear "nothing to release since `<tag>`" notice and exit `0` without mutating anything. | ✅ `check-releasable-commits` | `no-release.bats` |
+| R-SAFE-15 | The notice includes a stable, greppable token — a stdout line beginning `no-release` — so CI can branch on outcome. Exit code stays `0` (clean no-op = success; frozen 2.x exit contract R-EXIT-2 untouched). | ✅ | `no-release.bats` |
+| R-SAFE-16 | `--allow-empty` (boolean, long-only) forces the old behaviour for deliberate empty releases / re-tags. CLI-only — reset in `process-arguments` like `DO_RELEASE`/`BUMP_LEVEL` (R-CFG-6 pattern). | ✅ | `no-release.bats`, `args.bats` |
+| R-SAFE-17 | Applies even with `-v <version>` or `--major`/`--minor`/`--patch`: an explicit version is not evidence you meant to release zero commits; `--allow-empty` is the explicit signal. | ✅ | `no-release.bats` |
+| R-SAFE-18 | No previous matching tag (first release) → proceeds as today (R-BUMP-3 fallback unaffected). | ✅ | `no-release.bats` |
+
 Modules: `lib/git-checks.sh` (`check-worktree-clean`,
-`check-release-branch`), `lib/args.sh`, `lib/config.sh`.
+`check-release-branch`, `check-remote-sync`, `check-releasable-commits`),
+`lib/args.sh`, `lib/config.sh`.
+
+Verify-section ordering in `main()` (`ver-bump.sh`):
+`check-commits-exist` → `check-worktree-clean` → `check-release-branch` →
+`check-remote-sync` → `process-version` → `check-releasable-commits` →
+`check-branch-notexist` → `check-tag-exists` → `check-pr-deps`.
+The fetch precedes `check-tag-exists` (R-SAFE-7); the no-op check follows
+`process-version` because it needs `V_PREV` resolved (R-SAFE-14).

--- a/docs/features/safety-preflights/requirements.md
+++ b/docs/features/safety-preflights/requirements.md
@@ -19,6 +19,16 @@ contract (R-EXIT-2) is untouched.
 | R-SAFE-3 | Under `--dry-run` the check still runs (read-only) and fails with the same exit `3`, so the preview is honest about what a real run would do. | ✅ | `worktree-clean.bats` |
 | R-SAFE-4 | Skipped under `-n`/`--no-commit` (nothing is committed, nothing can be swept). | ✅ | `worktree-clean.bats` |
 
+## Remote sync (#58)
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-SAFE-5 | During Verify, if the configured remote (`PUSH_DEST`, default `origin`) exists, run `git fetch <remote> --tags --quiet`. If the fetch fails (offline, auth), **warn and continue** — air-gapped use must keep working. | ✅ `check-remote-sync` | `remote-sync.bats` |
+| R-SAFE-6 | After the fetch, if the current branch has an upstream and is behind it (`git rev-list --count HEAD..@{upstream}` > 0), exit `3` with a hint (`git pull --rebase`, or `--no-fetch` to skip). | ✅ | `remote-sync.bats` |
+| R-SAFE-7 | `check-tag-exists` runs **after** the fetch in `main()` ordering, so remote tags are visible to the existing local check — no second check needed. | ✅ | `remote-sync.bats` |
+| R-SAFE-8 | `--no-fetch` (boolean, long-only) + `NO_FETCH` config/env key skip the network preflight explicitly. | ✅ | `remote-sync.bats`, `args.bats` |
+| R-SAFE-9 | The fetch is read-only and MAY run under `--dry-run` so the preview reflects reality (same reasoning as R-REL-5's read-only notes command). | ✅ | `remote-sync.bats` |
+
 ## Release-branch guard (#59)
 
 | ID | Requirement | Status | Tests |

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -187,6 +187,18 @@ normalize-long-opts() {
         "Drop the '=<value>' — --allow-dirty is a boolean flag."
     fi
 
+    # --no-fetch — long-only boolean: skip the remote-sync preflight
+    # (R-SAFE-8). Sets the NO_FETCH config key directly, so the CLI wins
+    # over env / .ver-bumprc per R-CFG-3 (process-arguments runs last).
+    if [ "$arg" = "--no-fetch" ]; then
+      NO_FETCH=true
+      continue
+    elif [[ "$arg" == "--no-fetch="* ]]; then
+      fail 2 \
+        "Option --no-fetch doesn't take a value." \
+        "Drop the '=<value>' — --no-fetch is a boolean flag."
+    fi
+
     # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
     # value flag (no short form), captured here like --undo so it needs no getopts slot.
     if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -175,6 +175,18 @@ normalize-long-opts() {
         "Drop the '=<value>' — --branch is a boolean flag (did you mean --branch-prefix=?)."
     fi
 
+    # --allow-dirty — long-only boolean: skip the clean-working-tree preflight
+    # (R-SAFE-2). Sets the ALLOW_DIRTY config key directly, so the CLI wins
+    # over env / .ver-bumprc per R-CFG-3 (process-arguments runs last).
+    if [ "$arg" = "--allow-dirty" ]; then
+      ALLOW_DIRTY=true
+      continue
+    elif [[ "$arg" == "--allow-dirty="* ]]; then
+      fail 2 \
+        "Option --allow-dirty doesn't take a value." \
+        "Drop the '=<value>' — --allow-dirty is a boolean flag."
+    fi
+
     # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
     # value flag (no short form), captured here like --undo so it needs no getopts slot.
     if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -187,6 +187,19 @@ normalize-long-opts() {
         "Drop the '=<value>' — --allow-dirty is a boolean flag."
     fi
 
+    # --allow-empty — long-only boolean: force a release even when there are
+    # no new commits since the previous tag (R-SAFE-16). CLI-only — no env /
+    # .ver-bumprc contract (see the reset in process-arguments): a deliberate
+    # empty release must be an explicit per-invocation choice, like --yes.
+    if [ "$arg" = "--allow-empty" ]; then
+      ALLOW_EMPTY=true
+      continue
+    elif [[ "$arg" == "--allow-empty="* ]]; then
+      fail 2 \
+        "Option --allow-empty doesn't take a value." \
+        "Drop the '=<value>' — --allow-empty is a boolean flag."
+    fi
+
     # --no-fetch — long-only boolean: skip the remote-sync preflight
     # (R-SAFE-8). Sets the NO_FETCH config key directly, so the CLI wins
     # over env / .ver-bumprc per R-CFG-3 (process-arguments runs last).
@@ -303,13 +316,15 @@ normalize-long-opts() {
 process-arguments() {
   local OPTIONS OPTIND OPTARG
 
-  # DO_RELEASE and BUMP_LEVEL are CLI-only switches with no env / .ver-bumprc
-  # contract. Reset them before parsing so an inherited exported var — or a
-  # .ver-bumprc assignment (load-config sources the rc as raw shell) — can't
-  # silently force a bump or publish a release with no flag on the command line.
+  # DO_RELEASE, BUMP_LEVEL, and ALLOW_EMPTY are CLI-only switches with no
+  # env / .ver-bumprc contract. Reset them before parsing so an inherited
+  # exported var — or a .ver-bumprc assignment (load-config sources the rc as
+  # raw shell) — can't silently force a bump, publish a release, or push an
+  # empty release with no flag on the command line.
   DO_RELEASE=false
   DO_PR=false
   BUMP_LEVEL=
+  ALLOW_EMPTY=false
 
   normalize-long-opts "$@"
   set -- ${NORMALIZED_ARGV[@]+"${NORMALIZED_ARGV[@]}"}

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -150,7 +150,7 @@ _ver_bump() {
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
-          --allow-dirty \
+          --allow-dirty --no-fetch \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -190,6 +190,7 @@ _ver_bump() {
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
     '--release[publish a GitHub release for the new tag via gh]' \
     '--allow-dirty[skip the clean-working-tree preflight]' \
+    '--no-fetch[skip the remote-sync preflight]' \
     '--completions[emit completion script]:shell:(bash zsh fish)' \
     '--install-completions[install completion script for detected / specified shell]::shell:(bash zsh fish)' \
     '--about[print branded version info and exit]'
@@ -225,6 +226,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'
     complete -c $_cmd      -l release        -d 'Publish a GitHub release for the new tag via gh'
     complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'
+    complete -c $_cmd      -l no-fetch       -d 'Skip the remote-sync preflight'
     complete -c $_cmd      -l completions    -x -a 'bash zsh fish' -d 'Emit completion script'
     complete -c $_cmd      -l install-completions -a 'bash zsh fish' -d 'Install completions for detected/specified shell'
     complete -c $_cmd      -l about          -d 'Print branded version info and exit'

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -150,6 +150,7 @@ _ver_bump() {
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
+          --allow-dirty \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -188,6 +189,7 @@ _ver_bump() {
     '(--major --minor --patch -v --version)--minor[force a minor bump from the current version]' \
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
     '--release[publish a GitHub release for the new tag via gh]' \
+    '--allow-dirty[skip the clean-working-tree preflight]' \
     '--completions[emit completion script]:shell:(bash zsh fish)' \
     '--install-completions[install completion script for detected / specified shell]::shell:(bash zsh fish)' \
     '--about[print branded version info and exit]'
@@ -222,6 +224,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l minor          -d 'Force a minor bump from the current version'
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'
     complete -c $_cmd      -l release        -d 'Publish a GitHub release for the new tag via gh'
+    complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'
     complete -c $_cmd      -l completions    -x -a 'bash zsh fish' -d 'Emit completion script'
     complete -c $_cmd      -l install-completions -a 'bash zsh fish' -d 'Install completions for detected/specified shell'
     complete -c $_cmd      -l about          -d 'Print branded version info and exit'

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -150,7 +150,7 @@ _ver_bump() {
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
-          --allow-dirty --no-fetch \
+          --allow-dirty --allow-empty --no-fetch \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -190,6 +190,7 @@ _ver_bump() {
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
     '--release[publish a GitHub release for the new tag via gh]' \
     '--allow-dirty[skip the clean-working-tree preflight]' \
+    '--allow-empty[release even with no new commits since the previous tag]' \
     '--no-fetch[skip the remote-sync preflight]' \
     '--completions[emit completion script]:shell:(bash zsh fish)' \
     '--install-completions[install completion script for detected / specified shell]::shell:(bash zsh fish)' \
@@ -226,6 +227,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'
     complete -c $_cmd      -l release        -d 'Publish a GitHub release for the new tag via gh'
     complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'
+    complete -c $_cmd      -l allow-empty    -d 'Release even with no new commits since the previous tag'
     complete -c $_cmd      -l no-fetch       -d 'Skip the remote-sync preflight'
     complete -c $_cmd      -l completions    -x -a 'bash zsh fish' -d 'Emit completion script'
     complete -c $_cmd      -l install-completions -a 'bash zsh fish' -d 'Install completions for detected/specified shell'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -15,6 +15,7 @@ true
 # Supported keys (1:1 with existing globals):
 #   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX  CHANGELOG_STYLE
 #   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
+#   ALLOW_DIRTY (skip the clean-working-tree preflight, R-SAFE-2)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
@@ -24,7 +25,8 @@ true
 # Config-able keys, in a plain indexed array so bash 3.2 is happy.
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
-              FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE)
+              FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
+              ALLOW_DIRTY)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -116,8 +118,8 @@ load-config() {
 }
 
 # Apply built-in defaults for any config key still unset after load-config.
-# FLAG_* keys intentionally default to unset (false-equivalent under
-# [ "$FLAG_X" = true ]).
+# FLAG_* keys and the boolean safety keys (ALLOW_DIRTY) intentionally
+# default to unset (false-equivalent under [ "$KEY" = true ]).
 apply-config-defaults() {
   TAG_PREFIX="${TAG_PREFIX:-v}"
   REL_PREFIX="${REL_PREFIX:-release-}"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -16,6 +16,7 @@ true
 #   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX  CHANGELOG_STYLE
 #   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
 #   ALLOW_DIRTY (skip the clean-working-tree preflight, R-SAFE-2)
+#   NO_FETCH (skip the remote-sync preflight, R-SAFE-8)
 #   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
 #                     may be cut from; empty = no guard, R-SAFE-10)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
@@ -28,7 +29,7 @@ true
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
-              ALLOW_DIRTY RELEASE_BRANCHES)
+              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -120,8 +121,8 @@ load-config() {
 }
 
 # Apply built-in defaults for any config key still unset after load-config.
-# FLAG_* keys and the boolean safety keys (ALLOW_DIRTY) intentionally
-# default to unset (false-equivalent under [ "$KEY" = true ]);
+# FLAG_* keys and the boolean safety keys (ALLOW_DIRTY, NO_FETCH)
+# intentionally default to unset (false-equivalent under [ "$KEY" = true ]);
 # RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10).
 apply-config-defaults() {
   TAG_PREFIX="${TAG_PREFIX:-v}"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -16,6 +16,8 @@ true
 #   TAG_PREFIX  REL_PREFIX  PUSH_DEST  COMMIT_MSG_PREFIX  CHANGELOG_STYLE
 #   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
 #   ALLOW_DIRTY (skip the clean-working-tree preflight, R-SAFE-2)
+#   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
+#                     may be cut from; empty = no guard, R-SAFE-10)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
@@ -26,7 +28,7 @@ true
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
-              ALLOW_DIRTY)
+              ALLOW_DIRTY RELEASE_BRANCHES)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -119,7 +121,8 @@ load-config() {
 
 # Apply built-in defaults for any config key still unset after load-config.
 # FLAG_* keys and the boolean safety keys (ALLOW_DIRTY) intentionally
-# default to unset (false-equivalent under [ "$KEY" = true ]).
+# default to unset (false-equivalent under [ "$KEY" = true ]);
+# RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10).
 apply-config-defaults() {
   TAG_PREFIX="${TAG_PREFIX:-v}"
   REL_PREFIX="${REL_PREFIX:-release-}"

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -37,6 +37,41 @@ check-worktree-clean() {
     "Commit or stash them first, or pass --allow-dirty / set ALLOW_DIRTY=true to release anyway (untracked files are ignored)."
 }
 
+# Optional release-branch guard (R-SAFE-10..13). RELEASE_BRANCHES (config/env
+# key, no flag) is a space-separated glob list, e.g. "main develop release/*".
+# Unset/empty (the default) = no guard, zero behaviour change. When set, a
+# release from a non-matching branch — or from a detached HEAD — exits 3.
+# Deliberately NOT bypassed by --yes: this is a guard, not a prompt. The
+# one-shot bypass is an empty env override (RELEASE_BRANCHES= ver-bump …),
+# which beats the rc value per R-CFG-3. Release flow only: --undo,
+# --completions, --about, and --help all exit before the Verify section.
+check-release-branch() {
+  [ -n "${RELEASE_BRANCHES:-}" ] || return 0
+
+  local branch pat matched=false
+  branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    fail 3 \
+      "RELEASE_BRANCHES is set (${RELEASE_BRANCHES}) but HEAD is detached — a release must be cut from a named branch." \
+      "Checkout an allowed branch first, or clear the guard for one run: RELEASE_BRANCHES= ver-bump …"
+  fi
+
+  # Glob-match against each pattern. Word-splitting of the unquoted list and
+  # the unquoted case pattern are both intentional (space-separated globs).
+  # shellcheck disable=SC2254
+  for pat in $RELEASE_BRANCHES; do
+    case "$branch" in
+      $pat) matched=true; break ;;
+    esac
+  done
+
+  if [ "$matched" != true ]; then
+    fail 3 \
+      "Branch '${branch}' is not a release branch (RELEASE_BRANCHES: ${RELEASE_BRANCHES})." \
+      "Checkout an allowed branch, adjust RELEASE_BRANCHES in .ver-bumprc, or clear the guard for one run: RELEASE_BRANCHES= ver-bump …"
+  fi
+}
+
 # If there are no commits in repo, quit, because you can't tag with zero commits.
 check-commits-exist() {
   if ! git rev-parse HEAD &> /dev/null; then

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -72,6 +72,41 @@ check-release-branch() {
   fi
 }
 
+# Remote-sync preflight (R-SAFE-5..9). ver-bump otherwise never talks to the
+# remote before mutating: check-tag-exists consults local tags only, and a
+# stale local HEAD happily tags code that's already superseded on the remote.
+# Fetch (with tags) from the configured remote so (a) a behind-upstream HEAD
+# is refused here, and (b) check-tag-exists — which runs AFTER this in main()
+# — sees remote tags and catches collisions preflight instead of at push time.
+# Air-gapped use keeps working: no configured remote → silent skip; fetch
+# failure (offline, auth) → warn and continue. The fetch is read-only, so it
+# also runs under --dry-run (same reasoning as R-REL-5's notes command).
+# --no-fetch / NO_FETCH=true skips the whole preflight explicitly.
+check-remote-sync() {
+  [ "${NO_FETCH:-false}" = true ] && return 0
+
+  # PUSH_DEST may be a bare URL/path (e.g. -p /tmp/remote.git) rather than a
+  # configured remote — nothing to fetch state for, so skip silently.
+  git remote get-url "$PUSH_DEST" >/dev/null 2>&1 || return 0
+
+  if ! git fetch "$PUSH_DEST" --tags --quiet 2>/dev/null; then
+    log_warn "Could not fetch from <${S_VAL}${PUSH_DEST}${RESET-}> — continuing with local refs only."
+    return 0
+  fi
+
+  # Behind-upstream check: only meaningful when the current branch has an
+  # upstream configured. rev-list HEAD..@{upstream} counts commits the
+  # upstream has that we don't — anything > 0 means we'd tag a stale HEAD.
+  local upstream behind
+  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || return 0
+  behind=$(git rev-list --count 'HEAD..@{upstream}' 2>/dev/null) || return 0
+  if [ "${behind:-0}" -gt 0 ]; then
+    fail 3 \
+      "Current branch is ${behind} commit(s) behind ${upstream} — releasing now would tag a stale HEAD." \
+      "Run 'git pull --rebase' first, or pass --no-fetch / set NO_FETCH=true to skip the remote-sync preflight."
+  fi
+}
+
 # If there are no commits in repo, quit, because you can't tag with zero commits.
 check-commits-exist() {
   if ! git rev-parse HEAD &> /dev/null; then

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -3,6 +3,40 @@
 # shellcheck disable=SC2288
 true
 
+# Refuse to release from a dirty working tree (R-SAFE-1..4). do-commit runs a
+# bare `git commit -m …`, so anything staged before ver-bump ran — and any
+# modified tracked file `git add`-ed along the way — would be silently swept
+# into the release commit. Untracked files are ignored (same contract as
+# --undo's dirty check). Skipped under -n/--no-commit (nothing is committed,
+# nothing can be swept) and under --allow-dirty / ALLOW_DIRTY=true. The check
+# still runs under --dry-run (read-only) so the preview is honest about what
+# a real run would do.
+check-worktree-clean() {
+  [ "${FLAG_NOCOMMIT:-false}" = true ] && return 0
+  [ "${ALLOW_DIRTY:-false}" = true ] && return 0
+
+  local dirty count preview line
+  dirty=$(git status --porcelain --untracked-files=no 2>/dev/null)
+  [ -z "$dirty" ] && return 0
+
+  # Name the first few offending paths (+ total), so the error is actionable
+  # without the user re-running git status themselves. Porcelain lines are
+  # "XY <path>" — strip the two status columns and the separator space.
+  count=$(printf '%s\n' "$dirty" | grep -c .)
+  preview=""
+  local shown=0
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    (( shown >= 3 )) && { preview+=", …"; break; }
+    preview+="${preview:+, }${line:3}"
+    shown=$((shown + 1))
+  done <<< "$dirty"
+
+  fail 3 \
+    "Working tree has uncommitted changes to tracked files (${count}): ${preview}" \
+    "Commit or stash them first, or pass --allow-dirty / set ALLOW_DIRTY=true to release anyway (untracked files are ignored)."
+}
+
 # If there are no commits in repo, quit, because you can't tag with zero commits.
 check-commits-exist() {
   if ! git rev-parse HEAD &> /dev/null; then

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -116,6 +116,36 @@ check-commits-exist() {
   fi
 }
 
+# Nothing-to-release no-op (R-SAFE-14..18). When the previous version's tag
+# exists and HEAD has no commits since it, cutting a release would produce an
+# empty one — patch+1 with an empty changelog range. Print a notice and exit 0
+# instead: a clean no-op is success (semantic-release semantics), which makes
+# the release step safe to run unconditionally in CI. The notice includes a
+# stable stdout line beginning `no-release` so scripts can branch on outcome
+# without parsing prose. Applies even with -v/--major/--minor/--patch — an
+# explicit version is not evidence you meant to release zero commits;
+# --allow-empty is the explicit signal (deliberate re-tags / empty releases).
+# Must run AFTER process-version (needs V_PREV read from VER_FILE). No
+# previous matching tag (first release) → proceeds as today (R-BUMP-3).
+check-releasable-commits() {
+  [ "${ALLOW_EMPTY:-false}" = true ] && return 0
+  # With -v and no readable VER_FILE, V_PREV may be empty — no previous tag
+  # can be derived, so there is nothing to compare against.
+  [ -n "${V_PREV:-}" ] || return 0
+
+  local prev_tag count
+  prev_tag="${TAG_PREFIX}${V_PREV}"
+  git rev-parse --verify --quiet "refs/tags/${prev_tag}" >/dev/null || return 0
+
+  count=$(git rev-list --count "${prev_tag}..HEAD" 2>/dev/null) || return 0
+  [ "${count:-1}" -gt 0 ] && return 0
+
+  log_info "Nothing to release — no new commits since ${S_VAL}${prev_tag}${RESET-}."
+  # Stable, greppable outcome token (R-SAFE-15): line begins `no-release`.
+  printf 'no-release: no commits since %s\n' "${prev_tag}"
+  exit 0
+}
+
 #
 check-branch-notexist() {
   [ "$FLAG_BRANCH" = true ] || return 0

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -124,6 +124,7 @@ usage() {
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
   print-opt-row ""   "--patch"              ""            "Force a patch bump from the current version (mutually exclusive)."
   print-opt-row ""   "--allow-dirty"        ""            "Skip the clean-working-tree check (untracked files never trigger it)."
+  print-opt-row ""   "--no-fetch"           ""            "Skip the remote-sync preflight (no fetch / behind-upstream check)."
   print-opt-row ""   "--branch"             ""            "Cut a release-x.x.x branch (pre-2.0 default); otherwise tag in place."
   print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (GitHub-only; implies push to origin)."
   print-opt-row ""   "--base"               "<branch>"    "Base branch for --pr (GitHub-only; default: the branch you ran ver-bump from)."

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -123,6 +123,7 @@ usage() {
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
   print-opt-row ""   "--patch"              ""            "Force a patch bump from the current version (mutually exclusive)."
+  print-opt-row ""   "--allow-dirty"        ""            "Skip the clean-working-tree check (untracked files never trigger it)."
   print-opt-row ""   "--branch"             ""            "Cut a release-x.x.x branch (pre-2.0 default); otherwise tag in place."
   print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (GitHub-only; implies push to origin)."
   print-opt-row ""   "--base"               "<branch>"    "Base branch for --pr (GitHub-only; default: the branch you ran ver-bump from)."

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -124,6 +124,7 @@ usage() {
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
   print-opt-row ""   "--patch"              ""            "Force a patch bump from the current version (mutually exclusive)."
   print-opt-row ""   "--allow-dirty"        ""            "Skip the clean-working-tree check (untracked files never trigger it)."
+  print-opt-row ""   "--allow-empty"        ""            "Release even with no new commits since the previous tag."
   print-opt-row ""   "--no-fetch"           ""            "Skip the remote-sync preflight (no fetch / behind-upstream check)."
   print-opt-row ""   "--branch"             ""            "Cut a release-x.x.x branch (pre-2.0 default); otherwise tag in place."
   print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (GitHub-only; implies push to origin)."

--- a/test/args.bats
+++ b/test/args.bats
@@ -107,6 +107,26 @@ load 'test_helper'
   assert_output --partial "Option --allow-dirty doesn't take a value"
 }
 
+@test "long options: --allow-empty sets ALLOW_EMPTY" {
+  source ${profile_script}
+  process-arguments --allow-empty
+  assert_equal "${ALLOW_EMPTY}" "true"
+}
+
+@test "long options: --allow-empty=value is rejected" {
+  source ${profile_script}
+  run process-arguments --allow-empty=yes
+  assert_failure 2
+  assert_output --partial "Option --allow-empty doesn't take a value"
+}
+
+@test "process-arguments: resets a stale ALLOW_EMPTY from the environment" {
+  source ${profile_script}
+  ALLOW_EMPTY=true
+  process-arguments -d
+  assert_equal "${ALLOW_EMPTY}" "false"
+}
+
 @test "long options: --no-fetch sets NO_FETCH" {
   source ${profile_script}
   process-arguments --no-fetch

--- a/test/args.bats
+++ b/test/args.bats
@@ -94,6 +94,19 @@ load 'test_helper'
   assert_equal "${FLAG_BRANCH}" "true"
 }
 
+@test "long options: --allow-dirty sets ALLOW_DIRTY" {
+  source ${profile_script}
+  process-arguments --allow-dirty
+  assert_equal "${ALLOW_DIRTY}" "true"
+}
+
+@test "long options: --allow-dirty=value is rejected" {
+  source ${profile_script}
+  run process-arguments --allow-dirty=yes
+  assert_failure 2
+  assert_output --partial "Option --allow-dirty doesn't take a value"
+}
+
 @test "long options: --pr implies branch + push and sets DO_PR" {
   source ${profile_script}
   process-arguments --pr

--- a/test/args.bats
+++ b/test/args.bats
@@ -107,6 +107,19 @@ load 'test_helper'
   assert_output --partial "Option --allow-dirty doesn't take a value"
 }
 
+@test "long options: --no-fetch sets NO_FETCH" {
+  source ${profile_script}
+  process-arguments --no-fetch
+  assert_equal "${NO_FETCH}" "true"
+}
+
+@test "long options: --no-fetch=value is rejected" {
+  source ${profile_script}
+  run process-arguments --no-fetch=yes
+  assert_failure 2
+  assert_output --partial "Option --no-fetch doesn't take a value"
+}
+
 @test "long options: --pr implies branch + push and sets DO_PR" {
   source ${profile_script}
   process-arguments --pr

--- a/test/no-release.bats
+++ b/test/no-release.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+
+# check-releasable-commits (R-SAFE-14..18, issue #60): when the previous
+# version's tag exists and HEAD has no commits since it, ver-bump prints a
+# notice with a stable `no-release` stdout token and exits 0 without mutating
+# anything — the semantic-release-style idempotent no-op that makes a release
+# step safe to run unconditionally in CI. --allow-empty forces the old
+# behaviour for deliberate empty releases / re-tags.
+
+load 'test_helper'
+
+# Scratch repo where package.json's version is already tagged at HEAD:
+# zero commits since the previous tag.
+released_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: bumped to 1.2.3"
+  git tag -a v1.2.3 -m "v1.2.3"
+}
+
+@test "no-release: zero commits since tag -> exit 0, token, no mutation (R-SAFE-14/15)" {
+  released_repo
+
+  run ${profile_script} -v 1.2.4 -y
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Nothing to release"
+  # Stable greppable token: a line beginning `no-release`.
+  run bash -c '"$1" -v 1.2.4 -y | grep -c "^no-release"' _ "${profile_script}"
+  assert_output "1"
+
+  # Nothing was created or modified.
+  run git tag -l
+  assert_output "v1.2.3"
+  run jq -r '.version' package.json
+  assert_output "1.2.3"
+  assert_equal "$(git rev-list --count HEAD)" "2"
+}
+
+@test "no-release: token goes to stdout so CI can branch on it (R-SAFE-15)" {
+  released_repo
+
+  run bash -c '"$1" -v 1.2.4 -y >"$2/out" 2>"$2/err"' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep '^no-release' "$BATS_TEST_TMPDIR/out"
+  assert_success
+  assert_output --partial "v1.2.3"
+}
+
+@test "no-release: one commit since the tag -> proceeds" {
+  released_repo
+  git commit -q --allow-empty -m "fix: something new"
+
+  run ${profile_script} -d -b -c -p origin -v 1.2.4
+  assert_success
+  strip_ansi_output
+  refute_output --partial "no-release"
+  assert_output --partial "[dry-run]"
+}
+
+@test "no-release: no previous tag at all -> proceeds (first release, R-SAFE-18)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+
+  run ${profile_script} -d -b -c -p origin -v 1.2.4
+  assert_success
+  strip_ansi_output
+  refute_output --partial "no-release"
+}
+
+@test "no-release: --allow-empty forces the empty release (R-SAFE-16)" {
+  released_repo
+
+  run ${profile_script} -c -v 1.2.4 --allow-empty -n
+  assert_success
+  strip_ansi_output
+  refute_output --partial "no-release"
+  # The bump really happened (files written; -n skips commit/tag/push).
+  run jq -r '.version' package.json
+  assert_output "1.2.4"
+}
+
+@test "no-release: applies to --patch as well as -v (R-SAFE-17)" {
+  released_repo
+
+  run ${profile_script} --patch -y
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Nothing to release"
+  run git tag -l
+  assert_output "v1.2.3"
+}
+
+@test "no-release: applies to the interactive suggestion path too" {
+  released_repo
+
+  # Accept the suggested version with a bare <enter>; the no-op check fires
+  # right after process-version resolves it.
+  run bash -c 'printf "\n" | "$1"' _ "${profile_script}"
+  assert_success
+  strip_ansi_output
+  assert_output --partial "no-release"
+  run git tag -l
+  assert_output "v1.2.3"
+}
+
+@test "no-release: custom tag prefix is honoured when finding the previous tag" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: bumped to 1.2.3"
+  git tag -a rel/1.2.3 -m "rel/1.2.3"
+
+  run ${profile_script} -t rel/ -v 1.2.4 -y
+  assert_success
+  strip_ansi_output
+  assert_output --partial "no-release"
+  assert_output --partial "rel/1.2.3"
+}
+
+@test "no-release: env ALLOW_EMPTY cannot force an empty release (CLI-only reset)" {
+  released_repo
+
+  ALLOW_EMPTY=true run ${profile_script} -v 1.2.4 -y
+  assert_success
+  strip_ansi_output
+  # The env var is reset in process-arguments — the run is still a no-op.
+  assert_output --partial "no-release"
+  run git tag -l
+  assert_output "v1.2.3"
+}
+
+@test "no-release: completions list --allow-empty in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--allow-empty"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--allow-empty"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l allow-empty"
+}

--- a/test/release-branch-guard.bats
+++ b/test/release-branch-guard.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+# check-release-branch (R-SAFE-10..13, issue #59): opt-in RELEASE_BRANCHES
+# config/env key — a space-separated glob allowlist of branches a release may
+# be cut from. Unset (the default) keeps 2.0 behaviour: release from anywhere.
+# The guard is not a prompt, so --yes never bypasses it; the one-shot bypass
+# is an empty env override (env beats rc per R-CFG-3).
+
+load 'test_helper'
+
+# Seed a scratch repo with a committed package.json and cd into it.
+guard_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+}
+
+@test "branch-guard: unset RELEASE_BRANCHES releases from any branch (regression pin)" {
+  guard_repo
+  git checkout -qb feature-anything
+
+  unset RELEASE_BRANCHES
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "branch-guard: exact match proceeds" {
+  guard_repo
+  # Pin to the repo's actual default branch name (git init -b main has a
+  # fallback path in scratch_repo for older gits).
+  local cur
+  cur=$(git symbolic-ref --short HEAD)
+
+  RELEASE_BRANCHES="${cur} develop" run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "branch-guard: glob match (release/*) proceeds" {
+  guard_repo
+  git checkout -qb release/2026-Q3
+
+  RELEASE_BRANCHES="main release/*" run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "branch-guard: non-matching branch -> 3, names branch + allowed list" {
+  guard_repo
+  git checkout -qb feature-x
+
+  RELEASE_BRANCHES="main develop" run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "Branch 'feature-x' is not a release branch"
+  assert_output --partial "main develop"
+  assert_output --partial "Hint:"
+}
+
+@test "branch-guard: detached HEAD with guard active -> 3 (R-SAFE-12)" {
+  guard_repo
+  git checkout -q --detach
+
+  RELEASE_BRANCHES="main" run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "HEAD is detached"
+}
+
+@test "branch-guard: --yes does not bypass the guard (R-SAFE-11)" {
+  guard_repo
+  git checkout -qb feature-x
+
+  RELEASE_BRANCHES="main" run ${profile_script} -d -b -c -p origin -v 1.0.1 --yes
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "is not a release branch"
+}
+
+@test "branch-guard: RELEASE_BRANCHES from .ver-bumprc guards the run" {
+  guard_repo
+  git checkout -qb feature-x
+  printf 'RELEASE_BRANCHES="main develop"\n' > .ver-bumprc
+
+  unset RELEASE_BRANCHES
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "is not a release branch"
+}
+
+@test "branch-guard: empty env override beats the rc value (one-shot bypass)" {
+  guard_repo
+  git checkout -qb feature-x
+  printf 'RELEASE_BRANCHES="main develop"\n' > .ver-bumprc
+
+  RELEASE_BRANCHES="" run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "branch-guard: --undo is unaffected by the guard (R-SAFE-13)" {
+  guard_repo
+  # Fabricate the artefacts of a prior run: release branch + bump commit + tag.
+  git checkout -qb feat/x
+  git checkout -qb release-1.2.0
+  printf '{ "version": "1.2.0" }\n' > package.json
+  git commit -qam "chore: bumped 1.0.0 -> 1.2.0"
+  git tag -a v1.2.0 -m "v1.2.0"
+
+  # Current branch release-1.2.0 does NOT match the allowlist — undo must
+  # still run (the guard applies to the release flow only).
+  RELEASE_BRANCHES="main" run ${profile_script} --undo 1.2.0 --dry-run
+  assert_success
+  assert_output --partial "git tag -d v1.2.0"
+}
+
+@test "branch-guard: --about and --help are unaffected by the guard (R-SAFE-13)" {
+  guard_repo
+  git checkout -qb feature-x
+
+  RELEASE_BRANCHES="main" run ${profile_script} --about
+  assert_success
+  RELEASE_BRANCHES="main" run ${profile_script} --help
+  assert_success
+}
+
+@test "branch-guard: unit — guard runs before the version prompt (no mutation)" {
+  guard_repo
+  git checkout -qb feature-x
+
+  # Live run (no -d): must fail before prompting for a version or touching
+  # any file — stdin is closed, so reaching the prompt would hang/EOF-differ.
+  RELEASE_BRANCHES="main" run ${profile_script} -c -v 1.0.1
+  assert_failure 3
+  run jq -r '.version' package.json
+  assert_output "1.0.0"
+  run git tag -l
+  assert_output ""
+}

--- a/test/remote-sync.bats
+++ b/test/remote-sync.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+
+# check-remote-sync (R-SAFE-5..9, issue #58): fetch (with tags) from the
+# configured PUSH_DEST remote during Verify, refuse a behind-upstream HEAD,
+# and — because the fetch runs BEFORE check-tag-exists — surface remote-only
+# tag collisions preflight instead of at push time. All remotes in these
+# tests are local bare repos, so fetch failures are instant and no network
+# is touched.
+
+load 'test_helper'
+
+# Scratch repo with a committed package.json, a local bare "origin" remote,
+# and the current branch pushed with upstream tracking configured.
+synced_repo() {
+  local repo remote
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+
+  remote=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${remote}")
+  git init -q --bare "$remote"
+  git remote add origin "$remote"
+  git push -qu origin "$(git symbolic-ref --short HEAD)" 2>/dev/null
+}
+
+@test "remote-sync: tag existing only on the remote -> 3 before any file writes (R-SAFE-7)" {
+  synced_repo
+  # Put v1.0.1 on the remote but not locally.
+  git tag v1.0.1
+  git push -q origin v1.0.1
+  git tag -d v1.0.1 >/dev/null
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "A release with that tag"
+  # Nothing was previewed/mutated after the failure.
+  refute_output --partial "[dry-run] would"
+}
+
+@test "remote-sync: branch behind upstream -> 3 (R-SAFE-6)" {
+  synced_repo
+  git commit -q --allow-empty -m "feat: newer work"
+  git push -q origin HEAD
+  git reset -q --hard HEAD~1   # local is now 1 behind origin
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "behind"
+  assert_output --partial "git pull --rebase"
+}
+
+@test "remote-sync: no remote configured -> proceeds silently, no fetch attempted" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+  strip_ansi_output
+  refute_output --partial "Could not fetch"
+}
+
+@test "remote-sync: unreachable remote URL -> warning, run proceeds (R-SAFE-5)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+  git remote add origin /nonexistent/ver-bump-remote.git
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Could not fetch"
+}
+
+@test "remote-sync: --no-fetch skips the preflight — remote-only collision undetected (R-SAFE-8)" {
+  synced_repo
+  git tag v1.0.1
+  git push -q origin v1.0.1
+  git tag -d v1.0.1 >/dev/null
+
+  # Documented tradeoff: with --no-fetch the remote-only tag is invisible to
+  # the preflight, so the dry-run pipeline sails through.
+  run ${profile_script} -d -b -c -p origin -v 1.0.1 --no-fetch
+  assert_success
+}
+
+@test "remote-sync: --no-fetch live run still fails safely at push time" {
+  synced_repo
+  git tag v1.0.1
+  git push -q origin v1.0.1
+  git tag -d v1.0.1 >/dev/null
+
+  # Live run: the collision only surfaces at the push, which stays
+  # best-effort (warn, not abort) — the documented pre-#58 behaviour.
+  run ${profile_script} -c -p origin -v 1.0.1 --no-fetch
+  strip_ansi_output
+  assert_output --partial "Push failed"
+}
+
+@test "remote-sync: NO_FETCH=true in .ver-bumprc skips the preflight" {
+  synced_repo
+  printf 'NO_FETCH=true\n' > .ver-bumprc
+  git tag v1.0.1
+  git push -q origin v1.0.1
+  git tag -d v1.0.1 >/dev/null
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "remote-sync: behind-upstream check passes when in sync" {
+  synced_repo
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "remote-sync: fetch runs under --dry-run and makes remote tags visible (R-SAFE-9)" {
+  synced_repo
+  git tag v9.9.9
+  git push -q origin v9.9.9
+  git tag -d v9.9.9 >/dev/null
+
+  # The dry-run fetch is read-only but real: after the failed preflight the
+  # remote tag now exists locally (proof the fetch actually ran).
+  run ${profile_script} -d -b -c -p origin -v 9.9.9
+  assert_failure 3
+  run git tag -l v9.9.9
+  assert_output "v9.9.9"
+}
+
+@test "remote-sync: unit — no upstream configured skips the behind check" {
+  source ${profile_script}
+  synced_repo
+  git checkout -qb no-upstream-branch
+
+  PUSH_DEST=origin run check-remote-sync
+  assert_success
+}
+
+@test "remote-sync: completions list --no-fetch in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--no-fetch"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--no-fetch"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l no-fetch"
+}

--- a/test/worktree-clean.bats
+++ b/test/worktree-clean.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+
+# check-worktree-clean (R-SAFE-1..4, issue #57): refuse to release with
+# modified tracked files or a non-empty index — a bare `git commit` in
+# do-commit would silently sweep them into the release commit. Untracked
+# files are ignored; --allow-dirty / ALLOW_DIRTY bypass; -n/--no-commit
+# skips the guard; --dry-run still enforces it.
+
+load 'test_helper'
+
+# Seed a scratch repo with a committed package.json and cd into it.
+clean_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+}
+
+@test "worktree-clean: modified tracked file -> 3, names the file, tree untouched" {
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  run ${profile_script} -c -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "uncommitted changes to tracked files"
+  assert_output --partial "package.json"
+  assert_output --partial "Hint:"
+
+  # No mutation happened: content untouched, no tag, no extra commit.
+  run jq -r '.version' package.json
+  assert_output "1.0.0"
+  run git tag -l
+  assert_output ""
+  assert_equal "$(git rev-list --count HEAD)" "2"
+}
+
+@test "worktree-clean: pre-staged unrelated file -> 3" {
+  clean_repo
+  echo "unrelated" > extra.txt
+  git add extra.txt
+
+  run ${profile_script} -c -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "extra.txt"
+}
+
+@test "worktree-clean: untracked files alone do not trigger the guard" {
+  clean_repo
+  echo "stray" > stray.txt
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "worktree-clean: --allow-dirty bypasses the guard" {
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1 --allow-dirty
+  assert_success
+}
+
+@test "worktree-clean: ALLOW_DIRTY=true in .ver-bumprc bypasses the guard" {
+  clean_repo
+  printf 'ALLOW_DIRTY=true\n' > .ver-bumprc
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_success
+}
+
+@test "worktree-clean: env ALLOW_DIRTY=false beats an rc true (R-CFG-3)" {
+  clean_repo
+  printf 'ALLOW_DIRTY=true\n' > .ver-bumprc
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  ALLOW_DIRTY=false run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "uncommitted changes to tracked files"
+}
+
+@test "worktree-clean: CLI --allow-dirty beats env ALLOW_DIRTY=false (R-CFG-3)" {
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  ALLOW_DIRTY=false run ${profile_script} -d -b -c -p origin -v 1.0.1 --allow-dirty
+  assert_success
+}
+
+@test "worktree-clean: -n / --no-commit skips the guard (R-SAFE-4)" {
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  run ${profile_script} -n -c -v 1.0.1
+  assert_success
+  # The bump itself still ran — only the commit (and the guard) were skipped.
+  run jq -r '.version' package.json
+  assert_output "1.0.1"
+}
+
+@test "worktree-clean: --dry-run still enforces the guard (R-SAFE-3)" {
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "uncommitted changes to tracked files"
+  # The failure fires before any previewed side-effect.
+  refute_output --partial "[dry-run] would"
+  refute_output --partial "[dry-run] git add"
+}
+
+@test "worktree-clean: unit — FLAG_NOCOMMIT=true returns success on a dirty tree" {
+  source ${profile_script}
+  clean_repo
+  printf '{ "version": "1.0.0", "name": "wip" }\n' > package.json
+
+  FLAG_NOCOMMIT=true run check-worktree-clean
+  assert_success
+}
+
+@test "worktree-clean: unit — reports the offending-path count" {
+  source ${profile_script}
+  clean_repo
+  printf 'a\n' > a.txt; printf 'b\n' > b.txt
+  git add a.txt b.txt && git commit -qm "chore: seed a b"
+  printf 'a2\n' > a.txt; printf 'b2\n' > b.txt
+
+  run check-worktree-clean
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "(2)"
+  assert_output --partial "a.txt"
+  assert_output --partial "b.txt"
+}
+
+@test "worktree-clean: completions list --allow-dirty in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--allow-dirty"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--allow-dirty"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l allow-dirty"
+}

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -82,6 +82,7 @@ main() {
   check-release-branch
   check-remote-sync # must precede check-tag-exists so remote tags are visible
   process-version
+  check-releasable-commits # needs V_PREV + TAG_PREFIX, so after process-version
   check-branch-notexist
   check-tag-exists
   check-pr-deps

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -80,6 +80,7 @@ main() {
   check-commits-exist
   check-worktree-clean
   check-release-branch
+  check-remote-sync # must precede check-tag-exists so remote tags are visible
   process-version
   check-branch-notexist
   check-tag-exists

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -78,6 +78,7 @@ main() {
 
   section "Verify"
   check-commits-exist
+  check-worktree-clean
   process-version
   check-branch-notexist
   check-tag-exists

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -79,6 +79,7 @@ main() {
   section "Verify"
   check-commits-exist
   check-worktree-clean
+  check-release-branch
   process-version
   check-branch-notexist
   check-tag-exists


### PR DESCRIPTION
Implements the Tier-1 safety-preflight set from the 2026-07-15 feature review as four preflight guards in `main()`'s Verify section, one commit per issue. Every guard fails via `fail 3` (precondition) before any mutation; the frozen 2.x exit contract (R-EXIT-2) is untouched. The full R-SAFE-1..18 table with test mapping lives in `docs/features/safety-preflights/requirements.md`.

Refs #57. Refs #58. Refs #59. Refs #60.

## #57 — dirty-working-tree guard (commit 1)

`check-worktree-clean`: a non-empty `git status --porcelain --untracked-files=no` (modified tracked files or a non-empty index) exits 3 before any mutation, naming the first few offending paths + count. Previously `do-commit`'s bare `git commit -m` silently swept pre-staged work into the release commit. Untracked files are ignored (same contract as `--undo`'s existing dirty check). Bypass: `--allow-dirty` flag or `ALLOW_DIRTY` config/env key (new `_CONFIG_KEYS` member — CLI > env > rc > default holds, pinned by tests in both directions). Skipped under `-n/--no-commit`; still enforced under `--dry-run` so the preview is honest.

## #59 — release-branch guard (commit 2)

`check-release-branch`: opt-in `RELEASE_BRANCHES` config/env key, a space-separated glob allowlist (`"main develop release/*"`), matched with a pure-bash `case` loop. Unset/empty (default) = no guard — regression-pinned. Non-matching branch or detached HEAD exits 3 naming the branch and the allowed list. Deliberately **not** bypassed by `--yes` (guard, not prompt); the one-shot bypass is `RELEASE_BRANCHES= ver-bump …` (env beats rc, R-CFG-3). Release flow only — `--undo`, `--completions`, `--about`, `--help` exit before Verify (pinned by tests). No new flag.

## #58 — remote-sync preflight (commit 3)

`check-remote-sync`: when the configured remote (`PUSH_DEST`, default `origin`) exists, run `git fetch <remote> --tags --quiet`, then refuse a behind-upstream HEAD (`git rev-list --count HEAD..@{upstream}` > 0) with exit 3. Air-gapped-safe: no configured remote (including `-p <url/path>`) → silent skip; fetch failure → warn and continue. The fetch runs **before** `check-tag-exists`, so remote-only tag collisions are caught preflight by the existing local check instead of at push time. The fetch is read-only w.r.t. release artefacts and intentionally runs under `--dry-run` (R-SAFE-9 — it does update local remote-tracking refs/tags; same reasoning as R-REL-5's read-only notes command). Skip: `--no-fetch` flag or `NO_FETCH` config/env key. Tests use local bare-repo remotes only — no network.

## #60 — nothing-to-release no-op (commit 4)

`check-releasable-commits`: when the previous tag `${TAG_PREFIX}${V_PREV}` exists and `git rev-list --count tag..HEAD` is 0, print a notice and exit 0 with no mutation — the idempotent no-op that makes a CI release step safe to run unconditionally. Stable outcome token: a stdout line beginning `no-release`. Applies even with `-v`/`--major`/`--minor`/`--patch` (an explicit version is not evidence you meant to release zero commits — R-SAFE-17 design call as specced; flag in review if `-v` should imply intent). `--allow-empty` forces the old behaviour; it is CLI-only and reset in `process-arguments` alongside `DO_RELEASE`/`BUMP_LEVEL` (R-CFG-6 pattern), so env/rc can never force an empty release. First release (no matching tag) unaffected.

## Final Verify-section ordering

```text
check-commits-exist
check-worktree-clean        # 57 — fail fast, before any prompt
check-release-branch        # 59 — wrong branch is unfixable by later steps
check-remote-sync           # 58 — fetch BEFORE check-tag-exists (R-SAFE-7)
process-version
check-releasable-commits    # 60 — needs V_PREV + TAG_PREFIX resolved
check-branch-notexist
check-tag-exists            # now sees remote tags thanks to the fetch
check-pr-deps
```

Exactly the ordering proposed in the issues; the existing code did not argue otherwise. One consequence worth noting: in fully-interactive runs the version prompt (inside `process-version`) is answered before the no-op notice prints, because `V_PREV` is only resolved there — pinned by a test.

## R-SAFE coverage

| ID | Requirement (short) | Test(s) |
| --- | --- | --- |
| R-SAFE-1 | dirty tracked/index → 3 before mutation, paths named | `worktree-clean.bats` 1, 2, 11 |
| R-SAFE-2 | `--allow-dirty` / `ALLOW_DIRTY` bypass, R-CFG-3 precedence | `worktree-clean.bats` 4–7; `args.bats` |
| R-SAFE-3 | check still enforced under `--dry-run` | `worktree-clean.bats` 9 |
| R-SAFE-4 | skipped under `-n/--no-commit` | `worktree-clean.bats` 8, 10 |
| R-SAFE-5 | fetch when remote exists; fetch failure → warn + continue | `remote-sync.bats` 3, 4 |
| R-SAFE-6 | behind upstream → 3 with pull-rebase hint | `remote-sync.bats` 2, 8 |
| R-SAFE-7 | `check-tag-exists` after fetch → remote-only collision caught | `remote-sync.bats` 1 |
| R-SAFE-8 | `--no-fetch` / `NO_FETCH` skip | `remote-sync.bats` 5–7; `args.bats` |
| R-SAFE-9 | fetch runs under `--dry-run` (read-only) | `remote-sync.bats` 9 |
| R-SAFE-10 | `RELEASE_BRANCHES` glob list; unset = no guard (pinned) | `release-branch-guard.bats` 1–3, 7 |
| R-SAFE-11 | no match → 3 naming branch + list; not bypassed by `--yes`; empty-env bypass | `release-branch-guard.bats` 4, 6, 8 |
| R-SAFE-12 | detached HEAD with guard → 3 | `release-branch-guard.bats` 5 |
| R-SAFE-13 | release flow only (`--undo`/`--about`/`--help` unaffected) | `release-branch-guard.bats` 9, 10 |
| R-SAFE-14 | zero commits since tag → notice + exit 0, no mutation | `no-release.bats` 1, 2 |
| R-SAFE-15 | stable stdout token, line begins `no-release` | `no-release.bats` 1, 2 |
| R-SAFE-16 | `--allow-empty` forces old behaviour (CLI-only, env reset) | `no-release.bats` 5, 9; `args.bats` |
| R-SAFE-17 | applies with `-v` / `--patch` etc. | `no-release.bats` 1, 6 |
| R-SAFE-18 | first release (no previous tag) unaffected | `no-release.bats` 4 |

## Existing tests

**No existing test was modified or weakened.** All prior full-pipeline tests either commit their fixtures (clean tree) or use untracked `package.json` scratch files (ignored by the dirty check), run in repos with no configured remote (remote-sync skips silently), and never have the previous version's tag present with zero commits since — so all 237 pre-existing tests pass unchanged. `args.bats` only gained new cases (7).

## Test plan

- `pnpm lint` (shellcheck -x): zero warnings.
- `pnpm tests:run`: 0 failures, each commit leaves the suite green. At the original branch point (develop = 237 tests) the per-commit progression was 237 → 251 → 262 → 275 → 288:
  - #57: +12 `worktree-clean.bats`, +2 `args.bats`
  - #59: +11 `release-branch-guard.bats`
  - #58: +11 `remote-sync.bats`, +2 `args.bats`
  - #60: +10 `no-release.bats`, +3 `args.bats`
- The branch was then rebased onto current develop (over #74 json formatting, #75 grouped changelog, #76 curl installer — conflicts were the R-CFG-2 key-list rows and `_CONFIG_KEYS`, resolved as the union with `CHANGELOG_STYLE`). Final suite on the rebased branch: **347/347** across 29 files (develop alone: 296; this PR adds 51).
- Help/README flag parity (AC-7) and completion-emitter syntax checks (R-COMP-1/2) covered by the existing suite plus per-flag completion assertions in each new bats file.
