### PR TITLE
feat(git): opt-in signed release tags (--sign / TAG_SIGN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `ALLOW_DIRTY` | `--allow-dirty` | *unset* (dirty tree refuses) |
 | `NO_FETCH` | `--no-fetch` | *unset* (fetch + behind-upstream check) |
 | `RELEASE_BRANCHES` | *(no flag)* | *unset* (release from any branch) |
+| `TAG_SIGN` | `--sign` | `false` (annotated, unsigned tag) |
 
 Example:
 
@@ -409,6 +410,11 @@ output stays byte-identical to previous releases.
                               (GitHub-only, requires `gh` and -p / --push <remote>).
                               Notes are read from $VER_BUMP_RELEASE_NOTES_CMD (default
                               `npx jv-k/releasetool`).
+    --sign                    Create a signed tag (git tag -s) instead of an annotated
+                              one. The signing key and program come from your git
+                              config (user.signingkey, gpg.format) — ver-bump does no
+                              key management. Also available as the TAG_SIGN
+                              config/env key.
     --about                   Print name, version, author, and homepage; then exit.
     --completions <shell>     Emit completion script for bash, zsh, or fish to stdout.
     --install-completions [=<shell>]

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,6 +19,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [completions](./completions/requirements.md) | R-COMP | `args.bats`, `completions-syntax.bats`, `install-completions.bats` |
 | [changelog](./changelog/requirements.md) | R-LOG | `changelog.bats` |
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
+| [signed-tags](./signed-tags/requirements.md) | R-SIGN | `signed-tags.bats`, `args.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
 | [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats` |

--- a/docs/features/signed-tags/requirements.md
+++ b/docs/features/signed-tags/requirements.md
@@ -1,0 +1,22 @@
+# Signed tags (--sign / TAG_SIGN)
+
+Opt-in signed release tags for provenance-conscious teams
+([#68](https://github.com/jv-k/ver-bump/issues/68)): `--sign` (or
+`TAG_SIGN=true`) switches `do-tag` from `git tag -a` to `git tag -s`. Key
+and signing-program selection stay entirely in git's own config
+(`user.signingkey`, `gpg.format`) — ver-bump adds **no** key management and
+no new dependency checks; git's own error output is the error surface.
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-SIGN-1 | `--sign` (boolean, long-only) and the `TAG_SIGN=true` config/env key (precedence per R-CFG-3: CLI > env > `.ver-bumprc` > default `false`): `do-tag` uses `git tag -s` instead of `-a`. Default path is unchanged (`-a`). | ✅ | `signed-tags.bats`, `args.bats` |
+| R-SIGN-2 | Signing failure follows the existing tag-failure path: abort (exit 1) with git's output surfaced — the same handling that fixed the silent `git tag` failure. No gpg/ssh preflight. | ✅ | `signed-tags.bats` |
+| R-SIGN-3 | `--dry-run` prints the `git tag -s …` would-run line (prefix parity with the `-a` preview), and creates nothing. | ✅ | `signed-tags.bats` |
+| R-SIGN-4 | Composes with `-m`/`--message`: a custom message signs the same as the default message. | ✅ | `signed-tags.bats` |
+
+Modules: `lib/args.sh` (parse), `lib/config.sh` (`TAG_SIGN` key + default),
+`lib/git-actions.sh` (`do-tag` `-s`/`-a` switch).
+Tests: `test/signed-tags.bats` (argv captured via a PATH-stubbed `git`;
+precedence exercised end-to-end via the dry-run preview; plus a real
+SSH-key signing round-trip that skips where the environment can't sign),
+`test/args.bats` (flag parsing + `--sign=value` rejection).

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -212,6 +212,20 @@ normalize-long-opts() {
         "Drop the '=<value>' — --no-fetch is a boolean flag."
     fi
 
+    # --sign — long-only boolean: create a signed release tag (`git tag -s`,
+    # R-SIGN-1). Sets the TAG_SIGN config key directly, so the CLI wins over
+    # env / .ver-bumprc per R-CFG-3 (process-arguments runs last). Key and
+    # signing program stay in git's own config (user.signingkey, gpg.format) —
+    # ver-bump adds no key management; git's own error is the error surface.
+    if [ "$arg" = "--sign" ]; then
+      TAG_SIGN=true
+      continue
+    elif [[ "$arg" == "--sign="* ]]; then
+      fail 2 \
+        "Option --sign doesn't take a value." \
+        "Drop the '=<value>' — --sign is a boolean flag."
+    fi
+
     # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
     # value flag (no short form), captured here like --undo so it needs no getopts slot.
     if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -150,7 +150,7 @@ _ver_bump() {
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
-          --allow-dirty --allow-empty --no-fetch \
+          --sign --allow-dirty --allow-empty --no-fetch \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -189,6 +189,7 @@ _ver_bump() {
     '(--major --minor --patch -v --version)--minor[force a minor bump from the current version]' \
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
     '--release[publish a GitHub release for the new tag via gh]' \
+    '--sign[create a signed tag (git tag -s) instead of annotated]' \
     '--allow-dirty[skip the clean-working-tree preflight]' \
     '--allow-empty[release even with no new commits since the previous tag]' \
     '--no-fetch[skip the remote-sync preflight]' \
@@ -226,6 +227,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l minor          -d 'Force a minor bump from the current version'
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'
     complete -c $_cmd      -l release        -d 'Publish a GitHub release for the new tag via gh'
+    complete -c $_cmd      -l sign           -d 'Create a signed tag (git tag -s) instead of annotated'
     complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'
     complete -c $_cmd      -l allow-empty    -d 'Release even with no new commits since the previous tag'
     complete -c $_cmd      -l no-fetch       -d 'Skip the remote-sync preflight'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -17,6 +17,7 @@ true
 #   FLAG_BRANCH  PR_BASE  FLAG_NOCHANGELOG  FLAG_CHANGELOG_PAUSE
 #   ALLOW_DIRTY (skip the clean-working-tree preflight, R-SAFE-2)
 #   NO_FETCH (skip the remote-sync preflight, R-SAFE-8)
+#   TAG_SIGN (create a signed tag via `git tag -s`, R-SIGN-1)
 #   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
 #                     may be cut from; empty = no guard, R-SAFE-10)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
@@ -29,7 +30,7 @@ true
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
-              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES)
+              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES TAG_SIGN)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -132,4 +133,7 @@ apply-config-defaults() {
   # "flat" (default, 1.x-identical) or "grouped" (R-CHLOG-1). Any other
   # value behaves as flat — same lenient contract as the FLAG_* keys.
   CHANGELOG_STYLE="${CHANGELOG_STYLE:-flat}"
+  # Signed tags are opt-in (R-SIGN-1). Explicit false default; false and
+  # unset behave identically under [ "$TAG_SIGN" = true ].
+  TAG_SIGN="${TAG_SIGN:-false}"
 }

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -77,7 +77,10 @@ do-tag() {
   [ "${TAG_SIGN:-false}" = true ] && tag_opt="-s"
 
   if [ "$FLAG_DRYRUN" = true ]; then
-    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git tag ${tag_opt} ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET} -m '${tag_msg}'" >&2
+    # printf, not echo -e: tag_msg is user-supplied (-m/REL_NOTE) and must
+    # print verbatim — %s never interprets backslash escapes.
+    printf "%b[dry-run]%b would run: git tag %s %b%s%b -m '%s'\n" \
+      "${S_LIGHT-}" "${RESET-}" "$tag_opt" "${S_VAL-}" "${TAG_PREFIX}${V_NEW}" "${RESET-}" "$tag_msg" >&2
     log_success "Tagged ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET}"
     return
   fi

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -67,11 +67,17 @@ do-tag() {
   # would point at the wrong (pre-bump) commit. Skip the tag too.
   [ "$FLAG_NOCOMMIT" = true ] && return
 
-  local tag_msg
+  local tag_msg tag_opt
   tag_msg="${REL_NOTE:-Tag version ${V_NEW}.}"
+  # -a (annotated, default) vs -s (signed, R-SIGN-1): --sign / TAG_SIGN=true
+  # opts into `git tag -s`. Key + program selection stays entirely in git's
+  # own config (user.signingkey, gpg.format) — no preflight here; a signing
+  # failure surfaces git's own error via the abort path below (R-SIGN-2).
+  tag_opt="-a"
+  [ "${TAG_SIGN:-false}" = true ] && tag_opt="-s"
 
   if [ "$FLAG_DRYRUN" = true ]; then
-    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git tag -a ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET} -m '${tag_msg}'" >&2
+    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git tag ${tag_opt} ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET} -m '${tag_msg}'" >&2
     log_success "Tagged ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET}"
     return
   fi
@@ -79,7 +85,7 @@ do-tag() {
   # A failed `git tag` (e.g. bad object, signing failure, or a tag that
   # slipped past check-tag-exists) must abort — otherwise we'd report a false
   # "Tagged" success and push a branch whose tag was never created.
-  if ! git tag -a "${TAG_PREFIX}${V_NEW}" -m "${tag_msg}"; then
+  if ! git tag "$tag_opt" "${TAG_PREFIX}${V_NEW}" -m "${tag_msg}"; then
     fail 1 \
       "Failed to create git tag ${TAG_PREFIX}${V_NEW} (see git output above)." \
       "If a previous run left a partial release, check 'git tag -l ${TAG_PREFIX}${V_NEW}' and your release branch, then retry."

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -46,7 +46,7 @@ usage() {
   printf '\n%bUSAGE %b\n' "${S_HDR_CYAN-}" "${S_HDR_END-}"
   printf '  %b%s%b [-v <version>] [-m <message>] [-f <file.json>]... [-p <remote>] [-t <tag-prefix>] [-B <branch-prefix>] [-d] [-n] [-b] [-c] [-l] [-h]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
-  printf '  %b%s%b [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
+  printf '  %b%s%b [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--sign] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
 
   # Column width for label + 2-space gutter. Longest label is
@@ -130,6 +130,7 @@ usage() {
   print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (GitHub-only; implies push to origin)."
   print-opt-row ""   "--base"               "<branch>"    "Base branch for --pr (GitHub-only; default: the branch you ran ver-bump from)."
   print-opt-row ""   "--release"            ""            "Publish a GitHub release for the new tag (GitHub-only; requires -p, uses 'gh')."
+  print-opt-row ""   "--sign"               ""            "Create a signed tag (git tag -s; uses your git signing config)."
   print-opt-row ""   "--about"              ""            "Print name, version, author, and homepage; then exit."
   print-opt-row ""   "--completions"        "<shell>"     "Emit completion script for bash, zsh, or fish."
   print-opt-row ""   "--install-completions" "[=<shell>]" "Install completion script (auto-detects shell)."

--- a/test/args.bats
+++ b/test/args.bats
@@ -127,6 +127,19 @@ load 'test_helper'
   assert_equal "${ALLOW_EMPTY}" "false"
 }
 
+@test "long options: --sign sets TAG_SIGN" {
+  source ${profile_script}
+  process-arguments --sign
+  assert_equal "${TAG_SIGN}" "true"
+}
+
+@test "long options: --sign=value is rejected" {
+  source ${profile_script}
+  run process-arguments --sign=yes
+  assert_failure 2
+  assert_output --partial "Option --sign doesn't take a value"
+}
+
 @test "long options: --no-fetch sets NO_FETCH" {
   source ${profile_script}
   process-arguments --no-fetch

--- a/test/signed-tags.bats
+++ b/test/signed-tags.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+
+# Signed release tags (R-SIGN-1..4, #68): --sign / TAG_SIGN switch do-tag
+# from `git tag -a` to `git tag -s`. Git argv is captured with a PATH-stubbed
+# `git` so no signing key is needed; the CLI > env > rc > default precedence
+# chain is exercised end-to-end via the dry-run preview line (same recipe as
+# config-env.bats). One real SSH-key signing round-trip runs where the
+# environment can sign, and skips where it can't.
+
+load 'test_helper'
+
+# Drop a fake `git` at the front of PATH that appends its argv to
+# <stubdir>/git-args.log and succeeds. Echoes the stub dir; callers prefix
+# PATH for the calls under test. scratch_repo setup must run BEFORE the stub
+# is on PATH (it needs real git).
+make_git_stub() {
+  local dir
+  dir=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${dir}")
+  cat > "${dir}/git" <<EOF
+#!/bin/bash
+printf '%s\n' "\$*" >> "${dir}/git-args.log"
+exit 0
+EOF
+  chmod +x "${dir}/git"
+  echo "$dir"
+}
+
+# Fake `git` whose `tag` subcommand fails like a broken signing setup.
+make_failing_git_stub() {
+  local dir
+  dir=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${dir}")
+  cat > "${dir}/git" <<EOF
+#!/bin/bash
+if [ "\$1" = tag ]; then
+  echo "error: gpg failed to sign the data" >&2
+  exit 128
+fi
+exit 0
+EOF
+  chmod +x "${dir}/git"
+  echo "$dir"
+}
+
+# ── R-SIGN-1: -s vs -a selection ─────────────────────────────────────────
+
+@test "do-tag: TAG_SIGN=true uses git tag -s, not -a (R-SIGN-1)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local stub
+  stub=$(make_git_stub)
+
+  V_NEW="1.2.3"
+  REL_NOTE=
+  TAG_SIGN=true
+
+  PATH="${stub}:$PATH" run do-tag
+  assert_success
+
+  run cat "${stub}/git-args.log"
+  assert_output --partial "tag -s v1.2.3"
+  refute_output --partial "tag -a"
+}
+
+@test "do-tag: default stays git tag -a (unsigned, R-SIGN-1)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local stub
+  stub=$(make_git_stub)
+
+  V_NEW="1.2.3"
+  REL_NOTE=
+  unset TAG_SIGN
+
+  PATH="${stub}:$PATH" run do-tag
+  assert_success
+
+  run cat "${stub}/git-args.log"
+  assert_output --partial "tag -a v1.2.3"
+  refute_output --partial "tag -s"
+}
+
+# ── R-SIGN-4: composes with -m/--message ─────────────────────────────────
+
+@test "do-tag: --sign composes with a custom -m message (R-SIGN-4)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local stub
+  stub=$(make_git_stub)
+
+  V_NEW="1.2.3"
+  REL_NOTE="my custom release note"
+  TAG_SIGN=true
+
+  PATH="${stub}:$PATH" run do-tag
+  assert_success
+
+  run cat "${stub}/git-args.log"
+  assert_output --partial "tag -s v1.2.3 -m my custom release note"
+}
+
+# ── R-SIGN-2: signing failure follows the existing tag-failure path ──────
+
+@test "do-tag: signing failure aborts with git's output surfaced (R-SIGN-2)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  local stub
+  stub=$(make_failing_git_stub)
+
+  V_NEW="1.2.3"
+  REL_NOTE=
+  TAG_SIGN=true
+
+  PATH="${stub}:$PATH" run do-tag
+  assert_failure 1
+  strip_ansi_output
+  assert_output --partial "gpg failed to sign the data"
+  assert_output --partial "Failed to create git tag v1.2.3"
+}
+
+# ── R-SIGN-3: dry-run preview ────────────────────────────────────────────
+
+@test "dry-run: --sign preview prints git tag -s and creates nothing (R-SIGN-3)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  FLAG_DRYRUN=true
+  V_NEW="1.0.0"
+  REL_NOTE=
+  TAG_SIGN=true
+
+  run do-tag
+  strip_ansi_output
+  assert_success
+  assert_output --partial "[dry-run]"
+  assert_output --partial "git tag -s v1.0.0"
+
+  run git tag -l
+  assert_output ""
+}
+
+# ── R-SIGN-1 precedence (R-CFG-3), end-to-end via the dry-run preview ────
+
+@test "TAG_SIGN=true in .ver-bumprc → signed tag (end-to-end)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'TAG_SIGN=true\n' > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  unset TAG_SIGN
+  run ${profile_script} -d -c -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git tag -s v1.0.1"
+}
+
+@test "env TAG_SIGN=false beats .ver-bumprc TAG_SIGN=true (end-to-end)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'TAG_SIGN=true\n' > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  TAG_SIGN=false run ${profile_script} -d -c -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git tag -a v1.0.1"
+  refute_output --partial "git tag -s"
+}
+
+@test "CLI --sign beats env TAG_SIGN=false (end-to-end)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  TAG_SIGN=false run ${profile_script} -d -c -p origin --sign -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git tag -s v1.0.1"
+  refute_output --partial "git tag -a"
+}
+
+# ── Real signing round-trip (no stub): throwaway SSH key ─────────────────
+
+@test "do-tag: real git tag -s with a throwaway ssh key produces a signed tag" {
+  command -v ssh-keygen >/dev/null 2>&1 || skip "ssh-keygen not available"
+
+  source ${profile_script}
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+
+  ssh-keygen -t ed25519 -N '' -q -f "$repo/signkey"
+  git config gpg.format ssh
+  git config user.signingkey "$repo/signkey"
+
+  # Probe: skip (environment, not code) when this git/ssh-keygen pair can't
+  # do SSH signing at all (git < 2.34 or OpenSSH without `-Y sign`).
+  if ! git tag -s probe -m probe >/dev/null 2>&1; then
+    skip "git/ssh-keygen cannot SSH-sign in this environment"
+  fi
+  git tag -d probe >/dev/null 2>&1
+
+  V_NEW="1.2.3"
+  REL_NOTE=
+  TAG_SIGN=true
+
+  run do-tag
+  assert_success
+
+  run git cat-file tag v1.2.3
+  assert_output --partial "BEGIN SSH SIGNATURE"
+}

