### PR TITLE
feat(output): -q/--quiet — print the released version on stdout for CI capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ branch.
 $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... \
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
-           [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
+           [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-q|--quiet] [-h|--help] \
            [--branch] [--pr] [--base <branch>] \
            [--allow-dirty] [--allow-empty] [--no-fetch] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
@@ -375,6 +375,14 @@ output stays byte-identical to previous releases.
 -c, --no-changelog            Disable updating CHANGELOG.md automatically.
 -l, --pause-changelog         Pause before commit so CHANGELOG.md can be hand-edited.
 -y, --yes                     Skip interactive confirmation prompts.
+-q, --quiet                   Suppress decorative output — on success stdout carries
+                              exactly one line: the new version (no tag prefix, no
+                              colour); everything else goes to stderr. Errors keep
+                              the usual exit codes; a no-op run (nothing to release)
+                              prints nothing and exits 0. Requires --yes, -v, or
+                              --major/--minor/--patch, and refuses -l/--pause-changelog
+                              (a hidden prompt would hang the pipeline). CI capture:
+                                NEW_VERSION=$(ver-bump --yes --quiet -p origin)
 -h, --help                    Show help message.
     --undo [<version>]        Locally delete the release branch + tag for <version>
                               (refuses if pushed, dirty, or already merged).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,7 +22,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
 | [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats` |
-| [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
+| [ui-output](./ui-output/requirements.md) | R-UI, R-OUT | `ui.bats`, `color.bats`, `about.bats`, `quiet.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |
 | [installer](./installer/requirements.md) | R-DIST | `install.bats` |

--- a/docs/features/ui-output/requirements.md
+++ b/docs/features/ui-output/requirements.md
@@ -14,8 +14,35 @@ Backfilled requirements:
 | R-UI-4 | `--about` prints a branded block (name, version, author, homepage) and exits 0 anywhere. | ✅ shipped — `test/about.bats` |
 | R-UI-5 | Errors (via `fail`) go to stderr with an optional self-service hint; pipeable output (completions, `--help`) stays clean on stdout. | ✅ shipped |
 
-Modules: `lib/ui.sh`, `lib/styles.sh`, `lib/icons.sh`, `lib/usage.sh`.
-Tests: `test/ui.bats`, `test/color.bats`, `test/about.bats`.
+## Quiet mode (`-q` / `--quiet`) — machine-readable stdout
+
+The missing half of the machine contract R-EXIT started (issue #65):
+`NEW_VERSION=$(ver-bump --yes --quiet -p origin)` is the canonical CI
+capture pattern.
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-OUT-1 | `-q`/`--quiet`: decorative output is routed off stdout; on success stdout carries exactly one line — the new version, no tag prefix, no colour codes. Errors keep going to stderr with the contract exit codes. | ✅ shipped — `test/quiet.bats` |
+| R-OUT-2 | `--quiet` and interactive prompts are incompatible by construction (a hidden prompt is a hung pipeline): `--quiet` without `--yes`, `-v`, or a forced bump level exits `2` naming the fix; `--quiet` with `-l`/`--pause-changelog` (flag or rc key) exits `2`; `--quiet --undo` without `--yes` exits `2`. | ✅ shipped — `test/quiet.bats` |
+| R-OUT-3 | Composes with `--dry-run`: stdout gets the would-be version; the `[dry-run]` side-effect lines target stderr (R-DRY-2), so the pipe stays clean. | ✅ shipped — `test/quiet.bats` |
+| R-OUT-4 | A quiet no-op (nothing to release, R-SAFE-14) prints **nothing** on stdout — the `no-release` token is rerouted with the rest of the decoration — and exits `0`, so `[ -z "$out" ]` is the CI branch test for "no release happened". | ✅ shipped — `test/quiet.bats` |
+
+Implementation is stream discipline, not a renderer: `process-arguments`
+(`lib/args.sh`) pre-scans argv for `-q`/`--quiet`, saves the real stdout on
+FD 3 and redirects FD 1 to stderr (`exec 3>&1 1>&2`) before any option echo
+runs; `main()` (`ver-bump.sh`) prints the bare version to FD 3 as its last
+step. One redirect beats guarding every `log_*`/`echo` call site — nothing
+can leak into the captured pipeline, and warnings/prompts stay visible on
+stderr. `--undo` handles quiet in its own pre-scan (no version to report,
+so quiet stdout stays completely empty). `FLAG_QUIET` is CLI-only — reset
+in `process-arguments` like `BUMP_LEVEL`/`ALLOW_EMPTY`, never a
+`.ver-bumprc` key: hidden-output mode must be an explicit per-invocation
+choice (same rationale as `FLAG_YES`, R-YES-3).
+
+Modules: `lib/ui.sh`, `lib/styles.sh`, `lib/icons.sh`, `lib/usage.sh`;
+quiet mode: `lib/args.sh`, `ver-bump.sh`.
+Tests: `test/ui.bats`, `test/color.bats`, `test/about.bats`,
+`test/quiet.bats`.
 
 Style rules for contributors live in `docs/CODE_STYLE.md` (UI / colour
 discipline) — changes here require updating `ui.bats`.

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -102,12 +102,25 @@ normalize-long-opts() {
         case "$undo_a" in
           --dry-run|-d)       FLAG_DRYRUN=true ;;
           --yes|-y)           FLAG_YES=true ;;
+          --quiet|-q)         FLAG_QUIET=true ;;
           -t|--tag-prefix)    undo_capture=t ;;
           -B|--branch-prefix) undo_capture=B ;;
           --tag-prefix=*)     TAG_PREFIX="${undo_a#*=}" ;;
           --branch-prefix=*)  REL_PREFIX="${undo_a#*=}" ;;
         esac
       done
