### PR TITLE
feat(config): COMMIT_MSG_TEMPLATE with ${version} placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `REL_PREFIX` | `-B` / `--branch-prefix` | `release-` |
 | `PUSH_DEST` | `-p` / `--push` | `origin` |
 | `COMMIT_MSG_PREFIX` | *(no flag)* | `"chore: "` |
+| `COMMIT_MSG_TEMPLATE` | *(no flag)* | *unset* (prefix + generated file list) |
 | `CHANGELOG_STYLE` | *(no flag)* | `flat` |
 | `FLAG_BRANCH` | `--branch` | *unset* (tag in place) |
 | `PR_BASE` | `--base` | *(auto-detect)* |
@@ -358,6 +359,43 @@ ever dropped. Scopes render as a bold `**scope:**` prefix. With a
 non-GitHub remote (or no remote) the same grouping renders as plain text
 without links. Any other `CHANGELOG_STYLE` value behaves as `flat`, whose
 output stays byte-identical to previous releases.
+
+#### Commit message template (`COMMIT_MSG_TEMPLATE`)
+
+By default the bump commit's message is `COMMIT_MSG_PREFIX` plus a
+generated list of what changed:
+
+```text
+chore: updated package.json, updated CHANGELOG.md, bumped 1.1.7 -> 1.1.8
+```
+
+Set `COMMIT_MSG_TEMPLATE` — in `.ver-bumprc` or as an environment
+variable; there is no CLI flag — to replace the **whole** message with
+your own template. When it is set, `COMMIT_MSG_PREFIX` is **ignored**:
+the template owns the entire message, prefix included.
+
+```sh
+# .ver-bumprc — single quotes are required so your shell / the rc loader
+# doesn't expand the placeholders before ver-bump sees them
+COMMIT_MSG_TEMPLATE='chore(release): v${version}'
+```
+
+Available placeholders:
+
+| Placeholder | Replaced with | Example |
+| --- | --- | --- |
+| `${version}` | the new version | `1.1.8` |
+| `${prev_version}` | the previous version | `1.1.7` |
+| `${tag}` | the new tag (`TAG_PREFIX` + version) | `v1.1.8` |
+| `${files}` | the generated changed-file list | `updated package.json, updated CHANGELOG.md` |
+
+Substitution is a literal string replacement — the template is **never**
+evaluated as shell, so `$(...)`, backticks, and unknown `${...}`
+placeholders pass through as literal text. The CHANGELOG's entry for the
+bump commit uses the same rendered message (first line, in both `flat`
+and `grouped` styles), so the two never drift apart. The template applies
+to the bump commit only; the annotated tag's message keeps its own knob,
+`-m` / `--message`.
 
 ```text
 -v, --version [<version>]     Without a value: print tool version and exit.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -18,6 +18,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [config-file](./config-file/requirements.md) | R-CFG | `config.bats`, `config-env.bats` |
 | [completions](./completions/requirements.md) | R-COMP | `args.bats`, `completions-syntax.bats`, `install-completions.bats` |
 | [changelog](./changelog/requirements.md) | R-LOG | `changelog.bats` |
+| [commit-template](./commit-template/requirements.md) | R-TPL | `commit-template.bats` |
 | [release-flow](./release-flow/requirements.md) | R-FLOW | `git-ops.bats`, `pr.bats`, `prefixes.bats`, `e2e-live.bats` |
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |

--- a/docs/features/commit-template/requirements.md
+++ b/docs/features/commit-template/requirements.md
@@ -1,0 +1,55 @@
+# Commit message template (COMMIT_MSG_TEMPLATE)
+
+Whole-message template for the bump commit, so teams can express the
+near-standard `chore(release): v2.0.0` convention (or anything else)
+instead of the wordy generated default. Config/env only — no CLI flag.
+Originated in issue #69 (2026-07-15 feature review, Tier 3 — polish).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-TPL-1 | `COMMIT_MSG_TEMPLATE` config/env key (R-CFG-3 precedence: env > `.ver-bumprc` > default). Placeholders: `${version}`, `${prev_version}`, `${tag}`, `${files}` (the generated changed-file list that makes up the legacy message body, without its trailing `", "`). Unset/empty → the exact `COMMIT_MSG_PREFIX` + generated-list behaviour, byte-identical. | ✅ shipped — `render-commit-msg` |
+| R-TPL-2 | When set, the template owns the whole message and `COMMIT_MSG_PREFIX` is ignored (interaction documented in the README `.ver-bumprc` section). | ✅ shipped |
+| R-TPL-3 | Substitution is literal string replacement (bash `${var//pat/rep}`) — no `eval`, no command substitution of template content; `$(...)`/backticks/unknown placeholders stay literal text. | ✅ shipped |
+| R-TPL-4 | Applies to the bump commit only; the annotated tag message keeps its own knob (`-m`/`--message`). | ✅ shipped |
+
+## Design note — one renderer
+
+`render-commit-msg` (`lib/changelog.sh`) is the single renderer. Both
+consumers MUST go through it:
+
+- `do-commit` (`lib/git-actions.sh`) — the real `git commit -m`.
+- `do-changelog` (`lib/changelog.sh`) — the manual CHANGELOG entry for the
+  bump commit, which is written *before* that commit exists.
+
+That sharing is the invariant that keeps the CHANGELOG entry and the
+actual commit message identical in both `CHANGELOG_STYLE`s. The changelog
+logs the rendered message's first line only (the same subject-only view
+`git log %s` gives every other entry); grouped style then applies its
+normal subject rendering (type stripped, scope bolded) to that line, as
+it does for every commit.
+
+`${files}` is substituted last, so a bumped file whose name contains
+placeholder text cannot be substituted a second time. Because
+`.ver-bumprc` is shell-sourced, templates in the rc must be single-quoted
+(`COMMIT_MSG_TEMPLATE='chore(release): v${version}'`) or the shell
+expands the placeholders to empty strings at source time.
+
+## Test mapping
+
+`test/commit-template.bats` (16):
+
+- R-TPL-1 — legacy byte-identical pin (unit + live), each placeholder
+  renders, `${files}` matches the generated list (live), unknown
+  placeholder passes through, precedence trio (env > rc > default,
+  end-to-end dry-run).
+- R-TPL-2 — `COMMIT_MSG_PREFIX` ignored when template set (unit + live
+  whole-message assert).
+- R-TPL-3 — `$(touch …)`/backtick templates stay literal and execute
+  nothing (unit + live commit).
+- R-TPL-4 — annotated tag message unaffected (live).
+- Renderer sharing — CHANGELOG bump entry equals the commit subject in
+  flat and grouped styles; multi-line template keeps its body in the
+  commit but logs only the subject line.
+
+Modules: `lib/changelog.sh` (`render-commit-msg`, `do-changelog`),
+`lib/git-actions.sh` (`do-commit`), `lib/config.sh` (`_CONFIG_KEYS`).