--- a/test/signed-tags.bats
+++ b/test/signed-tags.bats
@@ -140,6 +140,22 @@ EOF
   assert_output ""
 }
 
+@test "dry-run: preview prints a backslash-containing -m message verbatim" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  FLAG_DRYRUN=true
+  V_NEW="1.0.0"
+  REL_NOTE='note with \n backslash'
+  TAG_SIGN=true
+
+  run do-tag
+  strip_ansi_output
+  assert_success
+  # echo -e would have turned \n into a real newline; printf %s must not.
+  assert_output --partial "git tag -s v1.0.0 -m 'note with \\n backslash'"
+}
+
 # ── R-SIGN-1 precedence (R-CFG-3), end-to-end via the dry-run preview ────
 
 @test "TAG_SIGN=true in .ver-bumprc → signed tag (end-to-end)" {


### PR DESCRIPTION
## Summary

`do-tag` hard-coded `git tag -a`, so provenance-conscious teams couldn't produce a signed release tag even though the 2.0 publish pipeline already does npm provenance + OIDC. This adds a `--sign` long-only boolean flag and a `TAG_SIGN` config/env key (R-CFG-3 precedence: CLI > env > `.ver-bumprc` > default `false`) that switch `do-tag` to `git tag -s`. Key and signing-program selection stay entirely in git's own config (`user.signingkey`, `gpg.format`) — ver-bump adds no key management and no gpg/ssh preflight; git's own error is the error surface.

Refs #68.

## R-SIGN coverage

| ID | Requirement | Where |
| --- | --- | --- |
| R-SIGN-1 | `--sign` / `TAG_SIGN=true` → `git tag -s` instead of `-a`; default unchanged; precedence per R-CFG-3 | `lib/args.sh`, `lib/config.sh`, `lib/git-actions.sh` |
| R-SIGN-2 | Signing failure follows the existing tag-failure abort path with git's output surfaced | `do-tag` (existing `fail 1` path, now flag-aware) |
| R-SIGN-3 | `--dry-run` prints the `git tag -s …` would-run line (prefix parity with the `-a` preview) | `do-tag` dry-run branch |
| R-SIGN-4 | Composes with `-m`/`--message` — custom message signs the same as the default | `do-tag` (`tag_msg` untouched) |

Parity: `--sign` added to `--help` (row + synopsis), all three completion emitters (bash/zsh/fish), the README options block, and the `.ver-bumprc` key table (`TAG_SIGN`, default `false`). New `docs/features/signed-tags/requirements.md` + index row.

## Test plan

**Before:** `git tag -a` was the only tag form — no way to sign; 347 tests.

**After:** 358/358 pass (`pnpm tests:run`), `pnpm lint` zero warnings. New `test/signed-tags.bats` (9 cases):

- PATH-stubbed `git` capturing argv: `--sign` → `-s` present / `-a` absent; default unchanged (`-a` present, no `-s`)
- `--sign` composes with a custom `-m` message (R-SIGN-4)
- stubbed `git tag` failure under `--sign` → exit 1 via the existing failure path, git stderr surfaced (R-SIGN-2)
- `--dry-run --sign` prints the `git tag -s` preview and creates nothing (R-SIGN-3)
- precedence end-to-end via the dry-run preview: rc `TAG_SIGN=true` → signed; env `TAG_SIGN=false` beats rc `true`; CLI `--sign` beats env `false`
- real signing round-trip: throwaway ed25519 key + `gpg.format ssh` in a scratch repo → tag object contains `BEGIN SSH SIGNATURE` (skips where the environment can't sign)

Plus 2 parse cases in `args.bats` (`--sign` sets `TAG_SIGN`; `--sign=value` → exit 2), and the existing help↔README flag-parity test passes with the new flag.