### PR TITLE
feat(version): git-tag version fallback + --source <file.json> for non-Node repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ver-bump
 
-An opinionated release tool for Git projects with a `package.json` (Node / JS / TS, or any repo that follows SemVer via `-f <file>.json`). Automates SemVer bumps, CHANGELOG updates, tagging, and pushing — driven by Conventional Commits. Tags in place by default, or cut a release branch (`--branch`) and open a pull request (`--pr`). The core flow — bump, changelog, tag, push — works on any Git remote and needs only `git` + `jq`; `--pr` and `--release` are GitHub-specific and require the optional [`gh`](https://cli.github.com) CLI. Single-file bash at runtime.
+An opinionated release tool for Git projects with a `package.json` (Node / JS / TS, or any repo that follows SemVer — point `--source <file>.json` at another manifest, or use no version file at all and let the latest release tag supply the current version). Automates SemVer bumps, CHANGELOG updates, tagging, and pushing — driven by Conventional Commits. Tags in place by default, or cut a release branch (`--branch`) and open a pull request (`--pr`). The core flow — bump, changelog, tag, push — works on any Git remote and needs only `git` + `jq`; `--pr` and `--release` are GitHub-specific and require the optional [`gh`](https://cli.github.com) CLI. Single-file bash at runtime.
 
 <p>
   <img src="https://raw.githubusercontent.com/jv-k/ver-bump/main/img/demo.gif?raw=true" alt="Animated demo: ver-bump reads commits, suggests a SemVer bump, updates package.json + CHANGELOG, creates a release branch, tags, and pushes.">
@@ -241,9 +241,20 @@ branch.
 
 ### Pre-requisites
 
-- Make sure you have `package.json` file in your project and it contains a `"version": "x.x.x"` parameter
+- A version source: a `package.json` with a `"version": "x.x.x"` field, another
+  JSON file via `--source <file.json>` (e.g. `composer.json`), or — with no
+  version file at all — at least one release tag (`v1.2.3`) for ver-bump to
+  derive the current version from
 - You have done some work and have some existing commits
 - You have the ability to push to your Git remote via the Git CLI
+
+**Non-Node repos** — Rust / Python / Go / anything SemVer works out of the
+box: if there is no version file, ver-bump reads the current version from
+your latest matching git tag, runs the same Conventional-Commit suggestion
+machinery, and cuts a CHANGELOG + tag release (skipping the commit when
+there is nothing to commit). Keep a JSON manifest like `composer.json`?
+Point `--source` at it (or set `SOURCE_FILE` in `.ver-bumprc`) and it
+becomes both the version source and the file that gets bumped.
 
 ### CLI
 
@@ -252,7 +263,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-h|--help] \
-           [--branch] [--pr] [--base <branch>] \
+           [--source <file.json>] [--branch] [--pr] [--base <branch>] \
            [--allow-dirty] [--allow-empty] [--no-fetch] \
            [--undo [<version>]] [--major | --minor | --patch] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
@@ -280,6 +291,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `TAG_PREFIX` | `-t` / `--tag-prefix` | `v` |
 | `REL_PREFIX` | `-B` / `--branch-prefix` | `release-` |
 | `PUSH_DEST` | `-p` / `--push` | `origin` |
+| `SOURCE_FILE` | `--source` | `package.json` |
 | `COMMIT_MSG_PREFIX` | *(no flag)* | `"chore: "` |
 | `CHANGELOG_STYLE` | *(no flag)* | `flat` |
 | `FLAG_BRANCH` | `--branch` | *unset* (tag in place) |
@@ -376,6 +388,16 @@ output stays byte-identical to previous releases.
 -l, --pause-changelog         Pause before commit so CHANGELOG.md can be hand-edited.
 -y, --yes                     Skip interactive confirmation prompts.
 -h, --help                    Show help message.
+    --source <file.json>      Version source + primary bump target (default:
+                              package.json). Replaces package.json for reading the
+                              current version and writing the bump; the built-in
+                              package-lock.json companion bump only applies when the
+                              source really is package.json. If the file doesn't
+                              exist, the current version is derived from the latest
+                              matching git tag instead and nothing is written for it
+                              (tag + CHANGELOG release; with nothing staged, the
+                              commit is skipped and the tag lands on HEAD). Also
+                              available as the SOURCE_FILE config/env key.
     --undo [<version>]        Locally delete the release branch + tag for <version>
                               (refuses if pushed, dirty, or already merged).
     --major                   Force a major bump from the current version.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -9,6 +9,7 @@ contract); IDs added after the PRD are backfilled here first.
 | --- | --- | --- |
 | [runtime-dependencies](./runtime-dependencies/requirements.md) | R-DEP | `errors.bats` |
 | [version-input](./version-input/requirements.md) | R-VER | `version.bats` |
+| [version-source](./version-source/requirements.md) | R-SRC | `version-source.bats` |
 | [bump-suggestion](./bump-suggestion/requirements.md) | R-BUMP | `bump-suggest.bats` |
 | [explicit-bump-switches](./explicit-bump-switches/requirements.md) | R-FORCE | `args.bats`, `bump-suggest.bats` |
 | [cli-options](./cli-options/requirements.md) | R-OPT | `args.bats` |