+      # --quiet + --undo (R-OUT-2): do-undo's confirmation prompt is
+      # interactive, so --yes is mandatory. There is no "new version" to
+      # report for an undo, so stdout stays completely empty: route all
+      # decoration to stderr and print nothing.
+      if [ "${FLAG_QUIET:-false}" = true ]; then
+        if [ "${FLAG_YES:-false}" != true ]; then
+          fail 2 \
+            "--quiet with --undo requires --yes (the undo confirmation prompt is interactive)." \
+            "Add --yes to auto-confirm the undo, or drop --quiet."
+        fi
+        exec 1>&2
+      fi
       if [[ "$arg" == "--undo="* ]]; then
         undo_ver="${arg#--undo=}"
         [ -z "$undo_ver" ] && fail 2 \
@@ -279,6 +292,7 @@ normalize-long-opts() {
       pause-changelog) short="-l"; needs_arg=0 ;;
       help)            short="-h"; needs_arg=0 ;;
       yes)             short="-y"; needs_arg=0 ;;
+      quiet)           short="-q"; needs_arg=0 ;;
       *)
         fail 2 \
           "Invalid option: --${name}" \
@@ -316,21 +330,47 @@ normalize-long-opts() {
 process-arguments() {
   local OPTIONS OPTIND OPTARG
 
-  # DO_RELEASE, BUMP_LEVEL, and ALLOW_EMPTY are CLI-only switches with no
-  # env / .ver-bumprc contract. Reset them before parsing so an inherited
-  # exported var — or a .ver-bumprc assignment (load-config sources the rc as
-  # raw shell) — can't silently force a bump, publish a release, or push an
-  # empty release with no flag on the command line.
+  # DO_RELEASE, BUMP_LEVEL, ALLOW_EMPTY, and FLAG_QUIET are CLI-only switches
+  # with no env / .ver-bumprc contract. Reset them before parsing so an
+  # inherited exported var — or a .ver-bumprc assignment (load-config sources
+  # the rc as raw shell) — can't silently force a bump, publish a release,
+  # push an empty release, or hide the run's output with no flag on the
+  # command line. FLAG_QUIET follows the FLAG_YES rationale (R-YES-3): a
+  # hidden-output mode must be an explicit per-invocation choice.
   DO_RELEASE=false
   DO_PR=false
   BUMP_LEVEL=
   ALLOW_EMPTY=false
+  FLAG_QUIET=false
 
   normalize-long-opts "$@"
   set -- ${NORMALIZED_ARGV[@]+"${NORMALIZED_ARGV[@]}"}
 
+  # -q/--quiet stream discipline (R-OUT-1): redirect BEFORE getopts runs,
+  # otherwise the "Option set:" echoes below would leak to stdout whenever
+  # another flag precedes -q in argv. FD 3 keeps a handle on the real stdout
+  # for the single bare-version line main() prints at the end; everything
+  # else — decoration, prompts, dry-run previews — lands on stderr. One
+  # redirect here beats guarding every log_*/echo call site: no current or
+  # future decoration line can ever leak into the captured pipeline.
+  # Like the --undo pre-scan, this scan reads flag positions approximately:
+  # an option *value* that begins with '-' and contains a 'q' (e.g.
+  # -m "-quote") is a false positive — same accepted trade-off as the other
+  # pre-scans in this file. --quiet has already been normalized to -q, and
+  # clustered shorts (-yq) are matched too.
+  local _qscan
+  for _qscan in "$@"; do
+    case "$_qscan" in
+      --) break ;;
+      -q*|-[!-]*q*) FLAG_QUIET=true; break ;;
+    esac
+  done
+  if [ "$FLAG_QUIET" = true ]; then
+    exec 3>&1 1>&2
+  fi
+
   # Get positional parameters
