### PR TITLE
docs(style): adopt in-repo standards; scope ralph to Sandcastle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ Full rules in [`docs/CODE_STYLE.md`](docs/CODE_STYLE.md) (§Pull requests,
 
 ### The `ralph:` scope is Sandcastle-only
 
-`ralph:` / `ralph-review:` / `ralph-merge:` scopes are reserved for commits
-authored by the autonomous **Sandcastle** harness in
+The `ralph:<area>`, `ralph-review:<area>`, and `ralph-merge` scopes are
+reserved for commits authored by the autonomous **Sandcastle** harness in
 [`.sandcastle/`](.sandcastle/) — its prompts `git log --grep="ralph:"` to see
 recent loop activity, so the marker only earns its keep on commits that harness
 actually produced. **Do not use these scopes for interactive sessions or normal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,44 @@
 # ver-bump — project instructions
 
-## Package manager
+`ver-bump` is a single-file Bash release tool (`ver-bump.sh` + `lib/*.sh`),
+tested with bats and linted with shellcheck. **The canonical coding standards
+live in [`docs/CODE_STYLE.md`](docs/CODE_STYLE.md)** — read it before writing
+code, commits, PRs, or issues. This file is the short entry point; that doc is
+the source of truth (and it is where project conventions belong — not in any
+tool's private/user-level memory).
 
-Use **pnpm**, not npm. When suggesting or running scripts from `package.json`,
-always prefer `pnpm run <script>` / `pnpm <cmd>`. The repo's lockfile is
-`pnpm-lock.yaml`; treat `package-lock.json` as stale if it appears.
+## Stack
+
+- **Bash 3.2+** (macOS default) — no associative arrays, no bash-4-isms.
+- **git** and **jq** are the only runtime dependencies; `gh` is conditional
+  (`--release` / `--pr`). Node deps are dev-only and must never be required to
+  run `ver-bump.sh`.
+- **pnpm**, not npm. `pnpm-lock.yaml` is canonical; a `package-lock.json` in
+  the tree is a bump *target*, not this project's own lockfile. Key scripts:
+  `pnpm lint` (shellcheck `-x`, must be zero warnings) and `pnpm tests:run`
+  (bats, expected to pass 100%).
+- Tests: bats-core under `test/`, one file per feature; requirements are
+  tracked in `docs/features/*/requirements.md`.
+
+## Commits & PRs
+
+Full rules in [`docs/CODE_STYLE.md`](docs/CODE_STYLE.md) (§Pull requests,
+§GitHub issues). The load-bearing ones:
+
+- **Conventional Commits, scoped:** `<type>(<scope>): <subject>` — imperative,
+  lowercase, no trailing period, ≤ 70 chars. Types: `feat fix refactor test
+  chore docs ci`. Scopes: `ui errors config args version git-actions changelog
+  json completions tests docs publish`.
+- **`Refs #N.`, never `Closes #N.`** — a human closes the issue after review.
+- Branches: `feat/*`, `fix/*`, `refactor/*`, `chore/*`, `docs/*`; releases use
+  `release-<version>`.
+
+### The `ralph:` scope is Sandcastle-only
+
+`ralph:` / `ralph-review:` / `ralph-merge:` scopes are reserved for commits
+authored by the autonomous **Sandcastle** harness in
+[`.sandcastle/`](.sandcastle/) — its prompts `git log --grep="ralph:"` to see
+recent loop activity, so the marker only earns its keep on commits that harness
+actually produced. **Do not use these scopes for interactive sessions or normal
+contributions** (human or agent); those use the plain scopes above. If you are
+not the Sandcastle loop, you are not `ralph`.

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -222,11 +222,11 @@ Rules:
   - `feat(completions): --install-completions with shell auto-detection`
   - `fix(config): reject group-writable or attacker-owned .ver-bumprc`
   - `refactor(ui): strip narrative colour, reserve accents for values`
-- The `ralph:` / `ralph-review:` / `ralph-merge:` scopes are **reserved for the
-  autonomous Sandcastle harness** ([`.sandcastle/`](../.sandcastle/)), whose
-  prompts `git log --grep="ralph:"` to track loop activity. Interactive
-  sessions and normal contributions — human or agent — use the plain scopes
-  above, never a `ralph` marker.
+- The `ralph:<area>`, `ralph-review:<area>`, and `ralph-merge` scopes are
+  **reserved for the autonomous Sandcastle harness**
+  ([`.sandcastle/`](../.sandcastle/)), whose prompts `git log --grep="ralph:"`
+  to track loop activity. Interactive sessions and normal contributions —
+  human or agent — use the plain scopes above, never a `ralph` marker.
 
 ### Body
 

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -222,6 +222,11 @@ Rules:
   - `feat(completions): --install-completions with shell auto-detection`
   - `fix(config): reject group-writable or attacker-owned .ver-bumprc`
   - `refactor(ui): strip narrative colour, reserve accents for values`
+- The `ralph:` / `ralph-review:` / `ralph-merge:` scopes are **reserved for the
+  autonomous Sandcastle harness** ([`.sandcastle/`](../.sandcastle/)), whose
+  prompts `git log --grep="ralph:"` to track loop activity. Interactive
+  sessions and normal contributions — human or agent — use the plain scopes
+  above, never a `ralph` marker.
 
 ### Body
 


### PR DESCRIPTION
## Summary

Makes the project's coding standards discoverable **in the repo** and fixes a convention gap that let the `ralph:` commit scope leak onto non-Sandcastle work.

- **CLAUDE.md** was a one-line pnpm note. Expanded into the project entry point: names [`docs/CODE_STYLE.md`](../blob/develop/docs/CODE_STYLE.md) as the canonical standards, and summarises the stack (Bash 3.2+, git/jq runtime, pnpm, bats/shellcheck) and the load-bearing commit/PR rules. Conventions now live in the repo, not in any tool's private/user-level memory.
- **docs/CODE_STYLE.md** §Pull requests → Title: added an explicit note that `ralph:` / `ralph-review:` / `ralph-merge:` scopes are **reserved for the autonomous Sandcastle harness** (`.sandcastle/`, whose prompts `git log --grep="ralph:"`). Interactive/human/normal-agent contributions use the plain `<type>(<scope>):` form already documented there.

## Why

The `ralph:` marker is a real, deliberate convention — but only for the `.sandcastle/` autonomous loop. It was previously documented **only** inside the Sandcastle prompt files, so anyone (or any agent) not reading those could over-apply it. Pinning the boundary in the canonical standards + CLAUDE.md keeps the `git log --grep="ralph:"` signal meaningful.

## Tests

Docs-only; no code paths touched. `pnpm lint` unaffected; full bats suite unchanged.

No linked issue — governance change requested directly by the maintainer.