--- a/docs/features/version-source/requirements.md
+++ b/docs/features/version-source/requirements.md
@@ -1,0 +1,31 @@
+# Version source (`--source` + git-tag fallback)
+
+`package.json` is only the *default* version source. `--source <file.json>`
+(or the `SOURCE_FILE` config/env key) points the source — and the primary
+bump target — at any JSON file, and when the source file does not exist the
+current version is derived from the latest matching release tag. Non-Node
+repos get the full bump-suggestion machinery without a dummy `package.json`
+or a `-v` on every run. Backfilled from issue
+[#63](https://github.com/jv-k/ver-bump/issues/63) (post-PRD, per the
+[features index](../README.md) convention).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-SRC-1 | `--source <file.json>` (long-only, takes arg) replaces `package.json` as the version source **and** primary bump target. The built-in `package-lock.json` companion bump (R-OPT-7) applies only when the source is actually `package.json`. | ✅ — `lib/args.sh`, `lib/version.sh::do-packagefile-bump`; `test/version-source.bats` |
+| R-SRC-2 | When the source file is absent: `V_PREV` derives from `git describe --tags --abbrev=0 --match "${TAG_PREFIX}[0-9]*"`, `TAG_PREFIX` stripped, validated as SemVer. The full suggestion machinery (R-BUMP-1..4) then works unchanged. | ✅ — `lib/version.sh::process-version`; `test/version-source.bats` |
+| R-SRC-3 | Tag-derived mode has no source file to write: the release consists of `-f` extras (if any) + CHANGELOG + commit + tag. When nothing is staged, the commit is skipped and the tag lands on the current HEAD (a tag-only release is valid output). | ✅ — `lib/git-actions.sh::do-commit`; `test/version-source.bats` |
+| R-SRC-4 | No tags **and** no source file → exit `3`, with a hint naming both escape routes (`-v <version>` for the first release, or create the file). | ✅ — `lib/version.sh::process-version`; `test/version-source.bats`, `test/errors.bats` |
+| R-SRC-5 | `SOURCE_FILE` config/env key mirrors the flag (R-CFG-3 precedence: CLI `--source` > env > `.ver-bumprc` > `package.json` default). | ✅ — `lib/config.sh`; `test/version-source.bats` |
+
+Notes:
+
+- A tag-derived `V_PREV` by definition has a matching tag, so the
+  nothing-to-release no-op guard (R-SAFE-14..18) applies to source-less
+  repos exactly as it does to `package.json` ones; `--allow-empty` remains
+  the override.
+- Completions restrict `--source` to `*.json` (same rule as `-f`,
+  R-COMP-3) in all three emitters.
+
+Modules: `lib/version.sh`, `lib/args.sh`, `lib/config.sh`,
+`lib/git-actions.sh`, `lib/completions.sh`. Tests:
+`test/version-source.bats`, `test/args.bats`.

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -212,6 +212,27 @@ normalize-long-opts() {
         "Drop the '=<value>' — --no-fetch is a boolean flag."
     fi
 
+    # --source <file.json> / --source=<file.json> — the version source and
+    # primary bump target (R-SRC-1). Long-only value flag captured here like
+    # --base, so it needs no getopts slot. Sets the SOURCE_FILE config key
+    # directly, so the CLI wins over env / .ver-bumprc per R-CFG-3.
+    if [ "$arg" = "--source" ] || [[ "$arg" == "--source="* ]]; then
+      if [[ "$arg" == "--source="* ]]; then
+        SOURCE_FILE="${arg#--source=}"
+        [ -z "$SOURCE_FILE" ] && fail 2 \
+          "--source= requires a file path." \
+          "Pass a JSON file: --source <file.json> or --source=<file.json>."
+      elif (( $# )) && [ "${1:0:1}" != "-" ]; then
+        SOURCE_FILE="$1"; shift
+      else
+        fail 2 \
+          "Option --source requires a file path." \
+          "Pass a JSON file: --source <file.json> or --source=<file.json>."
+      fi
+      echo -e "\n${S_LIGHT}Option set:${RESET} version source: <${S_VAL}${SOURCE_FILE}${RESET}>"
+      continue
+    fi
+
     # --base <branch> / --base=<branch> — explicit base branch for --pr. Long-only
     # value flag (no short form), captured here like --undo so it needs no getopts slot.
     if [ "$arg" = "--base" ] || [[ "$arg" == "--base="* ]]; then

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -133,7 +133,7 @@ _ver_bump() {
 
     # Options that take a file argument → complete .json paths
     case "$prev" in
-        -f|--file)
+        -f|--file|--source)
             COMPREPLY=( $(compgen -f -X '!*.json' -- "$cur") )
             return 0
             ;;
@@ -147,7 +147,7 @@ _ver_bump() {
             ;;
     esac
 
-    opts="--version --message --file --push --tag-prefix --branch-prefix \
+    opts="--version --message --file --source --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --undo --branch --pr --base --major --minor --patch --release \
           --allow-dirty --allow-empty --no-fetch \
@@ -171,6 +171,7 @@ _ver_bump() {
     '(-v --version)'{-v,--version}'[print tool version (no arg) or set manual SemVer]::version:' \
     '(-m --message)'{-m,--message}'[custom annotated-tag message]:message:' \
     '(-f --file)'{-f,--file}'[bump version in extra JSON file]:file:_files -g "*.json"' \
+    '--source[version source + primary bump target (default package.json)]:file:_files -g "*.json"' \
     '(-p --push)'{-p,--push}'[push branch + tag to <remote>]:remote:' \
     '(-t --tag-prefix)'{-t,--tag-prefix}'[override tag prefix]:prefix:' \
     '(-B --branch-prefix)'{-B,--branch-prefix}'[override branch prefix]:prefix:' \
@@ -208,6 +209,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd -s v -l version        -d 'Print tool version (no arg) or set manual SemVer'
     complete -c $_cmd -s m -l message        -r -d 'Custom annotated-tag message'
     complete -c $_cmd -s f -l file           -r -a '(__fish_complete_suffix .json)' -d 'Bump version in extra JSON file'
+    complete -c $_cmd      -l source         -r -a '(__fish_complete_suffix .json)' -d 'Version source + primary bump target'
     complete -c $_cmd -s p -l push           -r -d 'Push branch + tag to <remote>'
     complete -c $_cmd -s t -l tag-prefix     -r -d 'Override tag prefix'
     complete -c $_cmd -s B -l branch-prefix  -r -d 'Override branch prefix'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,6 +19,8 @@ true
 #   NO_FETCH (skip the remote-sync preflight, R-SAFE-8)
 #   RELEASE_BRANCHES (space-separated glob allowlist of branches a release
 #                     may be cut from; empty = no guard, R-SAFE-10)
+#   SOURCE_FILE (version source + primary bump target, mirrors --source;
+#                default package.json, R-SRC-1/5)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
 #
 # Safety: shell-sourced files are code. The rc must be owned by the current
@@ -29,7 +31,7 @@ true
 _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
-              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES)
+              ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES SOURCE_FILE)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that
@@ -132,4 +134,7 @@ apply-config-defaults() {
   # "flat" (default, 1.x-identical) or "grouped" (R-CHLOG-1). Any other
   # value behaves as flat — same lenient contract as the FLAG_* keys.
   CHANGELOG_STYLE="${CHANGELOG_STYLE:-flat}"
+  # Version source + primary bump target (R-SRC-1/5). VER_FILE derives from
+  # it in main() after process-arguments, so --source (CLI) wins per R-CFG-3.
+  SOURCE_FILE="${SOURCE_FILE:-package.json}"
 }

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -42,6 +42,22 @@ do-commit() {
 
   local COMMIT_MSG COMMIT_RC
 
+  # Tag-only release (R-SRC-3): when this run staged nothing — tag-derived
+  # source (nothing to write), -c, no -f extras — `git commit` would die
+  # with "nothing to commit". Skip the commit; do-tag then tags the current
+  # HEAD, which is a valid release output here. GIT_MSG doubles as the
+  # staging ledger (every path that stages a file appends to it), so the
+  # check behaves identically under --dry-run, where nothing is truly
+  # staged. The live path double-checks the index so anything staged
+  # outside this run (possible under --allow-dirty) is still committed,
+  # never silently dropped.
+  if [ -z "$GIT_MSG" ]; then
+    if [ "$FLAG_DRYRUN" = true ] || git diff --cached --quiet 2>/dev/null; then
+      log_info "Nothing staged to commit — skipping the commit; the tag will point at the current HEAD."
+      return 0
+    fi
+  fi
+
   GIT_MSG+="$(get-commit-msg)"
   echo -e "\nCommitting..."
 

--- a/lib/git-checks.sh
+++ b/lib/git-checks.sh
@@ -129,8 +129,11 @@ check-commits-exist() {
 # previous matching tag (first release) → proceeds as today (R-BUMP-3).
 check-releasable-commits() {
   [ "${ALLOW_EMPTY:-false}" = true ] && return 0
-  # With -v and no readable VER_FILE, V_PREV may be empty — no previous tag
-  # can be derived, so there is nothing to compare against.
+  # V_PREV may be empty only with -v when the source file is unreadable AND
+  # no matching tag exists (process-version's tag-derived fallback, R-SRC-2,
+  # otherwise fills it in) — then there is nothing to compare against. A
+  # tag-derived V_PREV by definition has a tag, so the guard applies to
+  # source-less repos exactly like package.json ones.
   [ -n "${V_PREV:-}" ] || return 0
 
   local prev_tag count

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -46,7 +46,7 @@ usage() {
   printf '\n%bUSAGE %b\n' "${S_HDR_CYAN-}" "${S_HDR_END-}"
   printf '  %b%s%b [-v <version>] [-m <message>] [-f <file.json>]... [-p <remote>] [-t <tag-prefix>] [-B <branch-prefix>] [-d] [-n] [-b] [-c] [-l] [-h]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
-  printf '  %b%s%b [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
+  printf '  %b%s%b [--source <file.json>] [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
 
   # Column width for label + 2-space gutter. Longest label is
@@ -119,6 +119,8 @@ usage() {
   print-opt-row "-l" "--pause-changelog" ""          "Pause before commit so CHANGELOG.md can be edited."
   print-opt-row "-h" "--help"          ""            "Show this help message."
   print-opt-row "-y" "--yes"           ""            "Skip interactive confirmation prompts."
+  print-opt-row ""   "--source"        "<file.json>" "Version source + primary bump target (default: package.json)."
+  print-opt-cont "If the file is missing, the current version derives from the latest matching git tag."
   print-opt-row ""   "--undo"          "[<version>]" "Locally delete release-X.Y.Z + tag vX.Y.Z (refuses if pushed/dirty)."
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
@@ -143,6 +145,7 @@ usage() {
   print-example-row "${SCRIPT_NAME} --pr"                  "Branch, push, and open a release PR (needs gh)."
   print-example-row "${SCRIPT_NAME} -t release/"           "Use a custom tag prefix (e.g. release/1.2.3)."
   print-example-row "${SCRIPT_NAME} -f composer.json"      "Also bump version in an extra JSON file."
+  print-example-row "${SCRIPT_NAME} --source composer.json" "Use composer.json as the version source (non-Node repo)."
   print-example-row "${SCRIPT_NAME} --about"               "Show branded version info."
   print-example-row "${SCRIPT_NAME} --install-completions" "Install shell completions (auto-detects shell)."
 

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -3,13 +3,13 @@
 # shellcheck disable=SC2288
 true
 
-# Suggests version from VERSION file, or grabs from user supplied -v <version>.
-# If none is set, suggest default from options.
+# Suggests version from the source file (VER_FILE), the latest matching git
+# tag, or grabs from user supplied -v <version>.
 
-# - If <package.json> doesn't exist, warn + exit
 # - If -v specified, set version from that
 # - Else,
-#   - Grab from package.json
+#   - Grab from the source file (package.json by default, --source overrides)
+#   - If the source file is absent, derive from the latest matching git tag
 #   - Suggest incremented number
 #   - Give prompt to user to modify
 # - Set globally
@@ -19,10 +19,12 @@ true
 # — MINOR version when you add functionality in a backwards compatible manner, and
 # — PATCH version when you make backwards compatible bug fixes.
 process-version() {
-  # Read V_PREV from VER_FILE (package.json) for display + same-version dedup.
-  # When -v is supplied, V_PREV is best-effort: the user already gave us V_NEW,
-  # so missing/empty VER_FILE is allowed. Without -v we need a version to bump,
-  # so a missing VER_FILE is a hard error.
+  # Read V_PREV from VER_FILE (the resolved --source / SOURCE_FILE target,
+  # package.json by default) for display + same-version dedup. When the file
+  # is absent, fall back to the latest matching release tag (R-SRC-2) — the
+  # suggestion machinery then works unchanged. Without -v we need a version
+  # to bump, so no file AND no tag is a hard error (R-SRC-4). With -v both
+  # reads are best-effort: the user already gave us V_NEW.
   if [ -f "$VER_FILE" ] && [ -s "$VER_FILE" ]; then
     V_PREV=$( jq -r '.version // empty' "$VER_FILE" 2>/dev/null )
 
@@ -39,8 +41,8 @@ process-version() {
         "<${VER_FILE}> doesn't contain a 'version' field." \
         "Add a top-level \"version\" key to ${VER_FILE}, or pass an explicit version with -v <version>."
     fi
-  elif [ -z "$V_USR_SUPPLIED" ]; then
-    local reason
+  else
+    local reason derived_tag
     if [ ! -f "$VER_FILE" ]; then
       reason="was not found"
     elif [ ! -s "$VER_FILE" ]; then
@@ -48,9 +50,36 @@ process-version() {
     else
       reason="could not be read"
     fi
-    fail 3 \
-      "<${VER_FILE}> ${reason}." \
-      "Run ver-bump inside a directory with a valid ${VER_FILE}, pass -v <version> to bypass, or override via VER_FILE=<path>."
+
+    # Source file absent: derive V_PREV from the latest release tag reachable
+    # from HEAD (R-SRC-2). The match glob "${TAG_PREFIX}[0-9]*" keeps
+    # unrelated tags (e.g. 'nightly') out. The derivation also runs with -v —
+    # it feeds the changelog range, the commit message, and the no-op guard
+    # (check-releasable-commits) — but stays best-effort there: an unusable
+    # tag is discarded, never fatal.
+    if derived_tag=$(git describe --tags --abbrev=0 --match "${TAG_PREFIX}[0-9]*" 2>/dev/null) \
+       && [ -n "$derived_tag" ]; then
+      V_PREV="${derived_tag#"${TAG_PREFIX}"}"
+      if ! is_semver "$V_PREV"; then
+        if [ -z "$V_USR_SUPPLIED" ]; then
+          fail 3 \
+            "<${VER_FILE}> ${reason} and the latest matching tag '${derived_tag}' is not '${TAG_PREFIX}' + a SemVer 2.0 version." \
+            "Tag releases as ${TAG_PREFIX}MAJOR.MINOR.PATCH, pass -v <version>, or create ${VER_FILE} with a \"version\" field."
+        fi
+        V_PREV=""
+      else
+        echo -e "\n<${S_VAL}${VER_FILE}${RESET}> ${reason} — current version derived from git tag <${S_VAL}${derived_tag}${RESET}>: ${S_VAL}$V_PREV${RESET}"
+        if [ -z "$V_USR_SUPPLIED" ] && [ -z "${BUMP_LEVEL-}" ]; then
+          set-v-suggest "$V_PREV" # full suggestion machinery, unchanged (R-SRC-2)
+        fi
+      fi
+    elif [ -z "$V_USR_SUPPLIED" ]; then
+      # No source file and no tag to derive from (R-SRC-4): name both escape
+      # routes — -v for a first release, or create the file.
+      fail 3 \
+        "<${VER_FILE}> ${reason} and no '${TAG_PREFIX}*' release tag exists to derive the current version from." \
+        "First release? Pass -v <version>. Otherwise create ${VER_FILE} with a \"version\" field, or point --source / SOURCE_FILE at the right file."
+    fi
   fi
 
   # If a version number is supplied by the user with [-v <version number>] — use it!
@@ -275,14 +304,20 @@ set-v-suggest() {
   V_SUGGEST="$1"
 }
 
+# Bump the resolved version source (VER_FILE — package.json by default, or
+# whatever --source / SOURCE_FILE points at, R-SRC-1). The built-in
+# package-lock.json companion bump (R-OPT-7) applies only when the source is
+# actually package.json — a --source composer.json run must not touch a
+# stray lock file.
 do-packagefile-bump() {
-  local NOTICE_MSG
-  NOTICE_MSG="<${S_VAL}package.json${RESET}>"
+  local NOTICE_MSG BUMP_LOCK=false
+  NOTICE_MSG="<${S_VAL}${VER_FILE}${RESET}>"
 
-  # Skip entirely if package.json is absent. With -v + -f, the user may be
-  # bumping only auxiliary JSON files — process-version already allowed
-  # missing VER_FILE in that path.
-  if [ ! -f package.json ]; then
+  # Skip entirely if the source file is absent. In tag-derived mode
+  # (R-SRC-2/3) there is nothing to write, and with -v + -f the user may be
+  # bumping only auxiliary JSON files — process-version already allowed the
+  # missing file in both paths.
+  if [ ! -f "$VER_FILE" ]; then
     log_warn "${NOTICE_MSG} not found — skipping."
     return
   fi
@@ -292,20 +327,22 @@ do-packagefile-bump() {
     return
   fi
 
+  [ "$VER_FILE" = "package.json" ] && [ -f package-lock.json ] && BUMP_LOCK=true
+
   if [ "$FLAG_DRYRUN" = true ]; then
-    echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package.json" >&2
-    [ -f package-lock.json ] && echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package-lock.json" >&2
+    echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in ${VER_FILE}" >&2
+    [ "$BUMP_LOCK" = true ] && echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package-lock.json" >&2
   else
-    # Bump package.json via jq (no npm dependency), preserving the file's
+    # Bump the source file via jq (no npm dependency), preserving the file's
     # own formatting where possible (R-FMT-1..3, lib/json.sh).
-    if ! json_set_version package.json "$V_NEW"; then
+    if ! json_set_version "$VER_FILE" "$V_NEW"; then
       fail 1 \
-        "Error updating <package.json>." \
-        "Check that package.json is valid JSON (run: jq . package.json) and that the file is writable."
+        "Error updating <${VER_FILE}>." \
+        "Check that ${VER_FILE} is valid JSON (run: jq . ${VER_FILE}) and that the file is writable."
     fi
     # package-lock.json: update both top-level .version and (if present) the
     # root package entry .packages[""].version — matches npm's own behaviour.
-    if [ -f package-lock.json ]; then
+    if [ "$BUMP_LOCK" = true ]; then
       # shellcheck disable=SC2016
       if ! jq_inplace package-lock.json '
         .version = $V
@@ -320,9 +357,9 @@ do-packagefile-bump() {
     fi
   fi
 
-  dryrun git add package.json
-  GIT_MSG+="updated package.json, "
-  if [ -f package-lock.json ]; then
+  dryrun git add "$VER_FILE"
+  GIT_MSG+="updated ${VER_FILE}, "
+  if [ "$BUMP_LOCK" = true ]; then
     dryrun git add package-lock.json
     GIT_MSG+="updated package-lock.json, "
     NOTICE_MSG+=" and <${S_VAL}package-lock.json${RESET}>"

--- a/test/args.bats
+++ b/test/args.bats
@@ -164,6 +164,28 @@ load 'test_helper'
   assert_failure 2
 }
 
+@test "long options: --source sets SOURCE_FILE (space and = forms)" {
+  source ${profile_script}
+  process-arguments --source composer.json
+  assert_equal "${SOURCE_FILE}" "composer.json"
+  process-arguments --source=manifest.json
+  assert_equal "${SOURCE_FILE}" "manifest.json"
+}
+
+@test "long options: --source without value exits 2" {
+  source ${profile_script}
+  run process-arguments --source
+  assert_failure 2
+  assert_output --partial "requires a file path"
+}
+
+@test "long options: --source= empty value exits 2" {
+  source ${profile_script}
+  run process-arguments --source=
+  assert_failure 2
+  assert_output --partial "requires a file path"
+}
+
 @test "long options: --push <remote> sets push flag + dest" {
   source ${profile_script}
   process-arguments --push upstream

--- a/test/version-source.bats
+++ b/test/version-source.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+
+# --source <file.json> + git-tag version fallback (R-SRC-1..5, issue #63).
+#
+# The version source is package.json only by default: --source (or the
+# SOURCE_FILE config/env key) points both the version read and the primary
+# bump write at any JSON file, and when the source file is absent V_PREV is
+# derived from the latest matching release tag — so non-Node repos get the
+# full suggestion machinery, and a tag-only release (nothing staged → no
+# commit, tag on HEAD) is a valid outcome.
+
+load 'test_helper'
+
+# Scratch repo with NO version file, a v1.4.0 release tag, and a bare
+# "remote" wired up as origin so full (non-dry) runs can push with -p origin
+# instead of hitting the interactive push prompt.
+tagged_repo_no_source() {
+  local repo remote
+  repo="$(scratch_repo)"
+  remote=$(mktemp -d)
+  CLEANUP_CMDS+=("rm -rf ${remote}")
+  git init -q --bare "$remote"
+  cd "$repo" || exit 1
+  git remote add origin "$remote"
+  git tag -a v1.4.0 -m "v1.4.0"
+}
+
+# ── R-SRC-2: tag-derived fallback feeds the suggestion machinery ──────────
+
+@test "tag fallback: no package.json, tag v1.4.0 + feat commit -> suggests 1.5.0, full release (R-SRC-2)" {
+  tagged_repo_no_source
+  git commit -q --allow-empty -m "feat: add shiny"
+
+  # Bare <enter> accepts the suggested version; -p origin skips the push prompt.
+  run bash -c 'printf "\n" | "$1" -p origin' _ "${profile_script}"
+  assert_success
+  strip_ansi_output
+  assert_output --partial "derived from git tag <v1.4.0>: 1.4.0"
+  assert_output --partial "suggesting minor bump"
+
+  # CHANGELOG was written and committed; the tag landed on the bump commit.
+  run git tag -l "v1.5.0"
+  assert_output "v1.5.0"
+  [ -f CHANGELOG.md ]
+  run grep -c "## 1.5.0" CHANGELOG.md
+  assert_output "1"
+  # initial + feat + changelog bump commit = 3; no package.json materialised.
+  assert_equal "$(git rev-list --count HEAD)" "3"
+  [ ! -f package.json ]
+}
+
+@test "tag fallback: derivation runs with -v too and feeds the changelog range" {
+  tagged_repo_no_source
+  git commit -q --allow-empty -m "feat: add shiny"
+
+  run ${profile_script} -p origin -v 2.0.0
+  assert_success
+  strip_ansi_output
+  assert_output --partial "derived from git tag <v1.4.0>: 1.4.0"
+  # No suggestion machinery with -v (R-FORCE-3).
+  refute_output --partial "suggesting"
+  # Changelog range anchored at the derived previous tag: the pre-tag
+  # "initial" commit must not leak into the new section.
+  run head -5 CHANGELOG.md
+  assert_output --partial "## 2.0.0"
+  assert_output --partial "feat: add shiny"
+  refute_output --partial "initial"
+}
+
+# ── R-SRC-3: tag-only release when nothing is staged ──────────────────────
+
+@test "tag-only: no source, -c, nothing staged -> skips commit, annotated tag on HEAD (R-SRC-3)" {
+  tagged_repo_no_source
+  git commit -q --allow-empty -m "feat: new thing"
+  local head_before
+  head_before=$(git rev-parse HEAD)
+
+  run ${profile_script} -c -p origin -v 1.5.0
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Nothing staged to commit"
+
+  # No new commit; the tag is annotated and points at the pre-run HEAD.
+  assert_equal "$(git rev-parse HEAD)" "$head_before"
+  run git cat-file -t "refs/tags/v1.5.0"
+  assert_output "tag"
+  assert_equal "$(git rev-list -n1 v1.5.0)" "$head_before"
+}
+
+@test "tag-only: dry-run previews the same skip without mutating (R-SRC-3 + dry-run parity)" {
+  tagged_repo_no_source
+  git commit -q --allow-empty -m "feat: shiny"
+
+  run ${profile_script} -d -c -p origin -v 1.5.0
+  assert_success
+  strip_ansi_output
+  assert_output --partial "derived from git tag"
+  assert_output --partial "Nothing staged to commit"
+  assert_output --partial "would run: git tag -a v1.5.0"
+  run git tag -l "v1.5.0"
+  assert_output ""
+  [ ! -f package.json ]
+  [ ! -f CHANGELOG.md ]
+}
+
+@test "tag fallback: no-op guard still applies — no commits since derived tag -> no-release (R-SAFE-14)" {
+  tagged_repo_no_source
+
+  run ${profile_script} -p origin -v 1.5.0
+  assert_success
+  strip_ansi_output
+  assert_output --partial "no-release"
+  run git tag -l "v1.5.0"
+  assert_output ""
+}
+
+# ── R-SRC-1: --source replaces the source AND the primary bump target ─────
+
+@test "--source composer.json: reads + bumps it; package.json and lock file untouched (R-SRC-1)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "2.3.4" }\n' > composer.json
+  printf '{ "version": "0.0.1" }\n' > package.json
+  printf '{ "version": "0.0.1", "packages": { "": { "version": "0.0.1" } } }\n' > package-lock.json
+  git add composer.json package.json package-lock.json
+  git commit -qm "chore: seed"
+
+  run ${profile_script} --source composer.json -c -n -v 2.4.0
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Current version read from <composer.json>: 2.3.4"
+  assert_output --partial "Bumped version in <composer.json>"
+  refute_output --partial "package-lock.json"
+
+  run jq -r '.version' composer.json
+  assert_output "2.4.0"
+  run jq -r '.version' package.json
+  assert_output "0.0.1"
+  run jq -r '.version' package-lock.json
+  assert_output "0.0.1"
+}
+
+@test "--source composer.json: suggestion machinery reads the alternate source" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "2.3.4" }\n' > composer.json
+  git add composer.json && git commit -qm "chore: seed"
+  git tag -a v2.3.4 -m "v2.3.4"
+  git commit -q --allow-empty -m "feat: php thing"
+
+  # Bare <enter> accepts the suggestion (2.4.0 from the feat: commit).
+  run bash -c 'printf "\n" | "$1" --source composer.json -c -n' _ "${profile_script}"
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Current version read from <composer.json>: 2.3.4"
+  assert_output --partial "suggesting minor bump"
+  run jq -r '.version' composer.json
+  assert_output "2.4.0"
+}
+
+@test "regression: default package.json flow unchanged (bump + lock companion)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "1.0.0" }\n' > package.json
+  printf '{ "version": "1.0.0", "packages": { "": { "version": "1.0.0" } } }\n' > package-lock.json
+  git add package.json package-lock.json && git commit -qm "chore: seed"
+  git tag -a v1.0.0 -m "v1.0.0"
+  git commit -q --allow-empty -m "fix: bug"
+
+  run ${profile_script} -c -n -v 1.0.1
+  assert_success
+  strip_ansi_output
+  assert_output --partial "Bumped version in <package.json> and <package-lock.json>"
+  run jq -r '.version' package.json
+  assert_output "1.0.1"
+  run jq -r '.version' package-lock.json
+  assert_output "1.0.1"
+  run jq -r '.packages."".version' package-lock.json
+  assert_output "1.0.1"
+}
+
+# ── R-SRC-2: custom tag prefix respected in the describe match ─────────────
+
+@test "tag fallback: custom --tag-prefix rel/ drives the describe match (R-SRC-2)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  git tag -a rel/1.4.0 -m "rel/1.4.0"
+  git tag -a v9.9.9 -m "decoy with the default prefix"
+  git commit -q --allow-empty -m "fix: something"
+
+  run ${profile_script} -t rel/ -c -n --patch
+  assert_success
+  strip_ansi_output
+  assert_output --partial "derived from git tag <rel/1.4.0>: 1.4.0"
+  assert_output --partial "1.4.1"
+  refute_output --partial "9.9.9"
+}
+
+# ── R-SRC-4: no tags AND no source file -> exit 3 with the dual hint ──────
+
+@test "no tags + no source file -> exit 3 with dual hint (R-SRC-4)" {
+  cd "$(scratch_repo)"
+
+  run ${profile_script}
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "was not found"
+  assert_output --partial "no 'v*' release tag"
+  assert_output --partial "Hint:"
+  assert_output --partial "-v <version>"
+  assert_output --partial "create package.json"
+}
+
+@test "no tags + no source file + -v proceeds (first release escape route, R-SRC-4)" {
+  cd "$(scratch_repo)"
+
+  run ${profile_script} -d -c -p origin -v 0.1.0
+  assert_success
+  strip_ansi_output
+  refute_output --partial "Hint:"
+  assert_output --partial "would run: git tag -a v0.1.0"
+}
+
+# ── R-SRC-5: SOURCE_FILE config/env key mirrors the flag ──────────────────
+
+@test "SOURCE_FILE via .ver-bumprc is honoured (R-SRC-5)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'SOURCE_FILE=composer.json\n' > .ver-bumprc
+  printf '{ "version": "3.0.0" }\n' > composer.json
+  git add composer.json .ver-bumprc && git commit -qm "chore: seed"
+
+  unset SOURCE_FILE
+  run ${profile_script} -d -c -p origin -v 3.0.1
+  assert_success
+  strip_ansi_output
+  assert_output --partial "read from <composer.json>: 3.0.0"
+  assert_output --partial "would set .version = '3.0.1' in composer.json"
+}
+
+@test "env SOURCE_FILE beats .ver-bumprc (R-SRC-5 / R-CFG-3)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf 'SOURCE_FILE=fromfile.json\n' > .ver-bumprc
+  printf '{ "version": "1.0.0" }\n' > fromfile.json
+  printf '{ "version": "2.0.0" }\n' > fromenv.json
+  git add . && git commit -qm "chore: seed"
+
+  SOURCE_FILE=fromenv.json run ${profile_script} -d -c -p origin -v 9.9.9
+  assert_success
+  strip_ansi_output
+  assert_output --partial "read from <fromenv.json>: 2.0.0"
+  refute_output --partial "fromfile.json>: 1.0.0"
+}
+
+@test "--source beats env SOURCE_FILE (R-SRC-5 / R-CFG-3)" {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "2.0.0" }\n' > fromenv.json
+  printf '{ "version": "3.0.0" }\n' > fromcli.json
+  git add . && git commit -qm "chore: seed"
+
+  SOURCE_FILE=fromenv.json run ${profile_script} --source fromcli.json -d -c -p origin -v 9.9.9
+  assert_success
+  strip_ansi_output
+  assert_output --partial "read from <fromcli.json>: 3.0.0"
+  refute_output --partial "fromenv.json>: 2.0.0"
+}
+
+# ── Surface parity: help + completions ─────────────────────────────────────
+
+@test "--help documents --source" {
+  run get_help_msg
+  assert_success
+  assert_output --partial -- "--source"
+  assert_output --partial "default: package.json"
+}
+
+@test "completions list --source in bash/zsh/fish, restricted to *.json (R-COMP-3)" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "-f|--file|--source"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- '--source[version source'
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l source"
+  assert_output --partial "__fish_complete_suffix .json"
+}

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -11,8 +11,10 @@
 #
 # Description:
 #   An opinionated release tool for Git projects with a `package.json` —
-#   primarily Node / JS / TS projects, but also usable for any SemVer repo
-#   via `-f <file>.json` for the bump target. It automates the mechanical
+#   primarily Node / JS / TS projects, but also usable for any SemVer repo:
+#   `--source <file>.json` swaps the version source / bump target, and with
+#   no version file at all the current version is derived from the latest
+#   release tag. It automates the mechanical
 #   parts of cutting a release (SemVer bump, CHANGELOG, release branch,
 #   tag, push), driven by Conventional Commits, and leaves the integration
 #   step (merge back to `develop` / `main`) to the human.
@@ -43,7 +45,6 @@ source "$MODULE_DIR/lib/config.sh"
 NOW="$(date +%F)"
 
 V_SUGGEST="0.1.0" # This is suggested in case VERSION file or user supplied version via -v is missing
-VER_FILE="package.json"
 GIT_MSG=""
 REL_NOTE=""
 FLAG_DRYRUN=false
@@ -59,6 +60,11 @@ FLAG_DRYRUN=false
 : "${COMMIT_MSG_PREFIX:=chore: }" # Commit msg prefix for the file changes this script makes
 : "${PUSH_DEST:=origin}"
 : "${CHANGELOG_STYLE:=flat}" # CHANGELOG.md style: flat (1.x-identical, default) | grouped
+: "${SOURCE_FILE:=package.json}" # Version source + primary bump target (R-SRC-1/5)
+
+# Internal alias for the resolved version source. Everything downstream reads
+# VER_FILE; main() re-derives it from SOURCE_FILE once config + CLI are final.
+VER_FILE="$SOURCE_FILE"
 
 JSON_FILES=()
 
@@ -73,6 +79,9 @@ main() {
 
   # Process and prepare
   process-arguments "$@"
+  # SOURCE_FILE is final here (CLI --source > env > .ver-bumprc > default);
+  # point the internal VER_FILE alias at it (R-SRC-1/5).
+  VER_FILE="$SOURCE_FILE"
   check-dependencies
   check-release-deps
 


### PR DESCRIPTION
## Summary

The version source was hard-wired to `package.json`, so the README's "any SemVer repo" pitch only held with a dummy manifest or `-v` on every run — and `-v` skips the flagship bump-suggestion machinery entirely. This PR makes the pitch literally true:

1. **`--source <file.json>`** (long-only; `--source value` / `--source=value`) replaces `package.json` as the version source **and** primary bump target. `SOURCE_FILE` config/env key mirrors the flag.
2. **Git-tag fallback** — when the source file is absent, the current version derives from `git describe --tags --abbrev=0 --match "${TAG_PREFIX}[0-9]*"` (prefix stripped, SemVer-validated), and the whole Conventional-Commit suggestion machinery works unchanged.

Refs #63.

## R-SRC coverage

| ID | Requirement | Where |
| --- | --- | --- |
| R-SRC-1 | `--source` replaces source + primary bump target; `package-lock.json` companion bump only when the source really is `package.json` | `lib/args.sh`, `lib/version.sh::do-packagefile-bump` |
| R-SRC-2 | Absent source → `V_PREV` from the latest matching tag; suggestion machinery unchanged | `lib/version.sh::process-version` |
| R-SRC-3 | Tag-derived mode writes nothing for the source; still honours `-f` extras / CHANGELOG / commit / tag / push; nothing staged → commit skipped, annotated tag on HEAD | `lib/git-actions.sh::do-commit` |
| R-SRC-4 | No tags **and** no source file → exit `3` with a dual hint (`-v` for a first release, or create the file) | `lib/version.sh::process-version` |
| R-SRC-5 | `SOURCE_FILE` key, R-CFG-3 precedence (CLI `--source` > env > `.ver-bumprc` > default) | `lib/config.sh` |

Completions (`bash`/`zsh`/`fish`) restrict `--source` to `*.json` like `-f` (R-COMP-3); `--help` row + README stay in flag parity (the `args.bats` parity test passes).

## Design decisions

- **`VER_FILE` becomes an internal alias** derived from `SOURCE_FILE` in `main()` after `process-arguments`, so the existing precedence machinery (`load-config` env snapshot → `apply-config-defaults` → CLI) resolves the source with zero new plumbing. Tests that source the script and set `VER_FILE` directly keep working.
- **Tag derivation also runs on `-v` paths (best-effort)** — it feeds the changelog range, the `bumped X -> Y` commit message, and the no-op guard, matching how a present source file behaves. With `-v` an unusable tag is discarded, never fatal, so the first-release escape route stays open.
- **No-op guard composes for free**: a tag-derived `V_PREV` by definition has a matching tag, so `check-releasable-commits` (PR #77) applies to source-less repos exactly like `package.json` ones; `--allow-empty` remains the override (covered by a test).
- **Tag-only commit skip is ledger-based**: `GIT_MSG` already records every file this run staged, so `do-commit` skips on an empty ledger — giving identical dry-run and live behaviour (dry-run stages nothing for real). The live path double-checks the index so anything pre-staged under `--allow-dirty` is still committed, never silently dropped. The normal flow is untouched (ledger non-empty whenever any file was bumped).
- **Lock companion gated on `VER_FILE = package.json` exactly** — `--source composer.json` in a repo with a stray `package-lock.json` no longer touches it.
- **Docs: new `docs/features/version-source/requirements.md`** rather than extending `version-input/` — R-VER is about validating versions entering the tool; R-SRC is a new bucket about *where* the version comes from. The features index says post-PRD IDs are backfilled one-folder-per-feature, so a new folder matches the existing layout (index row added).

## Test plan

**Before** (develop): a repo without `package.json` exits 3 (`<package.json> was not found`) unless `-v` is passed — and `-v` gives no suggestion, no accurate changelog range, and `git commit` dies with "nothing to commit" when only a tag is wanted. `--source` did not exist; a stray `package-lock.json` was bumped regardless of the bump target.

**After**: `test/version-source.bats` (16 new cases) proves:
- no `package.json`, tag `v1.4.0` + `feat:` commit → suggests `1.5.0`; CHANGELOG + commit + tag land; no `package.json` materialises
- tag-only case (no source, `-c`, nothing staged) → annotated tag on HEAD, no commit — plus dry-run parity for the same skip
- `--source composer.json` reads + writes it; lock-file logic not triggered; default `package.json` + lock behaviour pinned by a regression test
- custom `--tag-prefix rel/` respected in the describe match (decoy `v9.9.9` ignored)
- no tags + no file → exit `3` with the dual hint; `-v` proceeds
- `SOURCE_FILE` rc honoured; env beats rc; `--source` beats env
- `--help` and all three completion emitters list `--source`

`args.bats`: `--source` parse coverage (space/`=` forms, missing/empty value → exit 2).

Full suite: **366/366** (`pnpm tests:run`); `pnpm lint` (shellcheck) clean.