-  while getopts ":v:p:m:f:t:B:hbncdly" OPTIONS; do # Note: Adding the first : before the flags takes control of flags and prevents default error msgs.
+  while getopts ":v:p:m:f:t:B:hbncdlyq" OPTIONS; do # Note: Adding the first : before the flags takes control of flags and prevents default error msgs.
     case "$OPTIONS" in
       h )
         # Show help
@@ -398,6 +438,12 @@ process-arguments() {
       y )
         FLAG_YES=true
       ;;
+      q )
+        # Already set by the pre-scan above (which also performed the FD
+        # redirect); kept here so getopts accepts the flag and direct unit
+        # calls remain honest.
+        FLAG_QUIET=true
+      ;;
       \? )
         fail 2 \
           "Invalid option: -$OPTARG" \
@@ -410,4 +456,22 @@ process-arguments() {
       ;;
     esac
   done
+
+  # --quiet and interactive prompts are incompatible by construction — a
+  # hidden prompt is a hung pipeline (R-OUT-2). Fail fast at parse time
+  # rather than mid-release. FLAG_CHANGELOG_PAUSE is checked here (not in
+  # the -l getopts case) so a .ver-bumprc-set pause is caught too — the rc
+  # was already sourced by load-config before process-arguments ran.
+  if [ "$FLAG_QUIET" = true ]; then
+    if [ "${FLAG_CHANGELOG_PAUSE:-false}" = true ]; then
+      fail 2 \
+        "--quiet is incompatible with -l/--pause-changelog (an interactive pause would hang a captured pipeline)." \
+        "Drop -l/--pause-changelog (or unset FLAG_CHANGELOG_PAUSE in .ver-bumprc), or drop --quiet."
+    fi
+    if [ "${FLAG_YES:-false}" != true ] && [ -z "${V_USR_SUPPLIED-}" ] && [ -z "${BUMP_LEVEL-}" ]; then
+      fail 2 \
+        "--quiet would hide the interactive version prompt (a hidden prompt is a hung pipeline)." \
+        "Add --yes to accept the suggested version, pass -v <version>, or force a level with --major/--minor/--patch."
+    fi
+  fi
 }

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -149,10 +149,10 @@ _ver_bump() {
 
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
-          --yes --undo --branch --pr --base --major --minor --patch --release \
+          --yes --quiet --undo --branch --pr --base --major --minor --patch --release \
           --allow-dirty --allow-empty --no-fetch \
           --help --completions --install-completions --about \
-          -v -m -f -p -t -B -d -n -b -c -l -y -h"
+          -v -m -f -p -t -B -d -n -b -c -l -y -q -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 complete -F _ver_bump ver-bump
@@ -181,6 +181,7 @@ _ver_bump() {
     '(-l --pause-changelog)'{-l,--pause-changelog}'[pause before commit]' \
     '(-h --help)'{-h,--help}'[show help]' \
     '(-y --yes)'{-y,--yes}'[skip interactive confirmation prompts]' \
+    '(-q --quiet)'{-q,--quiet}'[suppress decoration; print only the new version on stdout]' \
     '--undo[locally delete release branch + tag for <version>]::version:' \
     '--branch[cut a release-x.x.x branch (else tag in place)]' \
     '--pr[branch + push + open a release PR via gh]' \
@@ -218,6 +219,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd -s l -l pause-changelog -d 'Pause before commit'
     complete -c $_cmd -s h -l help           -d 'Show help'
     complete -c $_cmd -s y -l yes            -d 'Skip interactive confirmation prompts'
+    complete -c $_cmd -s q -l quiet          -d 'Suppress decoration; print only the new version on stdout'
     complete -c $_cmd      -l undo           -d 'Locally delete release branch + tag for <version>'
     complete -c $_cmd      -l branch         -d 'Cut a release-x.x.x branch (else tag in place)'
     complete -c $_cmd      -l pr             -d 'Branch + push + open a release PR via gh'

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -119,6 +119,7 @@ usage() {
   print-opt-row "-l" "--pause-changelog" ""          "Pause before commit so CHANGELOG.md can be edited."
   print-opt-row "-h" "--help"          ""            "Show this help message."
   print-opt-row "-y" "--yes"           ""            "Skip interactive confirmation prompts."
+  print-opt-row "-q" "--quiet"         ""            "Suppress decoration; print only the new version on stdout (needs -y, -v, or a level)."
   print-opt-row ""   "--undo"          "[<version>]" "Locally delete release-X.Y.Z + tag vX.Y.Z (refuses if pushed/dirty)."
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."

--- a/test/quiet.bats
+++ b/test/quiet.bats
@@ -1,0 +1,270 @@
+#!/usr/bin/env bats
+
+# -q/--quiet (R-OUT-1..4, issue #65): machine-readable stdout for CI.
+# On success stdout carries exactly one line — the new version, bare —
+# and everything decorative is rerouted to stderr, so
+# NEW_VERSION=$(ver-bump --yes --quiet …) captures cleanly. Quiet and
+# interactive prompts are incompatible by construction (a hidden prompt
+# is a hung pipeline): missing --yes/-v/level, or -l/--pause-changelog,
+# exits 2 at parse time. A quiet no-op (R-SAFE-14) prints nothing on
+# stdout and exits 0, so [ -z "$out" ] is the "no release happened" test.
+
+load 'test_helper'
+
+# Scratch repo whose package.json version is already tagged, plus one
+# feat: commit — a releasable state where the conventional-commits
+# suggestion is a minor bump (1.2.3 -> 1.3.0).
+releasable_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: bumped to 1.2.3"
+  git tag -a v1.2.3 -m "v1.2.3"
+  git commit -q --allow-empty -m "feat: something new"
+}
+
+# Same, but with zero commits since the tag — the no-op state (#60).
+released_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: bumped to 1.2.3"
+  git tag -a v1.2.3 -m "v1.2.3"
+}
+
+# ── R-OUT-1: success prints exactly the bare version on stdout ─────────────
+
+@test "quiet: --quiet --yes success -> stdout is byte-exactly 'X.Y.Z\\n' (R-OUT-1)" {
+  releasable_repo
+
+  # -n -c keeps the run prompt-free after the version step (no push, no
+  # changelog); the suggestion path itself is what --yes vouches for.
+  run bash -c '"$1" --quiet --yes -n -c >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  printf '1.3.0\n' > "$BATS_TEST_TMPDIR/want"
+  run cmp "$BATS_TEST_TMPDIR/out" "$BATS_TEST_TMPDIR/want"
+  assert_success
+
+  # Decoration is rerouted to stderr, not dropped — the run still tells
+  # its story where a human (or a CI log) can see it.
+  run grep -c "Bumped version" "$BATS_TEST_TMPDIR/err"
+  assert_output "1"
+}
+
+@test "quiet: -q clusters with other short flags (-yqnc)" {
+  releasable_repo
+
+  run bash -c '"$1" -yqnc >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "1.3.0"
+}
+
+@test "quiet: no colour codes on stdout even when colour is forced (R-OUT-1)" {
+  releasable_repo
+
+  CLICOLOR_FORCE=1 run bash -c '"$1" --quiet --yes -n -c >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  printf '1.3.0\n' > "$BATS_TEST_TMPDIR/want"
+  run cmp "$BATS_TEST_TMPDIR/out" "$BATS_TEST_TMPDIR/want"
+  assert_success
+}
+
+@test "quiet: --quiet --major prints the forced-bump version (R-OUT-1)" {
+  releasable_repo
+
+  run bash -c '"$1" --quiet --major -d -c -p origin >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "2.0.0"
+}
+
+# ── R-OUT-2: quiet + prompts exit 2 at parse time ───────────────────────────
+
+@test "quiet: --quiet without --yes/-v/level -> exit 2 naming the fix (R-OUT-2)" {
+  releasable_repo
+
+  run ${profile_script} --quiet
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "hidden prompt is a hung pipeline"
+  assert_output --partial "--yes"
+  assert_output --partial "--major/--minor/--patch"
+}
+
+@test "quiet: --quiet -l -> exit 2 even with --yes (R-OUT-2)" {
+  releasable_repo
+
+  run ${profile_script} --quiet --yes -l
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "pause-changelog"
+}
+
+@test "quiet: rc-set FLAG_CHANGELOG_PAUSE is caught too (R-OUT-2)" {
+  releasable_repo
+  printf 'FLAG_CHANGELOG_PAUSE=true\n' > .ver-bumprc
+  chmod 644 .ver-bumprc
+
+  run ${profile_script} --quiet --yes
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "pause-changelog"
+}
+
+@test "quiet: --quiet --undo without --yes -> exit 2 (R-OUT-2)" {
+  released_repo
+
+  run ${profile_script} --quiet --undo 1.2.3
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "requires --yes"
+}
+
+@test "quiet: --quiet=value is rejected as a boolean flag (R-OPT-2)" {
+  releasable_repo
+
+  run ${profile_script} --quiet=true --yes
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "doesn't take a value"
+}
+
+# ── quiet + --undo: stdout stays completely empty ───────────────────────────
+
+@test "quiet: --quiet --undo --yes undoes silently, stdout empty" {
+  released_repo
+
+  run bash -c '"$1" --quiet --undo 1.2.3 --yes >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  # No version to report for an undo — stdout is byte-empty.
+  [ ! -s "$BATS_TEST_TMPDIR/out" ]
+  # The tag really was deleted.
+  run git tag -l
+  assert_output ""
+}
+
+# ── R-OUT-3: composes with --dry-run ────────────────────────────────────────
+
+@test "quiet: --quiet --dry-run -v 1.2.4 -> stdout '1.2.4', dry-run lines on stderr only (R-OUT-3)" {
+  releasable_repo
+
+  run bash -c '"$1" --quiet --dry-run -v 1.2.4 -c -p origin >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  printf '1.2.4\n' > "$BATS_TEST_TMPDIR/want"
+  run cmp "$BATS_TEST_TMPDIR/out" "$BATS_TEST_TMPDIR/want"
+  assert_success
+
+  run grep -c "dry-run" "$BATS_TEST_TMPDIR/err"
+  refute_output "0"
+  run grep -c "dry-run" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+
+  # Dry-run really was dry: no tag, no file change.
+  run git tag -l
+  assert_output "v1.2.3"
+  run jq -r '.version' package.json
+  assert_output "1.2.3"
+}
+
+# ── failure path: empty stdout, error on stderr, contract exit code ────────
+
+@test "quiet: dirty-tree preflight -> exit 3, empty stdout, error on stderr" {
+  releasable_repo
+  echo "dirty" >> package.json
+
+  run bash -c '"$1" --quiet --yes -v 1.2.4 >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_failure 3
+  [ ! -s "$BATS_TEST_TMPDIR/out" ]
+  run grep -c "uncommitted changes" "$BATS_TEST_TMPDIR/err"
+  assert_output "1"
+}
+
+# ── R-OUT-4: quiet no-op prints nothing on stdout, exits 0 ─────────────────
+
+@test "quiet: no-op run -> exit 0, stdout completely empty (R-OUT-4)" {
+  released_repo
+
+  run bash -c '"$1" --quiet --yes -v 1.2.4 >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  # [ -z "$out" ] is the documented CI branch test — the no-release token
+  # is rerouted with the rest of the decoration (R-SAFE-15 keeps it on
+  # stdout only for non-quiet runs).
+  [ ! -s "$BATS_TEST_TMPDIR/out" ]
+  run grep -c "^no-release" "$BATS_TEST_TMPDIR/err"
+  assert_output "1"
+}
+
+# ── regression pins: non-quiet output is unchanged ──────────────────────────
+
+@test "quiet: without --quiet, decoration and the no-release token stay on stdout" {
+  released_repo
+
+  # Success-path decoration on stdout (dry-run side-effects on stderr).
+  git commit -q --allow-empty -m "feat: something new"
+  run bash -c '"$1" -d -c -p origin -v 1.2.4 >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep -c "Option set" "$BATS_TEST_TMPDIR/out"
+  assert_output "3"
+  # And no stray bare-version machine line was added to non-quiet runs:
+  # stdout has no line that is exactly the version.
+  run grep -cx "1.2.4" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+}
+
+@test "quiet: FLAG_QUIET is CLI-only — a .ver-bumprc key cannot hide output" {
+  releasable_repo
+  printf 'FLAG_QUIET=true\n' > .ver-bumprc
+  chmod 644 .ver-bumprc
+
+  run bash -c '"$1" -d -c -p origin -v 1.2.4 >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  # Decoration still on stdout: the rc key was reset in process-arguments.
+  run grep -c "Option set" "$BATS_TEST_TMPDIR/out"
+  assert_output "3"
+}
+
+@test "quiet: env FLAG_QUIET cannot hide output either (CLI-only reset)" {
+  releasable_repo
+
+  FLAG_QUIET=true run bash -c '"$1" -d -c -p origin -v 1.2.4 >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep -c "Option set" "$BATS_TEST_TMPDIR/out"
+  assert_output "3"
+}
+
+# ── surface parity ───────────────────────────────────────────────────────────
+
+@test "quiet: --help lists -q/--quiet" {
+  run bash -c 'get_help_msg() { "$1" -h 2>&1; }; get_help_msg "$1"' _ "${profile_script}"
+  assert_success
+  strip_ansi_output
+  assert_output --partial "--quiet"
+}
+
+@test "quiet: completions list --quiet in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--quiet"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--quiet"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l quiet"
+}

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -47,6 +47,7 @@ VER_FILE="package.json"
 GIT_MSG=""
 REL_NOTE=""
 FLAG_DRYRUN=false
