### PR TITLE
feat(hooks): PRE_BUMP_CMD / POST_TAG_CMD release hooks (exit code 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It does several things that are typically required for releasing a Git repositor
   - [Config file (`.ver-bumprc`)](#config-file-ver-bumprc)
   - [Version suggestion](#version-suggestion)
   - [Dry-run](#dry-run)
+  - [Release hooks](#release-hooks)
   - [Exit codes](#exit-codes)
 - [Shell completions](#shell-completions)
 - [Example](#example)
@@ -253,7 +254,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
            [--branch] [--pr] [--base <branch>] \
-           [--allow-dirty] [--allow-empty] [--no-fetch] \
+           [--allow-dirty] [--allow-empty] [--no-fetch] [--no-hooks] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
@@ -289,6 +290,8 @@ Supported keys (each maps 1:1 to an existing global):
 | `ALLOW_DIRTY` | `--allow-dirty` | *unset* (dirty tree refuses) |
 | `NO_FETCH` | `--no-fetch` | *unset* (fetch + behind-upstream check) |
 | `RELEASE_BRANCHES` | *(no flag)* | *unset* (release from any branch) |
+| `PRE_BUMP_CMD` | *(no flag — see [Release hooks](#release-hooks))* | *unset* (no hook) |
+| `POST_TAG_CMD` | *(no flag — see [Release hooks](#release-hooks))* | *unset* (no hook) |
 
 Example:
 
@@ -397,6 +400,9 @@ output stays byte-identical to previous releases.
                               --tags' and no behind-upstream check before releasing.
                               Remote-only tag collisions then surface at push time
                               instead. Also available as the NO_FETCH config/env key.
+    --no-hooks                Skip the PRE_BUMP_CMD / POST_TAG_CMD release hooks for
+                              this run (like git's --no-verify). CLI-only — there is
+                              no env or .ver-bumprc equivalent.
     --branch                  Cut a release-<version> branch (the pre-2.0 default).
                               Otherwise ver-bump tags the current branch in place.
     --pr                      Create the release branch, push it, then open a pull
@@ -467,6 +473,54 @@ $ ver-bump --dry-run
 Combine with `--no-branch` / `--no-commit` / `--no-changelog` to narrow the
 preview down to just the steps you want to see.
 
+### Release hooks
+
+Two hook points cover the common "run my tests before tagging" and "build an
+artifact after tagging" cases. Each is a single command string, run via
+`bash -c`, set as an environment variable or a `.ver-bumprc` key (same
+[precedence](#config-file-ver-bumprc) as every other key — there is
+deliberately no CLI flag to set them):
+
+| Key | Runs | On non-zero exit |
+| --- | --- | --- |
+| `PRE_BUMP_CMD` | after **all** Verify preflights pass, before any file is touched | exit `4`, nothing mutated |
+| `POST_TAG_CMD` | after the tag is created, before push / `--pr` / `--release` | exit `4`; the commit + tag are kept — recover with `--undo` |
+
+```sh
+# .ver-bumprc
+PRE_BUMP_CMD="npm test"
+POST_TAG_CMD="npm run build:artifacts"
+```
+
+Hook stdout/stderr stream straight through to your terminal, and the resolved
+command is logged before it runs. Each hook sees the release context in its
+environment:
+
+| Variable | Value |
+| --- | --- |
+| `VER_BUMP_VERSION` | the new version (e.g. `1.3.0`) |
+| `VER_BUMP_PREV_VERSION` | the previous version (e.g. `1.2.3`) |
+| `VER_BUMP_TAG` | the full tag name (e.g. `v1.3.0`) |
+
+**Quoting:** `.ver-bumprc` is shell-sourced, so **single-quote** hook strings
+that reference these variables — a double-quoted `"echo $VER_BUMP_TAG"`
+expands at config-load time (while the variables are still empty), whereas
+`'echo $VER_BUMP_TAG'` defers expansion until the hook runs:
+
+```sh
+POST_TAG_CMD='echo "released $VER_BUMP_TAG" >> releases.log'
+```
+
+Under `--dry-run` the hook command is printed with the `[dry-run]` prefix and
+not executed. Pass `--no-hooks` to skip both hooks for a single run (git's
+`--no-verify` convention); to disable just one hook for a run, empty the key
+instead — env beats the file: `PRE_BUMP_CMD= ver-bump …`
+
+> **Migrating from 1.x:** ver-bump 2.0 no longer shells out to `npm version`,
+> so npm's `preversion` / `version` / `postversion` lifecycle scripts stopped
+> firing as a side-effect. If you relied on `preversion` to run your tests,
+> one `.ver-bumprc` line restores it: `PRE_BUMP_CMD="npm test"`.
+
 ### Exit codes
 
 | Code | Meaning |
@@ -475,7 +529,7 @@ preview down to just the steps you want to see.
 | `1` | Generic runtime error (failed commit, jq write error, etc.). |
 | `2` | Usage / argument-parse error (unknown flag, missing value). |
 | `3` | Precondition failure (missing `package.json`, missing `git`/`jq`, SemVer validation, insecure `.ver-bumprc`, branch/tag already exists). |
-| `4` | Hook failure (reserved for future use). |
+| `4` | Hook failure — `PRE_BUMP_CMD` or `POST_TAG_CMD` exited non-zero (see [Release hooks](#release-hooks)). |
 | `5` | User abort (declined a prompt, e.g. push confirmation). |
 
 ## Shell completions

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -90,7 +90,7 @@ Canonical table (from `fail` in [lib/errors.sh](../lib/errors.sh)):
 | 1    | generic error                                                           |
 | 2    | usage / arg-parse error                                                 |
 | 3    | precondition (dirty tree, missing tag, SemVer parse, missing dep, …)    |
-| 4    | hook failure (reserved)                                                 |
+| 4    | hook failure (`PRE_BUMP_CMD` / `POST_TAG_CMD` exited non-zero)          |
 | 5    | user abort (declined prompt)                                            |
 
 Always exit via `fail <code> "<message>" "<hint>"`. The hint is optional

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -102,7 +102,7 @@ real script (not just dry-run) without touching their working repo.
 - **Not a CHANGELOG rewriter.** The existing `git log` dump is preserved as-is. A grouped, conventional-commit-aware changelog is scope for a later release.
 - **Not a monorepo release manager.** One tool, one `package.json`, one bump. `-f` remains a secondary knob.
 - **Not an npm publisher.** Registry publishing stays in the user's CI. (GitHub-release creation *did* land in 2.0, behind the opt-in `--release` flag — see §5.8; it is off by default and adds no default-path dependencies.)
-- **No plugin/hook system** in this release (exit code `4` is reserved for it as a forward-compat signal).
+- **No plugin/hook system** in this release (exit code `4` is reserved for it as a forward-compat signal). *Post-2.0, issue #62 claimed the reserved code for a deliberately minimal two-hook surface — `PRE_BUMP_CMD` / `POST_TAG_CMD` (R-HOOK-1..6, [`docs/features/hooks`](features/hooks/requirements.md)) — which stays short of a plugin system.*
 
 ---
 
@@ -177,7 +177,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | `1`  | Generic / unexpected error |
 | `2`  | Usage or argument-parse error (bad/unknown flag, bad value) |
 | `3`  | Precondition failure (missing `git`/`jq`, no `package.json`, dirty tree, missing tag, SemVer parse failure) |
-| `4`  | Hook failure — **reserved** for user-supplied release hooks (future) |
+| `4`  | Hook failure — a user-supplied release hook (`PRE_BUMP_CMD` / `POST_TAG_CMD`) exited non-zero (R-HOOK-1/2, [`docs/features/hooks`](features/hooks/requirements.md)) |
 | `5`  | User abort (declined an interactive prompt) |
 
 | ID | Requirement |
@@ -221,7 +221,7 @@ Each requirement has an ID so tests and PRs can reference it.
 | ID | Requirement |
 | --- | --- |
 | **R-CFG-1** | `.ver-bumprc` is discovered by walking up from `$PWD` to `/`. First match wins; absence is not an error. |
-| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, `NO_FETCH`, `RELEASE_BRANCHES`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
+| **R-CFG-2** | Supported keys: `TAG_PREFIX`, `REL_PREFIX`, `PUSH_DEST`, `COMMIT_MSG_PREFIX`, `CHANGELOG_STYLE`, `FLAG_BRANCH`, `PR_BASE`, `FLAG_NOCHANGELOG`, `FLAG_CHANGELOG_PAUSE`, `ALLOW_DIRTY`, `NO_FETCH`, `RELEASE_BRANCHES`, `PRE_BUMP_CMD`, `POST_TAG_CMD`, plus deprecated `FLAG_NOBRANCH` (back-compat; superseded by `FLAG_BRANCH`). Only these participate in the precedence contract (R-CFG-3); other assignments in the file execute as plain shell (R-CFG-5) but are unsupported and carry no precedence or compatibility guarantee. |
 | **R-CFG-3** | Precedence end-to-end: CLI > environment > `.ver-bumprc` > built-in default. |
 | **R-CFG-4** | `.ver-bumprc` is refused (exit `3`) if world-writable, group-writable, or not owned by the invoking user. |
 | **R-CFG-5** | `.ver-bumprc` is shell-sourced, not parsed. Failures in sourcing exit `3` with the shell error as context. |
@@ -292,7 +292,7 @@ Each requirement has an ID so tests and PRs can reference it.
 
 - **B-1 — `-v` rejects non-SemVer.** Existing calls like `-v banana` will fail with exit `2`. This was never guaranteed; old behaviour tagged a corrupt version. **Migration**: fix the input.
 - **B-2 — Exit codes change.** `1.1.x` used `exit 1` for nearly every error. `2.0.0` uses `2`/`3`/`5` for usage, precondition, and user-abort failures. **Migration**: CI wrappers that branched on exit code `0` vs. non-zero are unaffected; wrappers that branched on specific non-zero codes must update.
-- **B-3 — `npm` no longer invoked.** `npm version`'s lifecycle scripts (`preversion`, `version`, `postversion`) will no longer fire as a side-effect of running `ver-bump`. **Migration**: if you relied on them, invoke them explicitly or move the logic into a separate step.
+- **B-3 — `npm` no longer invoked.** `npm version`'s lifecycle scripts (`preversion`, `version`, `postversion`) will no longer fire as a side-effect of running `ver-bump`. **Migration**: if you relied on them, invoke them explicitly or move the logic into a separate step. *Post-2.0, the release hooks (issue #62) close the common case: `PRE_BUMP_CMD="npm test"` in `.ver-bumprc` restores a `preversion`-style test gate — see [`docs/features/hooks`](features/hooks/requirements.md).*
 - **B-4 — bare `-v` / `--version` prints the tool version.** In `1.1.x`, `-v` without a value was an argument-parse error. In `2.0.0` it prints `ver-bump <ver>` and exits `0` (matching every modern CLI). With a value, `-v <semver>` keeps its `1.1.x` meaning. **Migration**: none expected — no working `1.1.x` invocation relied on the error.
 - **B-5 — tag-in-place is the new default workflow.** `1.1.x` always cut a `release-<version>` branch; `2.0.0` commits and tags the current branch in place (§5.14, ADR-12). `-b`/`--no-branch` becomes a no-op. **Migration**: pass `--branch` per run, or set `FLAG_BRANCH=true` in `.ver-bumprc` to keep the old behaviour as a team default.
 
@@ -355,7 +355,7 @@ All resolved for 2.0:
 ## 13. Future work (post-2.0)
 
 - **Grouped CHANGELOG** from Conventional Commits (the other major friction point vs. modern tools). *Shipped post-2.0 as opt-in `CHANGELOG_STYLE=grouped` (issue #61; R-CHLOG-1..5 in [docs/features/changelog/requirements.md](features/changelog/requirements.md)); the flat default is unchanged — flipping it is a 3.0 decision.*
-- **Hook system** (exit code `4` is reserved): `pre-bump`, `post-tag`, `post-push`.
+- **Hook system** (exit code `4` is reserved): `pre-bump`, `post-tag`, `post-push`. *`pre-bump` and `post-tag` shipped post-2.0 as `PRE_BUMP_CMD` / `POST_TAG_CMD` (issue #62; R-HOOK-1..6 in [docs/features/hooks/requirements.md](features/hooks/requirements.md)), claiming exit code `4`. `post-push` remains future work.*
 - **Non-npm install paths** — Homebrew formula (deferred from 2.0; issue [#24](https://github.com/jv-k/ver-bump/issues/24)), `basher` ([#39](https://github.com/jv-k/ver-bump/issues/39)).
 - **GitHub Packages publishing docs** ([#40](https://github.com/jv-k/ver-bump/issues/40)).
 
@@ -387,6 +387,7 @@ Exactly the flags shipping in `2.0.0`:
 | — | `--allow-dirty` | | Skip the clean-working-tree preflight (R-SAFE-2, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
 | — | `--allow-empty` | | Release even with no new commits since the previous tag (R-SAFE-16) |
 | — | `--no-fetch` | | Skip the remote-sync preflight (R-SAFE-8, [`docs/features/safety-preflights`](./features/safety-preflights/requirements.md)) |
+| — | `--no-hooks` | | Skip the `PRE_BUMP_CMD` / `POST_TAG_CMD` release hooks (R-HOOK-5, [`docs/features/hooks`](./features/hooks/requirements.md)) |
 | — | `--branch` | | Cut a `release-<version>` branch (pre-2.0 default) instead of tagging in place (§5.14) |
 | — | `--pr` | | Branch + push + open a release PR via `gh`; implies push to `origin` (§5.14) |
 | — | `--base` | ✓ | Base branch for `--pr` (default: resolution chain in R-FLOW-2) |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -102,7 +102,7 @@ real script (not just dry-run) without touching their working repo.
 - **Not a CHANGELOG rewriter.** The existing `git log` dump is preserved as-is. A grouped, conventional-commit-aware changelog is scope for a later release.
 - **Not a monorepo release manager.** One tool, one `package.json`, one bump. `-f` remains a secondary knob.
 - **Not an npm publisher.** Registry publishing stays in the user's CI. (GitHub-release creation *did* land in 2.0, behind the opt-in `--release` flag — see §5.8; it is off by default and adds no default-path dependencies.)
-- **No plugin/hook system** in this release (exit code `4` is reserved for it as a forward-compat signal). *Post-2.0, issue #62 claimed the reserved code for a deliberately minimal two-hook surface — `PRE_BUMP_CMD` / `POST_TAG_CMD` (R-HOOK-1..6, [`docs/features/hooks`](features/hooks/requirements.md)) — which stays short of a plugin system.*
+- **No plugin system** in this release. *Post-2.0, issue #62 added a deliberately minimal two-hook surface — `PRE_BUMP_CMD` / `POST_TAG_CMD` (R-HOOK-1..6, [`docs/features/hooks`](features/hooks/requirements.md)) — which stays short of a plugin system; exit code `4`, previously reserved, is now in use for hook failures.*
 
 ---
 
@@ -355,7 +355,7 @@ All resolved for 2.0:
 ## 13. Future work (post-2.0)
 
 - **Grouped CHANGELOG** from Conventional Commits (the other major friction point vs. modern tools). *Shipped post-2.0 as opt-in `CHANGELOG_STYLE=grouped` (issue #61; R-CHLOG-1..5 in [docs/features/changelog/requirements.md](features/changelog/requirements.md)); the flat default is unchanged — flipping it is a 3.0 decision.*
-- **Hook system** (exit code `4` is reserved): `pre-bump`, `post-tag`, `post-push`. *`pre-bump` and `post-tag` shipped post-2.0 as `PRE_BUMP_CMD` / `POST_TAG_CMD` (issue #62; R-HOOK-1..6 in [docs/features/hooks/requirements.md](features/hooks/requirements.md)), claiming exit code `4`. `post-push` remains future work.*
+- **Hook system** — a `post-push` hook remains future work. *`pre-bump` and `post-tag` shipped post-2.0 as `PRE_BUMP_CMD` / `POST_TAG_CMD` (issue #62; R-HOOK-1..6 in [docs/features/hooks/requirements.md](features/hooks/requirements.md)) and now use exit code `4` for hook failures — it is no longer reserved.*
 - **Non-npm install paths** — Homebrew formula (deferred from 2.0; issue [#24](https://github.com/jv-k/ver-bump/issues/24)), `basher` ([#39](https://github.com/jv-k/ver-bump/issues/39)).
 - **GitHub Packages publishing docs** ([#40](https://github.com/jv-k/ver-bump/issues/40)).
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [github-release](./github-release/requirements.md) | R-REL | `release.bats` |
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
 | [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats` |
+| [hooks](./hooks/requirements.md) | R-HOOK | `hooks.bats`, `args.bats` |
 | [ui-output](./ui-output/requirements.md) | R-UI | `ui.bats`, `color.bats`, `about.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |

--- a/docs/features/hooks/requirements.md
+++ b/docs/features/hooks/requirements.md
@@ -1,0 +1,33 @@
+# Release hooks
+
+Two user-supplied hook points — `PRE_BUMP_CMD` and `POST_TAG_CMD` — around
+the mutation phase of a release ([#62](https://github.com/jv-k/ver-bump/issues/62)).
+Deliberately minimal: a plugin system stays a non-goal (PRD §3.1). Hook
+failures are the first (and only) user of exit code `4`, reserved for exactly
+this since the exit-code contract landed (PRD §5.6) — the frozen 2.x contract
+(R-EXIT-2) is untouched because the code's meaning was published in 2.0.0.
+
+Closes the B-3 migration gap: 1.x users who relied on npm's `preversion`
+lifecycle running their tests migrate with one `.ver-bumprc` line:
+`PRE_BUMP_CMD="npm test"`.
+
+| ID | Requirement | Status | Tests |
+| --- | --- | --- | --- |
+| R-HOOK-1 | `PRE_BUMP_CMD`: run via `bash -c` after **all** Verify preflights pass and **before any file mutation**. Non-zero → exit `4`, nothing mutated (working tree porcelain-clean, no tag, no commit). | ✅ `run-pre-bump-hook` | `hooks.bats` |
+| R-HOOK-2 | `POST_TAG_CMD`: run after tag creation, before push / `--pr` / `--release`. Non-zero → exit `4`; the created commit + tag are left in place and the failure copy points at `--undo` for recovery. Skipped under `-n`/`--no-commit` (no tag was created — mirrors `do-tag`). | ✅ `run-post-tag-hook` | `hooks.bats` |
+| R-HOOK-3 | Keys come from the environment or `.ver-bumprc` only (same trust domain — the rc is already shell-sourced behind the R-CFG-4 permission checks). Precedence per R-CFG-3 (env beats rc). No CLI flag to *set* a hook. Unset/empty = no hook, zero behaviour change (regression-pinned). | ✅ `lib/config.sh` (`_CONFIG_KEYS`) | `hooks.bats` |
+| R-HOOK-4 | Hook stdout/stderr stream through to the user (not captured); the resolved command is logged before running. Under `--dry-run` the command is printed to stderr with the `[dry-run]` prefix (R-DRY-2) and **not** executed. | ✅ `_run-hook` | `hooks.bats` |
+| R-HOOK-5 | `--no-hooks` (boolean, long-only) skips both — parity with git's `--no-verify` escape hatch. CLI-only, reset in `process-arguments` (R-CFG-6 pattern): an rc/env assignment must never silently disable hooks; the one-shot single-hook bypass is emptying the key (`PRE_BUMP_CMD= ver-bump …`). | ✅ | `hooks.bats`, `args.bats` |
+| R-HOOK-6 | Hooks receive `VER_BUMP_VERSION` (new version), `VER_BUMP_PREV_VERSION` (previous version), and `VER_BUMP_TAG` (full tag name, `TAG_PREFIX` + version) in their environment. Exported for the child process only. Rc-defined hooks must single-quote references to these vars (the rc is shell-sourced, so double quotes expand at load time while they are still empty) — documented in the README and pinned by test. | ✅ `_run-hook` | `hooks.bats` |
+
+Modules: `lib/hooks.sh` (`run-pre-bump-hook`, `run-post-tag-hook`,
+`_run-hook`), `lib/args.sh` (`--no-hooks`), `lib/config.sh` (keys),
+`lib/errors.sh` (exit-code table wording), `lib/usage.sh`,
+`lib/completions.sh`.
+
+Call sites in `main()` (`ver-bump.sh`): `run-pre-bump-hook` opens the Release
+section — after the entire Verify section (so `process-version` has resolved
+`V_NEW`/`V_PREV` and every preflight has passed) and immediately before
+`do-packagefile-bump`, the first mutation. `run-post-tag-hook` sits between
+`do-tag` and `do-push`, so a failing hook stops the release before anything
+leaves the machine.

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -212,6 +212,20 @@ normalize-long-opts() {
         "Drop the '=<value>' — --no-fetch is a boolean flag."
     fi
 
+    # --no-hooks — long-only boolean: skip both release hooks (PRE_BUMP_CMD /
+    # POST_TAG_CMD) for this run (R-HOOK-5) — git's --no-verify convention.
+    # CLI-only like --allow-empty (reset in process-arguments): an rc or env
+    # assignment must never silently disable hooks the team relies on. The
+    # one-shot env bypass is emptying the key itself (PRE_BUMP_CMD= ver-bump …).
+    if [ "$arg" = "--no-hooks" ]; then
+      FLAG_NOHOOKS=true
+      continue
+    elif [[ "$arg" == "--no-hooks="* ]]; then
+      fail 2 \
+        "Option --no-hooks doesn't take a value." \
+        "Drop the '=<value>' — --no-hooks is a boolean flag."
+    fi
+
     # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
     # value flag (no short form), captured here like --undo so it needs no getopts slot.
     if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then
@@ -316,15 +330,17 @@ normalize-long-opts() {
 process-arguments() {
   local OPTIONS OPTIND OPTARG
 
-  # DO_RELEASE, BUMP_LEVEL, and ALLOW_EMPTY are CLI-only switches with no
-  # env / .ver-bumprc contract. Reset them before parsing so an inherited
-  # exported var — or a .ver-bumprc assignment (load-config sources the rc as
-  # raw shell) — can't silently force a bump, publish a release, or push an
-  # empty release with no flag on the command line.
+  # DO_RELEASE, BUMP_LEVEL, ALLOW_EMPTY, and FLAG_NOHOOKS are CLI-only
+  # switches with no env / .ver-bumprc contract. Reset them before parsing so
+  # an inherited exported var — or a .ver-bumprc assignment (load-config
+  # sources the rc as raw shell) — can't silently force a bump, publish a
+  # release, push an empty release, or disable the release hooks with no flag
+  # on the command line.
   DO_RELEASE=false
   DO_PR=false
   BUMP_LEVEL=
   ALLOW_EMPTY=false
+  FLAG_NOHOOKS=false
 
   normalize-long-opts "$@"
   set -- ${NORMALIZED_ARGV[@]+"${NORMALIZED_ARGV[@]}"}

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -150,7 +150,7 @@ _ver_bump() {
     opts="--version --message --file --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
-          --allow-dirty --allow-empty --no-fetch \
+          --allow-dirty --allow-empty --no-fetch --no-hooks \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -h"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
@@ -192,6 +192,7 @@ _ver_bump() {
     '--allow-dirty[skip the clean-working-tree preflight]' \
     '--allow-empty[release even with no new commits since the previous tag]' \
     '--no-fetch[skip the remote-sync preflight]' \
+    '--no-hooks[skip the PRE_BUMP_CMD / POST_TAG_CMD release hooks]' \
     '--completions[emit completion script]:shell:(bash zsh fish)' \
     '--install-completions[install completion script for detected / specified shell]::shell:(bash zsh fish)' \
     '--about[print branded version info and exit]'
@@ -229,6 +230,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'
     complete -c $_cmd      -l allow-empty    -d 'Release even with no new commits since the previous tag'
     complete -c $_cmd      -l no-fetch       -d 'Skip the remote-sync preflight'
+    complete -c $_cmd      -l no-hooks       -d 'Skip the PRE_BUMP_CMD / POST_TAG_CMD release hooks'
     complete -c $_cmd      -l completions    -x -a 'bash zsh fish' -d 'Emit completion script'
     complete -c $_cmd      -l install-completions -a 'bash zsh fish' -d 'Install completions for detected/specified shell'
     complete -c $_cmd      -l about          -d 'Print branded version info and exit'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,6 +19,8 @@ true
 #   NO_FETCH (skip the remote-sync preflight, R-SAFE-8)
 #   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
 #                     may be cut from; empty = no guard, R-SAFE-10)
+#   PRE_BUMP_CMD (release hook before any mutation; empty = no hook, R-HOOK-1)
+#   POST_TAG_CMD (release hook after tag, before push; empty = no hook, R-HOOK-2)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
@@ -29,7 +31,8 @@ true
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
-              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES)
+              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES \
+              PRE_BUMP_CMD POST_TAG_CMD)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -123,7 +126,8 @@ load-config() {
 # Apply built-in defaults for any config key still unset after load-config.
 # FLAG_* keys and the boolean safety keys (ALLOW_DIRTY, NO_FETCH)
 # intentionally default to unset (false-equivalent under [ "$KEY" = true ]);
-# RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10).
+# RELEASE_BRANCHES defaults to unset/empty = guard off (R-SAFE-10);
+# PRE_BUMP_CMD / POST_TAG_CMD default to unset/empty = no hook (R-HOOK-1/2).
 apply-config-defaults() {
   TAG_PREFIX="${TAG_PREFIX:-v}"
   REL_PREFIX="${REL_PREFIX:-release-}"

--- a/lib/errors.sh
+++ b/lib/errors.sh
@@ -13,7 +13,7 @@ true
 #   2  usage / arg-parse error
 #   3  precondition (dirty tree, missing tag, SemVer parse failure,
 #                    missing package.json, missing dependency like git/jq)
-#   4  hook failure (reserved)
+#   4  hook failure (PRE_BUMP_CMD / POST_TAG_CMD exited non-zero, R-HOOK-1/2)
 #   5  user abort (declined prompt)
 fail() {
   local code=$1

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# shellcheck disable=SC2288
+true
+
+# Release hooks (R-HOOK-1..6, issue #62). Two fixed hook points — deliberately
+# not a plugin system (PRD §3.1):
+#
+#   PRE_BUMP_CMD  — after ALL Verify preflights pass, before any file mutation.
+#                   Non-zero → exit 4, nothing mutated.
+#   POST_TAG_CMD  — after tag creation, before push / --pr / --release.
+#                   Non-zero → exit 4; the commit + tag are kept (recover with
+#                   --undo).
+#
+# Both keys come from the environment or .ver-bumprc only (R-HOOK-3, same
+# trust domain: the rc is already shell-sourced behind the R-CFG-4 permission
+# checks). There is no CLI flag to *set* a hook; `--no-hooks` (R-HOOK-5)
+# skips both for a single run. Empty/unset key = no hook.
+
+# _run-hook <name> <cmd> — shared runner for both hook points (R-HOOK-4/6).
+#   Logs the resolved command, then runs it via `bash -c` with the release
+#   context exported for the child only:
+#     VER_BUMP_VERSION       new version (V_NEW)
+#     VER_BUMP_PREV_VERSION  previous version (V_PREV)
+#     VER_BUMP_TAG           full tag name (TAG_PREFIX + V_NEW)
+#   stdout/stderr are NOT captured — they stream through to the user, so
+#   test runners and build tools keep their progress output. Under --dry-run
+#   the command is printed with the [dry-run] prefix (stderr, R-DRY-2) and
+#   not executed. Returns the hook's exit status; callers translate non-zero
+#   into `fail 4` with hook-specific recovery copy.
+_run-hook() {
+  local name=$1 cmd=$2
+
+  if [ "${FLAG_DRYRUN:-false}" = true ]; then
+    echo -e "${S_LIGHT-}[dry-run]${RESET-} would run ${name} hook: bash -c '${cmd}'" >&2
+    return 0
+  fi
+
+  echo -e "\nRunning ${name} hook: ${S_VAL-}${cmd}${RESET-}"
+  VER_BUMP_VERSION="${V_NEW-}" \
+  VER_BUMP_PREV_VERSION="${V_PREV-}" \
+  VER_BUMP_TAG="${TAG_PREFIX-}${V_NEW-}" \
+    bash -c "$cmd"
+}
+
+# run-pre-bump-hook — PRE_BUMP_CMD (R-HOOK-1). Called from main() after the
+# entire Verify section (V_NEW/V_PREV are resolved by then) and immediately
+# before the Release section's first mutation (do-packagefile-bump), so a
+# failing hook leaves the working tree byte-identical.
+run-pre-bump-hook() {
+  [ "${FLAG_NOHOOKS:-false}" = true ] && return 0
+  [ -n "${PRE_BUMP_CMD:-}" ] || return 0
+
+  local rc=0
+  _run-hook "pre-bump" "$PRE_BUMP_CMD" || rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  fail 4 \
+    "pre-bump hook failed (exit ${rc}): ${PRE_BUMP_CMD}" \
+    "Nothing was changed. Fix the PRE_BUMP_CMD command, or skip hooks for one run with --no-hooks."
+}
+
+# run-post-tag-hook — POST_TAG_CMD (R-HOOK-2). Called from main() between
+# do-tag and do-push, so a failing hook stops the release before anything
+# leaves the machine. The bump commit + tag already exist and are
+# intentionally kept — --undo is the recovery path, and rolling back
+# automatically could destroy hook side-effects the user wants to inspect.
+run-post-tag-hook() {
+  [ "${FLAG_NOHOOKS:-false}" = true ] && return 0
+  [ -n "${POST_TAG_CMD:-}" ] || return 0
+  # Under -n / --no-commit no tag was created — nothing to hook onto
+  # (mirrors do-tag's own skip).
+  [ "${FLAG_NOCOMMIT:-false}" = true ] && return 0
+
+  local rc=0
+  _run-hook "post-tag" "$POST_TAG_CMD" || rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  fail 4 \
+    "post-tag hook failed (exit ${rc}): ${POST_TAG_CMD}" \
+    "The release commit and tag ${TAG_PREFIX-}${V_NEW-} were kept (nothing was pushed). Recover with 'ver-bump --undo ${V_NEW-}', or fix the hook and push manually."
+}

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -126,6 +126,7 @@ usage() {
   print-opt-row ""   "--allow-dirty"        ""            "Skip the clean-working-tree check (untracked files never trigger it)."
   print-opt-row ""   "--allow-empty"        ""            "Release even with no new commits since the previous tag."
   print-opt-row ""   "--no-fetch"           ""            "Skip the remote-sync preflight (no fetch / behind-upstream check)."
+  print-opt-row ""   "--no-hooks"           ""            "Skip the PRE_BUMP_CMD / POST_TAG_CMD release hooks for this run."
   print-opt-row ""   "--branch"             ""            "Cut a release-x.x.x branch (pre-2.0 default); otherwise tag in place."
   print-opt-row ""   "--pr"                 ""            "Branch + push + open a release PR via 'gh' (GitHub-only; implies push to origin)."
   print-opt-row ""   "--base"               "<branch>"    "Base branch for --pr (GitHub-only; default: the branch you ran ver-bump from)."

--- a/test/args.bats
+++ b/test/args.bats
@@ -140,6 +140,26 @@ load 'test_helper'
   assert_output --partial "Option --no-fetch doesn't take a value"
 }
 
+@test "long options: --no-hooks sets FLAG_NOHOOKS" {
+  source ${profile_script}
+  process-arguments --no-hooks
+  assert_equal "${FLAG_NOHOOKS}" "true"
+}
+
+@test "long options: --no-hooks=value is rejected" {
+  source ${profile_script}
+  run process-arguments --no-hooks=yes
+  assert_failure 2
+  assert_output --partial "Option --no-hooks doesn't take a value"
+}
+
+@test "process-arguments: resets a stale FLAG_NOHOOKS from the environment" {
+  source ${profile_script}
+  FLAG_NOHOOKS=true
+  process-arguments -d
+  assert_equal "${FLAG_NOHOOKS}" "false"
+}
+
 @test "long options: --pr implies branch + push and sets DO_PR" {
   source ${profile_script}
   process-arguments --pr

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -1,0 +1,296 @@
+#!/usr/bin/env bats
+
+# Release hooks (R-HOOK-1..6, issue #62): PRE_BUMP_CMD runs after all Verify
+# preflights and before any mutation; POST_TAG_CMD runs after the tag and
+# before push / --pr / --release. Non-zero exits 4 — the first real user of
+# the code reserved since the 2.0 exit contract (PRD §5.6). Keys come from
+# env or .ver-bumprc only; --no-hooks skips both for a run.
+
+load 'test_helper'
+
+# Scratch repo with a committed package.json at 1.0.0 — clean tree, no tags,
+# so every preflight passes and a full live release can run end-to-end.
+hooks_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+}
+
+# ── R-HOOK-1: PRE_BUMP_CMD ───────────────────────────────────────────────
+
+@test "hooks: failing PRE_BUMP_CMD exits 4 and mutates nothing (R-HOOK-1)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="exit 7" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+  strip_ansi_output
+  assert_output --partial "pre-bump hook failed (exit 7)"
+  assert_output --partial "--no-hooks"
+
+  # Nothing mutated: porcelain-clean tree, no tag, version untouched.
+  run git status --porcelain
+  assert_output ""
+  run git tag -l
+  assert_output ""
+  run jq -r '.version' package.json
+  assert_output "1.0.0"
+  assert_equal "$(git rev-list --count HEAD)" "2"
+}
+
+@test "hooks: PRE_BUMP_CMD runs via bash -c (pipeline works) and streams output (R-HOOK-1/4)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="echo hook-street-cred | tr a-z A-Z" \
+    run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  strip_ansi_output
+  # Resolved command logged before running, hook stdout streamed through.
+  assert_output --partial "Running pre-bump hook"
+  assert_output --partial "echo hook-street-cred | tr a-z A-Z"
+  assert_output --partial "HOOK-STREET-CRED"
+}
+
+@test "hooks: passing PRE_BUMP_CMD lets the release proceed (R-HOOK-1)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="true" run ${profile_script} -v 1.0.1 -c -n
+  assert_success
+  run jq -r '.version' package.json
+  assert_output "1.0.1"
+}
+
+# ── R-HOOK-2: POST_TAG_CMD ───────────────────────────────────────────────
+
+@test "hooks: failing POST_TAG_CMD exits 4, keeps commit + tag, points at --undo (R-HOOK-2)" {
+  hooks_repo
+
+  POST_TAG_CMD="exit 3" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+  strip_ansi_output
+  assert_output --partial "post-tag hook failed (exit 3)"
+  assert_output --partial "--undo 1.0.1"
+
+  # The bump commit and tag were kept; nothing was pushed (no remote exists).
+  run git tag -l
+  assert_output "v1.0.1"
+  run jq -r '.version' package.json
+  assert_output "1.0.1"
+  assert_equal "$(git rev-list --count HEAD)" "3"
+}
+
+@test "hooks: POST_TAG_CMD failure stops the run before the push prompt (R-HOOK-2)" {
+  hooks_repo
+
+  # No -p and no piped answer: reaching do-push would block on the prompt /
+  # exit 5. Exit 4 proves the run stopped at the hook, before any push path.
+  POST_TAG_CMD="false" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+  strip_ansi_output
+  refute_output --partial "Push branch + tags"
+}
+
+@test "hooks: POST_TAG_CMD is skipped under -n/--no-commit (no tag exists)" {
+  hooks_repo
+
+  POST_TAG_CMD="false" run ${profile_script} -v 1.0.1 -c -n
+  assert_success
+  strip_ansi_output
+  refute_output --partial "post-tag hook"
+}
+
+# ── R-HOOK-3: env / rc sourcing + precedence ─────────────────────────────
+
+@test "hooks: PRE_BUMP_CMD from .ver-bumprc is honoured (R-HOOK-3)" {
+  hooks_repo
+  printf 'PRE_BUMP_CMD="touch rc-hook-ran"\n' > .ver-bumprc
+
+  run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  [ -f rc-hook-ran ]
+}
+
+@test "hooks: env PRE_BUMP_CMD beats .ver-bumprc (R-HOOK-3 / R-CFG-3)" {
+  hooks_repo
+  printf 'PRE_BUMP_CMD="touch from-file"\n' > .ver-bumprc
+
+  PRE_BUMP_CMD="touch from-env" run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  [ -f from-env ]
+  [ ! -f from-file ]
+}
+
+@test "hooks: empty env PRE_BUMP_CMD disables an rc-defined hook (R-HOOK-3)" {
+  hooks_repo
+  printf 'PRE_BUMP_CMD="touch from-file"\n' > .ver-bumprc
+
+  PRE_BUMP_CMD="" run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  [ ! -f from-file ]
+}
+
+@test "hooks: env POST_TAG_CMD beats .ver-bumprc (R-HOOK-3 / R-CFG-3)" {
+  hooks_repo
+  printf 'POST_TAG_CMD="touch from-file; exit 1"\n' > .ver-bumprc
+
+  POST_TAG_CMD="touch from-env; exit 1" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+  [ -f from-env ]
+  [ ! -f from-file ]
+}
+
+# ── R-HOOK-4: logging + dry-run ──────────────────────────────────────────
+
+@test "hooks: --dry-run prints both hooks with [dry-run] prefix, executes neither (R-HOOK-4)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="touch pre-ran" POST_TAG_CMD="touch post-ran" \
+    run ${profile_script} -v 1.0.1 -d -c -p origin
+  assert_success
+  strip_ansi_output
+  assert_output --partial "[dry-run] would run pre-bump hook: bash -c 'touch pre-ran'"
+  assert_output --partial "[dry-run] would run post-tag hook: bash -c 'touch post-ran'"
+  [ ! -f pre-ran ]
+  [ ! -f post-ran ]
+  run git status --porcelain
+  assert_output ""
+}
+
+@test "hooks: dry-run hook preview goes to stderr (R-DRY-2)" {
+  hooks_repo
+
+  run bash -c \
+    'PRE_BUMP_CMD="touch pre-ran" "$1" -v 1.0.1 -d -c -p origin >"$2/out" 2>"$2/err"' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep 'would run pre-bump hook' "$BATS_TEST_TMPDIR/err"
+  assert_success
+}
+
+@test "hooks: failing hook's own stderr streams through (R-HOOK-4)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="echo boom-diagnostic >&2; exit 1" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+  strip_ansi_output
+  assert_output --partial "boom-diagnostic"
+}
+
+# ── R-HOOK-5: --no-hooks ─────────────────────────────────────────────────
+
+@test "hooks: --no-hooks skips both hooks (R-HOOK-5)" {
+  hooks_repo
+
+  PRE_BUMP_CMD="touch pre-ran; exit 1" POST_TAG_CMD="touch post-ran; exit 1" \
+    run ${profile_script} -v 1.0.1 -y --no-hooks
+  assert_failure 5 # falls through to the push prompt, declined by empty stdin
+  [ ! -f pre-ran ]
+  [ ! -f post-ran ]
+  # The release itself went through: bump commit + tag exist.
+  run git tag -l
+  assert_output "v1.0.1"
+}
+
+@test "hooks: env FLAG_NOHOOKS cannot skip hooks (CLI-only reset)" {
+  hooks_repo
+
+  FLAG_NOHOOKS=true PRE_BUMP_CMD="exit 1" run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+}
+
+@test "hooks: .ver-bumprc FLAG_NOHOOKS cannot skip hooks (CLI-only reset)" {
+  hooks_repo
+  printf 'FLAG_NOHOOKS=true\nPRE_BUMP_CMD="exit 1"\n' > .ver-bumprc
+
+  run ${profile_script} -v 1.0.1 -y
+  assert_failure 4
+}
+
+# ── R-HOOK-6: exported environment ───────────────────────────────────────
+
+@test "hooks: PRE_BUMP_CMD sees VER_BUMP_VERSION / _PREV_VERSION / _TAG (R-HOOK-6)" {
+  hooks_repo
+
+  PRE_BUMP_CMD='printf "%s|%s|%s" "$VER_BUMP_VERSION" "$VER_BUMP_PREV_VERSION" "$VER_BUMP_TAG" > hook-env' \
+    run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  run cat hook-env
+  assert_output "1.0.1|1.0.0|v1.0.1"
+}
+
+@test "hooks: single-quoted rc hook defers VER_BUMP_* expansion to run time (R-HOOK-6)" {
+  hooks_repo
+  # Single quotes in the rc are load-bearing: the rc is shell-sourced, so a
+  # double-quoted string would expand $VER_BUMP_* at load time (still empty).
+  cat > .ver-bumprc <<'RC'
+PRE_BUMP_CMD='printf "%s" "$VER_BUMP_TAG" > hook-env'
+RC
+
+  run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  run cat hook-env
+  assert_output "v1.0.1"
+}
+
+@test "hooks: POST_TAG_CMD sees the same env, custom tag prefix honoured (R-HOOK-6)" {
+  hooks_repo
+
+  # Hook writes its env then fails, so the run exits 4 before the push prompt.
+  POST_TAG_CMD='printf "%s|%s" "$VER_BUMP_VERSION" "$VER_BUMP_TAG" > hook-env; exit 1' \
+    run ${profile_script} -v 1.0.1 -y -t rel/
+  assert_failure 4
+  run cat hook-env
+  assert_output "1.0.1|rel/1.0.1"
+}
+
+@test "hooks: VER_BUMP_* vars are exported to the hook only, not leaked" {
+  hooks_repo
+
+  # After a successful hooked run, the parent environment written by the
+  # release itself (git config, files) must not contain VER_BUMP_VERSION —
+  # verify via a second hook that runs in the same ver-bump process ordering.
+  PRE_BUMP_CMD='env | grep -c "^VER_BUMP_" > hook-env' \
+    run ${profile_script} -v 1.0.1 -y -n -c
+  assert_success
+  run cat hook-env
+  assert_output "3"
+  # And the bats process env is untouched.
+  [ -z "${VER_BUMP_VERSION-}" ]
+}
+
+# ── Regression pin: hooks absent = zero behaviour change ─────────────────
+
+@test "hooks: unset hooks leave a release byte-identical (regression pin)" {
+  hooks_repo
+
+  run ${profile_script} -v 1.0.1 -c -n
+  assert_success
+  strip_ansi_output
+  refute_output --partial "hook"
+  run jq -r '.version' package.json
+  assert_output "1.0.1"
+}
+
+@test "hooks: unset hooks + dry-run print no hook lines (regression pin)" {
+  hooks_repo
+
+  run ${profile_script} -v 1.0.1 -d -c -p origin
+  assert_success
+  strip_ansi_output
+  refute_output --partial "hook"
+}
+
+# ── Surface: completions ─────────────────────────────────────────────────
+
+@test "hooks: completions list --no-hooks in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--no-hooks"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--no-hooks"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l no-hooks"
+}

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -37,6 +37,7 @@ source "$MODULE_DIR/lib/git-checks.sh"
 source "$MODULE_DIR/lib/version.sh"
 source "$MODULE_DIR/lib/changelog.sh"
 source "$MODULE_DIR/lib/git-actions.sh"
+source "$MODULE_DIR/lib/hooks.sh"
 
 source "$MODULE_DIR/lib/config.sh"
 
@@ -88,6 +89,7 @@ main() {
   check-pr-deps
 
   section "Release"
+  run-pre-bump-hook # PRE_BUMP_CMD: all preflights passed, nothing mutated yet (R-HOOK-1)
   do-packagefile-bump
   bump-json-files
   do-versionfile
@@ -95,6 +97,7 @@ main() {
   do-branch
   do-commit
   do-tag
+  run-post-tag-hook # POST_TAG_CMD: tag exists, nothing pushed yet (R-HOOK-2)
   do-push
   do-pr
   do-github-release


### PR DESCRIPTION
## Summary

Implements the two-hook minimum from the feature review: `PRE_BUMP_CMD` runs via `bash -c` after **all** Verify preflights pass and before any file mutation; `POST_TAG_CMD` runs after tag creation and before push / `--pr` / `--release`. A non-zero hook exits `4` — the first real user of the code reserved for hooks since the 2.0 exit contract (PRD §5.6); the "reserved" wording in PRD §5.6, `lib/errors.sh`, `docs/CODE_STYLE.md`, and the README exit table is updated to hook failure. Deliberately short of a plugin system (PRD §3.1 non-goal stands).

Refs #62.

## R-HOOK coverage

| ID | Behaviour | Where |
| --- | --- | --- |
| R-HOOK-1 | `PRE_BUMP_CMD` after Verify, before any mutation; non-zero → exit 4, nothing mutated (porcelain-clean pinned by test) | `run-pre-bump-hook`, first call in the Release section |
| R-HOOK-2 | `POST_TAG_CMD` after `do-tag`, before `do-push`; non-zero → exit 4, commit + tag kept, failure hint names `ver-bump --undo <version>` | `run-post-tag-hook` |
| R-HOOK-3 | Keys via env or `.ver-bumprc` only (added to `_CONFIG_KEYS`, precedence per R-CFG-3, env beats rc); no CLI flag to set a hook; empty = no hook | `lib/config.sh` |
| R-HOOK-4 | Resolved command logged before running; hook stdout/stderr stream through (not captured); `--dry-run` prints `[dry-run] would run <name> hook: bash -c '<cmd>'` to stderr and executes nothing | `_run-hook` |
| R-HOOK-5 | `--no-hooks` long-only boolean skips both (git `--no-verify` convention). CLI-only — reset in `process-arguments` like `ALLOW_EMPTY`, so an rc/env assignment can never silently disable team hooks; the one-shot single-hook bypass is `PRE_BUMP_CMD= ver-bump …` | `lib/args.sh`, usage, all three completion emitters, README (help↔README parity test passes) |
| R-HOOK-6 | `VER_BUMP_VERSION` / `VER_BUMP_PREV_VERSION` / `VER_BUMP_TAG` exported to the hook child only | `_run-hook` |

Living contract: `docs/features/hooks/requirements.md` (indexed in `docs/features/README.md`).

## Design decisions

- **New `lib/hooks.sh`** rather than growing `lib/git-actions.sh`: hooks run arbitrary user commands, not git side-effects — "one module, one reason to change" (CODE_STYLE architecture rules). `git-actions.sh` stays the git-verb module; `main()` just gains the two orchestration calls.
- **`POST_TAG_CMD` is skipped under `-n`/`--no-commit`** — no tag was created, mirroring `do-tag`'s own skip.
- **Post-tag failure keeps the commit + tag** (no automatic rollback): the hook may have produced side-effects worth inspecting, and `--undo` is the purpose-built recovery path (hint printed on failure).
- **Quoting gotcha documented + pinned**: the rc is shell-sourced, so a double-quoted hook string expands `$VER_BUMP_*` at load time (still empty). README tells users to single-quote; a test pins that single-quoted rc hooks see the real values at run time.

## Migration note (closes the B-3 lifecycle gap)

ver-bump 2.0 stopped shelling out to `npm version`, so npm's `preversion`/`version`/`postversion` lifecycle no longer fires. 1.x users who relied on `preversion` running their tests migrate with one `.ver-bumprc` line:

```sh
PRE_BUMP_CMD="npm test"
```

Documented in the README Release hooks section and PRD §8.1 B-3.

## Test plan

- `pnpm lint` — clean (shellcheck, zero warnings).
- `pnpm tests:run` — **373/373** passing (was **347** on `develop`): +23 in new `test/hooks.bats` (fail paths for both hooks incl. exit-code + hint assertions, rc/env precedence, dry-run to stderr, `--no-hooks`, `VER_BUMP_*` env incl. custom tag prefix, hooks-absent regression pins, completions) and +3 in `test/args.bats` (`--no-hooks` sets flag / rejects `=value` / stale env reset).
- Manual end-to-end in a scratch repo: live run with both hooks (values interpolated, streaming output), post-tag failure leaving commit + tag with the `--undo` hint, and `--dry-run` preview.