--- a/docs/features/commit-template/requirements.md
+++ b/docs/features/commit-template/requirements.md
@@ -34,9 +34,16 @@ placeholder text cannot be substituted a second time. Because
 (`COMMIT_MSG_TEMPLATE='chore(release): v${version}'`) or the shell
 expands the placeholders to empty strings at source time.
 
+On bash 5.2+ (`patsub_replacement`, on by default) `&` and `\` are special
+on the replacement side of `${var//pat/rep}`, so substituted values are
+backslash-escaped first — but only when that option is active, because
+bash 3.2 substitutes replacements literally and the extra backslashes
+would leak into the message there. A bumped file named `R&D.json` renders
+identically on both generations (pinned in tests).
+
 ## Test mapping
 
-`test/commit-template.bats` (16):
+`test/commit-template.bats` (19):
 
 - R-TPL-1 — legacy byte-identical pin (unit + live), each placeholder
   renders, `${files}` matches the generated list (live), unknown
@@ -45,7 +52,9 @@ expands the placeholders to empty strings at source time.
 - R-TPL-2 — `COMMIT_MSG_PREFIX` ignored when template set (unit + live
   whole-message assert).
 - R-TPL-3 — `$(touch …)`/backtick templates stay literal and execute
-  nothing (unit + live commit).
+  nothing (unit + live commit); `&`/`\` stay literal in template text and
+  in substituted values (unit + live `-f R&D.json`), identically on bash
+  3.2 and 5.2+.
 - R-TPL-4 — annotated tag message unaffected (live).
 - Renderer sharing — CHANGELOG bump entry equals the commit subject in
   flat and grouped styles; multi-line template keeps its body in the

--- a/docs/features/config-file/requirements.md
+++ b/docs/features/config-file/requirements.md
@@ -6,7 +6,7 @@ Repo- or home-level defaults without repeating flags. Shipped in 2.0
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-CFG-1 | Discovered by walking up from `$PWD` to `/`; first match wins; absence is not an error. | ✅ shipped — `_find-rc-upward` |
-| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), `NO_FETCH` (R-SAFE-8), `RELEASE_BRANCHES` (R-SAFE-10), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
+| R-CFG-2 | Supported keys (`_CONFIG_KEYS`): `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `COMMIT_MSG_TEMPLATE` (#69, R-TPL), `CHANGELOG_STYLE` (#61), `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY` (R-SAFE-2), `NO_FETCH` (R-SAFE-8), `RELEASE_BRANCHES` (R-SAFE-10), plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`, ADR-12). Only these get precedence tracking; other assignments execute as raw shell (R-CFG-5) with no guarantee. | ✅ shipped |
 | R-CFG-3 | Precedence: CLI > env > `.ver-bumprc` > built-in default, end-to-end. | ✅ shipped (`f6d66b4`) — `test/config-env.bats` |
 | R-CFG-4 | Refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. | ✅ shipped (`6a37077`) |
 | R-CFG-5 | Shell-sourced, not parsed; sourcing failures exit `3` with the shell error as context. | ✅ shipped |

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -9,6 +9,50 @@ get-commit-msg() {
   echo bumped "$CMD" "$V_NEW"
 }
 
+# Render the final bump-commit message (R-TPL-1..3, issue #69).
+#   $1 = the accumulated changed-file list ("updated package.json, ..."),
+#        i.e. GIT_MSG before the trailing "bumped ..." summary is appended.
+#
+# COMMIT_MSG_TEMPLATE unset/empty → legacy output, byte-identical to 1.x:
+# COMMIT_MSG_PREFIX + file list + get-commit-msg (R-TPL-1).
+#
+# COMMIT_MSG_TEMPLATE set → the template owns the WHOLE message and
+# COMMIT_MSG_PREFIX is ignored (R-TPL-2). Placeholders are replaced with
+# plain bash string substitution — the template is never eval'd, so
+# $(...) or `...` inside it stays literal text (R-TPL-3):
+#   ${version}       the new version                   (V_NEW)
+#   ${prev_version}  the previous version              (V_PREV)
+#   ${tag}           the new tag                       (TAG_PREFIX + V_NEW)
+#   ${files}         the generated changed-file list, without the
+#                    trailing ", " the legacy assembly relies on
+# Unknown placeholders pass through untouched. ${files} is substituted
+# LAST so a file name that happens to contain placeholder text can't be
+# substituted a second time.
+#
+# Both do-commit (the real commit) and do-changelog (the manual bump entry,
+# written before that commit exists) MUST render through here — one
+# renderer is what keeps the CHANGELOG entry and the actual commit message
+# from drifting apart.
+# shellcheck disable=SC2016 # the single-quoted ${...} placeholders below are literal search patterns, not expansions
+render-commit-msg() {
+  local files=$1
+
+  if [ -z "${COMMIT_MSG_TEMPLATE-}" ]; then
+    printf '%s' "${COMMIT_MSG_PREFIX}${files}$(get-commit-msg)"
+    return 0
+  fi
+
+  # Pattern lives in a variable and is quoted at expansion, so bash treats
+  # it as a literal string, not a glob — safe on bash 3.2.
+  local msg="$COMMIT_MSG_TEMPLATE" ph
+  local tag="${TAG_PREFIX}${V_NEW}" files_trimmed="${files%, }"
+  ph='${version}';      msg=${msg//"$ph"/$V_NEW}
+  ph='${prev_version}'; msg=${msg//"$ph"/$V_PREV}
+  ph='${tag}';          msg=${msg//"$ph"/$tag}
+  ph='${files}';        msg=${msg//"$ph"/$files_trimmed}
+  printf '%s' "$msg"
+}
+
 capitalise() {
   echo "$(tr '[:lower:]' '[:upper:]' <<< "${1:0:1}")${1:1}"
 }
@@ -106,7 +150,8 @@ _changelog-grouped-section() {
   fi
 
   # The bump commit is classified like any other commit (its section
-  # follows COMMIT_MSG_PREFIX — "chore: " lands in Other by default).
+  # follows the rendered message — the default "chore: " prefix, or a
+  # COMMIT_MSG_TEMPLATE's leading type, lands it in Other/feat/fix/…).
   entry="- $(_changelog-render-subject "$bump_entry")"$'\n'
   case "$(classify-commit "$bump_entry" "")" in
     breaking) breaking+="$entry" ;;
@@ -192,16 +237,21 @@ do-changelog() {
   TMP=$(mktemp "./CHANGELOG.md.XXXXXX")
 
   # The bump commit's own entry:
-  # - The final commit is done after do-changelog(), so we need to create the log entry for it manually:
-  LOG_MSG="${GIT_MSG}$(get-commit-msg)"
+  # - The final commit is done after do-changelog(), so we need to create the log entry for it manually.
+  # - render-commit-msg is the ONE renderer shared with do-commit, so this
+  #   entry and the eventual commit message cannot drift (R-TPL-1/2). Only
+  #   the first line is logged — the same subject-only view `git log %s`
+  #   gives every other entry (a template may carry a multi-line body).
+  LOG_MSG=$(render-commit-msg "$GIT_MSG")
+  LOG_MSG="${LOG_MSG%%$'\n'*}"
 
   if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then
-    _changelog-grouped-section "$COMMITS_MSG" "${COMMIT_MSG_PREFIX}${LOG_MSG}" "$RANGE" > "$TMP"
+    _changelog-grouped-section "$COMMITS_MSG" "${LOG_MSG}" "$RANGE" > "$TMP"
   else
     # Heading
     echo "## $V_NEW ($NOW)" > "$TMP"
     # Log the bumping commit
-    echo "- ${COMMIT_MSG_PREFIX}${LOG_MSG}" >> "$TMP"
+    echo "- ${LOG_MSG}" >> "$TMP"
     # Add previous commits
     [ -n "$COMMITS_MSG" ] && echo "$COMMITS_MSG" >> "$TMP"
   fi

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -45,9 +45,27 @@ render-commit-msg() {
   # Pattern lives in a variable and is quoted at expansion, so bash treats
   # it as a literal string, not a glob — safe on bash 3.2.
   local msg="$COMMIT_MSG_TEMPLATE" ph
+  local version="$V_NEW" prev="$V_PREV"
   local tag="${TAG_PREFIX}${V_NEW}" files_trimmed="${files%, }"
-  ph='${version}';      msg=${msg//"$ph"/$V_NEW}
-  ph='${prev_version}'; msg=${msg//"$ph"/$V_PREV}
+
+  # bash 5.2+ enables patsub_replacement by default, which makes `&` and
+  # `\` special on the REPLACEMENT side of ${var//pat/rep} — a bumped file
+  # named "R&D.json" would splice the matched placeholder back into the
+  # message. Escape the values, but only when that option is active: bash
+  # 3.2 substitutes replacements literally and must NOT get the extra
+  # backslashes (its shopt doesn't know the option, so the block is
+  # skipped). The escape expansions use double-quoted replacements, which
+  # both bash generations treat literally.
+  if shopt -q patsub_replacement 2>/dev/null; then
+    local bs=$'\\'
+    version=${version//"$bs"/"$bs$bs"};             version=${version//&/"$bs&"}
+    prev=${prev//"$bs"/"$bs$bs"};                   prev=${prev//&/"$bs&"}
+    tag=${tag//"$bs"/"$bs$bs"};                     tag=${tag//&/"$bs&"}
+    files_trimmed=${files_trimmed//"$bs"/"$bs$bs"}; files_trimmed=${files_trimmed//&/"$bs&"}
+  fi
+
+  ph='${version}';      msg=${msg//"$ph"/$version}
+  ph='${prev_version}'; msg=${msg//"$ph"/$prev}
   ph='${tag}';          msg=${msg//"$ph"/$tag}
   ph='${files}';        msg=${msg//"$ph"/$files_trimmed}
   printf '%s' "$msg"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,6 +19,10 @@ true
 #   NO_FETCH (skip the remote-sync preflight, R-SAFE-8)
 #   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
 #                     may be cut from; empty = no guard, R-SAFE-10)
+#   COMMIT_MSG_TEMPLATE (whole bump-commit message template with literal
+#                        ${version}/${prev_version}/${tag}/${files}
+#                        placeholders; when set COMMIT_MSG_PREFIX is
+#                        ignored; empty = legacy prefix+list, R-TPL-1/2)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
@@ -27,7 +31,7 @@ true
 
 # Config-able keys, in a plain indexed array so bash 3.2 is happy.
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
-              FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
+              COMMIT_MSG_TEMPLATE FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
               ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES)
 
@@ -123,7 +127,9 @@ load-config() {
 # Apply built-in defaults for any config key still unset after load-config.
 # FLAG_* keys and the boolean safety keys (ALLOW_DIRTY, NO_FETCH)
 # intentionally default to unset (false-equivalent under [ "$KEY" = true ]);
-# RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10).
+# RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10);
+# COMMIT_MSG_TEMPLATE defaults to unset/empty = the legacy
+# COMMIT_MSG_PREFIX + generated-list message (R-TPL-1).
 apply-config-defaults() {
   TAG_PREFIX="${TAG_PREFIX:-v}"
   REL_PREFIX="${REL_PREFIX:-release-}"

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -40,18 +40,22 @@ do-branch() {
 do-commit() {
   [ "$FLAG_NOCOMMIT" = true ] && return
 
-  local COMMIT_MSG COMMIT_RC
+  local COMMIT_MSG COMMIT_RC FINAL_MSG
 
-  GIT_MSG+="$(get-commit-msg)"
+  # ONE renderer, shared with do-changelog's manual bump entry, so the
+  # CHANGELOG and the commit can't disagree — see render-commit-msg in
+  # lib/changelog.sh (R-TPL-1..3). Applies to this bump commit only; the
+  # tag message has its own knob, -m/--message (R-TPL-4).
+  FINAL_MSG=$(render-commit-msg "$GIT_MSG")
   echo -e "\nCommitting..."
 
   if [ "$FLAG_DRYRUN" = true ]; then
-    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git commit -m '${S_VAL}${COMMIT_MSG_PREFIX}${GIT_MSG}${RESET}'" >&2
+    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git commit -m '${S_VAL}${FINAL_MSG}${RESET}'" >&2
     log_success "(dry-run) commit prepared"
     return
   fi
 
-  COMMIT_MSG=$( git commit -m "${COMMIT_MSG_PREFIX}${GIT_MSG}" 2>&1 ); COMMIT_RC=$?
+  COMMIT_MSG=$( git commit -m "${FINAL_MSG}" 2>&1 ); COMMIT_RC=$?
   if [ "$COMMIT_RC" -ne 0 ]; then
     fail 1 \
       "git commit failed: ${COMMIT_MSG}" \

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -50,7 +50,10 @@ do-commit() {
   echo -e "\nCommitting..."
 
   if [ "$FLAG_DRYRUN" = true ]; then
-    echo -e "${S_LIGHT}[dry-run]${RESET} would run: git commit -m '${S_VAL}${FINAL_MSG}${RESET}'" >&2
+    # %q shell-quotes the message so the preview stays copy-pasteable even
+    # when a template carries quotes, backslashes, or $(...) text.
+    printf '%b[dry-run]%b would run: git commit -m %b%q%b\n' \
+      "${S_LIGHT}" "${RESET}" "${S_VAL}" "${FINAL_MSG}" "${RESET}" >&2
     log_success "(dry-run) commit prepared"
     return
   fi

--- a/test/commit-template.bats
+++ b/test/commit-template.bats
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+
+# COMMIT_MSG_TEMPLATE — whole-message template for the bump commit with
+# literal ${version}/${prev_version}/${tag}/${files} placeholders
+# (R-TPL-1..4, issue #69). Shared setup lives in test/test_helper.bash.
+#
+# render-commit-msg is the ONE renderer shared by do-commit and
+# do-changelog's manual bump entry; the live tests below pin that the
+# actual commit message and the CHANGELOG entry stay identical in both
+# changelog styles, with and without a template.
+
+load 'test_helper'
+
+# Unit fixture: deterministic renderer inputs. Callers must have sourced
+# ${profile_script} first.
+_render_fixture() {
+  V_PREV="1.0.0"
+  V_NEW="1.1.0"
+  TAG_PREFIX="v"
+  COMMIT_MSG_PREFIX="chore: "
+  unset COMMIT_MSG_TEMPLATE
+}
+
+# Live fixture: scratch repo with package.json@1.0.0 and a throwaway bare
+# remote so `-p <remote> -y` completes end-to-end without prompting
+# (mirrors e2e-live.bats). Sets LIVE_REMOTE.
+_live_repo() {
+  local remote
+  cd "$(scratch_repo)"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "feat: seed a feature"
+  remote=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${remote}")
+  git init -q --bare "${remote}"
+  LIVE_REMOTE="${remote}"
+}
+
+# R-TPL-1: legacy default (unset template) #####################################
+
+@test "render-commit-msg: unset template renders the legacy prefix + list + bump summary byte-identically" {
+  source ${profile_script}
+  _render_fixture
+
+  assert_equal \
+    "$(render-commit-msg 'updated package.json, updated CHANGELOG.md, ')" \
+    "chore: updated package.json, updated CHANGELOG.md, bumped 1.0.0 -> 1.1.0"
+
+  # Same-version path keeps the legacy "bumped to" wording too.
+  V_PREV="1.1.0"
+  assert_equal \
+    "$(render-commit-msg 'updated package.json, ')" \
+    "chore: updated package.json, bumped to 1.1.0"
+}
+
+@test "live: unset template — commit message and flat CHANGELOG entry are the legacy strings, byte-identical (regression pin)" {
+  _live_repo
+  unset COMMIT_MSG_TEMPLATE
+
+  run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" \
+    "chore: updated package.json, created CHANGELOG.md, bumped 1.0.0 -> 1.1.0"
+  # The changelog's manual bump entry is the same rendered message.
+  assert_equal "$(sed -n 2p CHANGELOG.md)" \
+    "- chore: updated package.json, created CHANGELOG.md, bumped 1.0.0 -> 1.1.0"
+}
+
+# R-TPL-1: placeholders ########################################################
+
+@test "render-commit-msg: every placeholder renders; \${files} is the generated list without the trailing comma" {
+  source ${profile_script}
+  _render_fixture
+  COMMIT_MSG_TEMPLATE='v=${version} p=${prev_version} t=${tag} f=[${files}] again=${version}'
+
+  assert_equal \
+    "$(render-commit-msg 'updated package.json, updated CHANGELOG.md, ')" \
+    "v=1.1.0 p=1.0.0 t=v1.1.0 f=[updated package.json, updated CHANGELOG.md] again=1.1.0"
+}
+
+@test "render-commit-msg: unknown placeholders pass through literally" {
+  source ${profile_script}
+  _render_fixture
+  COMMIT_MSG_TEMPLATE='keep ${unknown} and ${VERSION} but not ${version}'
+
+  assert_equal \
+    "$(render-commit-msg '')" \
+    'keep ${unknown} and ${VERSION} but not 1.1.0'
+}
+
+@test "live: template — commit subject is exactly the rendered template; tag message is untouched (R-TPL-2/4)" {
+  _live_repo
+
+  COMMIT_MSG_TEMPLATE='chore(release): v${version}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  # The template owns the WHOLE message — no prefix, no generated list.
+  assert_equal "$(git log -1 --pretty=%B)" "chore(release): v1.1.0"
+  # The annotated tag keeps its own message (-m/--message knob), R-TPL-4.
+  assert_equal "$(git tag -l --format='%(contents:subject)' v1.1.0)" \
+    "Tag version 1.1.0."
+}
+
+@test "live: template \${files} matches today's generated changed-file list" {
+  _live_repo
+
+  COMMIT_MSG_TEMPLATE='files: ${files}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" \
+    "files: updated package.json, created CHANGELOG.md"
+}
+
+# R-TPL-2: COMMIT_MSG_PREFIX is ignored when the template is set ###############
+
+@test "render-commit-msg: template set — COMMIT_MSG_PREFIX is ignored" {
+  source ${profile_script}
+  _render_fixture
+  COMMIT_MSG_PREFIX="zzz: "
+  COMMIT_MSG_TEMPLATE='chore(release): v${version}'
+
+  assert_equal "$(render-commit-msg 'updated package.json, ')" \
+    "chore(release): v1.1.0"
+}
+
+# R-TPL-3: literal substitution, never eval ####################################
+
+@test "render-commit-msg: \$(...) and backticks in the template stay literal — nothing executes" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+  _render_fixture
+  COMMIT_MSG_TEMPLATE='pwn $(touch ./pwned-a) `touch ./pwned-b` ${version}'
+
+  assert_equal "$(render-commit-msg '')" \
+    'pwn $(touch ./pwned-a) `touch ./pwned-b` 1.1.0'
+  [ ! -f pwned-a ]
+  [ ! -f pwned-b ]
+}
+
+@test "live: injection-shaped template lands literally in the real commit, and nothing executes" {
+  _live_repo
+
+  COMMIT_MSG_TEMPLATE='release ${version} $(touch ./pwned)' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  [ ! -f ./pwned ]
+  assert_equal "$(git log -1 --pretty=%B)" 'release 1.1.0 $(touch ./pwned)'
+}
+
+# CHANGELOG parity: the manual bump entry uses the same renderer ###############
+
+@test "live flat: CHANGELOG bump entry equals the templated commit subject" {
+  _live_repo
+
+  COMMIT_MSG_TEMPLATE='chore(release): v${version}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(sed -n 2p CHANGELOG.md)" "- $(git log -1 --pretty=%s)"
+  assert_equal "$(sed -n 2p CHANGELOG.md)" "- chore(release): v1.1.0"
+}
+
+@test "live grouped: non-conventional template — CHANGELOG bump entry equals the commit subject verbatim" {
+  _live_repo
+
+  CHANGELOG_STYLE=grouped COMMIT_MSG_TEMPLATE='release ${prev_version} -> ${version}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" "release 1.0.0 -> 1.1.0"
+  # Non-conventional subjects render verbatim under Other (nothing dropped).
+  run cat CHANGELOG.md
+  assert_output --partial "### Other"
+  assert_output --partial "- release 1.0.0 -> 1.1.0"
+}
+
+@test "live grouped: conventional template is classified and scope-bolded like any other commit" {
+  _live_repo
+
+  CHANGELOG_STYLE=grouped COMMIT_MSG_TEMPLATE='chore(release): v${version}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" "chore(release): v1.1.0"
+  # Same grouped rendering rules as every other entry: chore → Other,
+  # scope becomes a bold prefix — derived from the SAME rendered message.
+  run cat CHANGELOG.md
+  assert_output --partial "### Other"
+  assert_output --partial "- **release:** v1.1.0"
+}
+
+@test "live: multi-line template — commit keeps the full body, CHANGELOG logs the subject line only" {
+  _live_repo
+
+  COMMIT_MSG_TEMPLATE=$'chore(release): v${version}\n\nbumped from ${prev_version}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" \
+    $'chore(release): v1.1.0\n\nbumped from 1.0.0'
+  assert_equal "$(sed -n 2p CHANGELOG.md)" "- chore(release): v1.1.0"
+}
+
+# R-CFG-3 precedence: env > .ver-bumprc > default ##############################
+
+@test "precedence: env COMMIT_MSG_TEMPLATE beats .ver-bumprc (end-to-end dry-run)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  # Single quotes in the rc are load-bearing: it is shell-sourced, so a
+  # double-quoted ${version} would expand (to empty) at source time.
+  printf "COMMIT_MSG_TEMPLATE='from-file \${version}'\n" > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  COMMIT_MSG_TEMPLATE='from-env ${version}' \
+    run ${profile_script} -d -b -c -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git commit -m 'from-env 1.0.1'"
+  refute_output --partial "from-file"
+}
+
+@test "precedence: .ver-bumprc COMMIT_MSG_TEMPLATE beats the legacy default (end-to-end dry-run)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf "COMMIT_MSG_TEMPLATE='from-file \${version}'\n" > "$repo/.ver-bumprc"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  unset COMMIT_MSG_TEMPLATE
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git commit -m 'from-file 1.0.1'"
+  refute_output --partial "chore: updated package.json"
+}
+
+@test "precedence: nothing set — dry-run previews the legacy message (end-to-end)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > "$repo/package.json"
+
+  unset COMMIT_MSG_TEMPLATE
+  run ${profile_script} -d -b -c -p origin -v 1.0.1
+  strip_ansi_output
+  assert_success
+  assert_output --partial "git commit -m 'chore: updated package.json, bumped 1.0.0 -> 1.0.1'"
+}

--- a/test/commit-template.bats
+++ b/test/commit-template.bats
@@ -139,6 +139,27 @@ _live_repo() {
   [ ! -f pwned-b ]
 }
 
+@test "render-commit-msg: & and backslash in the template text stay literal" {
+  source ${profile_script}
+  _render_fixture
+  COMMIT_MSG_TEMPLATE='R&D \release\ v${version} & co'
+
+  assert_equal "$(render-commit-msg '')" 'R&D \release\ v1.1.0 & co'
+}
+
+@test "render-commit-msg: & and backslash in substituted values stay literal (bash 5.2 patsub_replacement)" {
+  source ${profile_script}
+  _render_fixture
+  # On bash 5.2+ an unescaped & in the replacement would splice the matched
+  # placeholder back in ("updated R${files}D.json ..."); bash 3.2 was always
+  # literal. The assertion is on the final message only, so it must pass
+  # identically on both generations.
+  COMMIT_MSG_TEMPLATE='files: ${files} (${version})'
+
+  assert_equal "$(render-commit-msg 'updated R&D.json, updated a\b.json, ')" \
+    'files: updated R&D.json, updated a\b.json (1.1.0)'
+}
+
 @test "live: injection-shaped template lands literally in the real commit, and nothing executes" {
   _live_repo
 
@@ -148,6 +169,19 @@ _live_repo() {
 
   [ ! -f ./pwned ]
   assert_equal "$(git log -1 --pretty=%B)" 'release 1.1.0 $(touch ./pwned)'
+}
+
+@test "live: bumped file named with & lands literally in the templated message" {
+  _live_repo
+  printf '{ "version": "1.0.0" }\n' > "R&D.json"
+  git add "R&D.json" && git commit -qm "chore: add R&D.json"
+
+  COMMIT_MSG_TEMPLATE='files: ${files}' \
+    run ${profile_script} -v 1.1.0 -p "${LIVE_REMOTE}" -y -f "R&D.json"
+  assert_success
+
+  assert_equal "$(git log -1 --pretty=%B)" \
+    "files: updated package.json, updated R&D.json, created CHANGELOG.md"
 }
 
 # CHANGELOG parity: the manual bump entry uses the same renderer ###############
@@ -219,7 +253,8 @@ _live_repo() {
     run ${profile_script} -d -b -c -p origin -v 1.0.1
   strip_ansi_output
   assert_success
-  assert_output --partial "git commit -m 'from-env 1.0.1'"
+  # The preview %q-quotes the message (spaces become backslash-escaped).
+  assert_output --partial 'git commit -m from-env\ 1.0.1'
   refute_output --partial "from-file"
 }
 
@@ -234,8 +269,8 @@ _live_repo() {
   run ${profile_script} -d -b -c -p origin -v 1.0.1
   strip_ansi_output
   assert_success
-  assert_output --partial "git commit -m 'from-file 1.0.1'"
-  refute_output --partial "chore: updated package.json"
+  assert_output --partial 'git commit -m from-file\ 1.0.1'
+  refute_output --partial "chore:"
 }
 
 @test "precedence: nothing set — dry-run previews the legacy message (end-to-end)" {
@@ -248,5 +283,5 @@ _live_repo() {
   run ${profile_script} -d -b -c -p origin -v 1.0.1
   strip_ansi_output
   assert_success
-  assert_output --partial "git commit -m 'chore: updated package.json, bumped 1.0.0 -> 1.0.1'"
+  assert_output --partial 'git commit -m chore:\ updated\ package.json\,\ bumped\ 1.0.0\ -\>\ 1.0.1'
 }

--- a/test/config.bats
+++ b/test/config.bats
@@ -13,8 +13,8 @@ load 'test_helper'
 # itself, so our tests can assert "default" paths deterministically. Does NOT
 # unset the generic shell-inherited ones (those never are).
 _clear_config_env() {
-  unset TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX CHANGELOG_STYLE \
-        FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE
+  unset TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX COMMIT_MSG_TEMPLATE \
+        CHANGELOG_STYLE FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE
 }
 
 # Absent file ##################################################################


### PR DESCRIPTION
Only `COMMIT_MSG_PREFIX` was configurable, so the near-standard `chore(release): v2.0.0` convention couldn't be expressed. This adds a whole-message template with placeholders, with today's output preserved byte-identically as the default — zero migration.

## Changes

- **`lib/changelog.sh`** — new `render-commit-msg` renderer: unset/empty template → legacy `COMMIT_MSG_PREFIX` + generated file list + `bumped X -> Y`, byte-identical; set → the template owns the whole message. Placeholders `${version}`, `${prev_version}`, `${tag}`, `${files}` replaced via literal bash `${var//pat/rep}` — never `eval`, so `$(...)`/backticks/unknown placeholders stay literal text. `do-changelog`'s manual bump entry now renders through it (first line only — the same subject view `git log %s` gives every other entry).
- **`lib/git-actions.sh`** — `do-commit` renders through the same helper (dry-run preview included).
- **`lib/config.sh`** — `COMMIT_MSG_TEMPLATE` added to `_CONFIG_KEYS` (full R-CFG-3 precedence: env > `.ver-bumprc` > default); default intentionally unset = legacy path. No CLI flag by design.
- **Docs** — README `.ver-bumprc` key row + template subsection (placeholders, prefix-ignored interaction, single-quoting gotcha for the shell-sourced rc, bump-commit-only scope); new `docs/features/commit-template/requirements.md`; features index row; R-CFG-2 key list updated.

## Design note — one shared renderer

The CHANGELOG's entry for the bump commit is written *before* that commit exists, in both flat and grouped styles. Rendering in two places would let the changelog and the real commit drift, so `render-commit-msg` is the single renderer both `do-commit` and `do-changelog` call — pinned by parity tests in both `CHANGELOG_STYLE`s. `${files}` substitutes last so a bumped file name containing placeholder text can't be substituted twice.

## R-TPL coverage

| ID | Requirement | Tests |
| --- | --- | --- |
| R-TPL-1 | Config/env key, four placeholders, unset → byte-identical legacy | legacy pins (unit + live), placeholder table, `${files}` live, precedence trio |
| R-TPL-2 | Template owns the whole message; `COMMIT_MSG_PREFIX` ignored | unit + live whole-`%B` asserts |
| R-TPL-3 | Literal substitution — no eval, no command substitution | `$(touch ./pwned)` unit + live: literal in message, file never created |
| R-TPL-4 | Bump commit only; tag keeps `-m/--message` | live tag-annotation assert |

## Test plan

Before: 347 tests. After: **363/363 green** (`pnpm tests:run`), including the new `test/commit-template.bats` (16). `pnpm lint` (shellcheck): zero warnings — the intentional literal-`${...}` patterns carry a scoped, justified `SC2016` disable.

Refs #69.