+FLAG_QUIET=false # -q/--quiet: decoration to stderr, bare new version on stdout (R-OUT-1). CLI-only; reset in process-arguments.
 
 # Config-keyed defaults use `:=` so exported env values survive. An
 # unconditional assignment (e.g. `TAG_PREFIX="v"`) would clobber
@@ -102,6 +103,16 @@ main() {
   section "Done"
   log_success "$( capitalise "$( get-commit-msg )" )"
   echo
+
+  # Machine-readable success line (R-OUT-1): under --quiet, FD 3 is the real
+  # stdout saved by process-arguments (everything else was rerouted to
+  # stderr), and it receives exactly one line — the new version, bare: no
+  # tag prefix, no colour. A no-op run never reaches this point
+  # (check-releasable-commits exits 0 first), so quiet stdout stays empty
+  # for "no release happened" (R-OUT-4).
+  if [ "$FLAG_QUIET" = true ]; then
+    printf '%s\n' "$V_NEW" >&3
+  fi
 }
 
 # Execute script when it is executed as a script, and when it is brought into the environment with source (so it can be tested)


### PR DESCRIPTION
Implements the R-OUT bucket from #65: a quiet mode that makes
`NEW_VERSION=$(ver-bump --yes --quiet -p origin)` the canonical CI capture
pattern — the missing half of the machine contract R-EXIT started.

Refs #65. Interacts with the #60 no-op detection (PR #77): a quiet no-op
keeps stdout **byte-empty** (the `no-release` token is rerouted with the
rest of the decoration) and exits 0, so `[ -z "$out" ]` is the CI branch
test for "no release happened".

## Design: one redirect, not a renderer

`process-arguments` pre-scans argv for `-q`/`--quiet` (after long-opt
normalization, so `--quiet` is already `-q` and clustered shorts like
`-yq` match), then runs `exec 3>&1 1>&2` **before** getopts: FD 3 keeps
the real stdout for the single bare-version line `main()` prints at the
end; every other byte — `log_*`, `section` pills, `Option set:` echoes,
prompts, dry-run previews — lands on stderr. Rationale:

- One `exec` beats guarding every `log_*`/bare-`echo` call site: no
  decoration line, current or future, can ever leak into the captured
  pipeline (`lib/ui.sh` needed zero changes).
- Rerouted, not swallowed: warnings (e.g. a best-effort push failure) and
  progress stay visible on stderr / in CI logs instead of vanishing.
- The exiting pre-scanned modes (`--about`, bare `--version`,
  `--completions`, `--install-completions`) run before the redirect, so
  their already-clean stdout contracts are untouched.

`FLAG_QUIET` is **CLI-only** — reset in `process-arguments` like
`BUMP_LEVEL`/`ALLOW_EMPTY`/`DO_RELEASE`, never a `.ver-bumprc` key: a
hidden-output mode must be an explicit per-invocation choice, same
rationale as `FLAG_YES` (R-YES-3). Pinned by tests for both the rc-key
and env-var smuggling paths.

## R-OUT coverage

- **R-OUT-1** — success stdout is byte-exactly `X.Y.Z\n`: no tag prefix,
  no colour (asserted with `cmp`, including under `CLICOLOR_FORCE=1`);
  errors keep going to stderr with the contract exit codes.
- **R-OUT-2** — quiet + prompts are incompatible by construction:
  `--quiet` without `--yes`/`-v`/`--major|--minor|--patch` exits 2 naming
  the fix; `--quiet` + `-l`/`--pause-changelog` exits 2 (checked after the
  rc is loaded, so an rc-set `FLAG_CHANGELOG_PAUSE` is caught too);
  `--quiet --undo` without `--yes` exits 2.
- **R-OUT-3** — composes with `--dry-run`: stdout gets the would-be
  version; `[dry-run]` lines already target stderr (R-DRY-2), pinned.
- **R-OUT-4** — quiet no-op: exit 0, stdout completely empty.

**Scope choice for `--undo`** (documented in the requirements doc): quiet
undo requires `--yes` and prints **nothing** to stdout — an undo has no
new version to report, so its quiet contract is simply "empty stdout,
decoration on stderr, contract exit codes".

**Known pre-scan trade-off** (same as the existing `--undo`/-d/-y
pre-scans, commented in code): an option *value* that begins with `-` and
contains `q` (e.g. `-m "-quote"`) false-positives the quiet scan.

## Test plan

Before: styled log lines on stdout forced CI to re-derive the version
with `jq` after the run; `--quiet` was an unknown option (exit 2).

After — `test/quiet.bats`, 18 new cases (see R-OUT mapping above), plus
regression pins that non-quiet output is unchanged (decoration and the
`no-release` token stay on stdout; no stray bare-version line is added).
Help/README parity is enforced by the existing `args.bats` parity test;
`--quiet` added to all three completion emitters and checked by
`completions-syntax.bats`.

- `pnpm lint`: clean
- `pnpm tests:run`: 365/365 (347 existing + 18 new), zero failures