### PR TITLE
feat(version): --preid <id> to start or advance a prerelease line

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-q|--quiet] [-h|--help] \
            [--source <file.json>] [--branch] [--pr] [--base <branch>] \
            [--allow-dirty] [--allow-empty] [--no-fetch] [--no-hooks] \
-           [--undo [<version>]] [--major | --minor | --patch] [--release] \
+           [--undo [<version>]] [--major | --minor | --patch] [--preid <id>] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
 ```
 
@@ -453,9 +453,23 @@ to the bump commit only; the annotated tag's message keeps its own knob,
     --major                   Force a major bump from the current version.
                               Mutually exclusive with --minor / --patch and -v.
                               From a prerelease (X.Y.Z-dev.N), drops the prerelease
-                              before bumping the stable component.
+                              before bumping the stable component (unless combined
+                              with --preid — see below).
     --minor                   Force a minor bump (see --major for semantics).
     --patch                   Force a patch bump (see --major for semantics).
+    --preid <id>              Start or advance a prerelease line. Combined with
+                              --major/--minor/--patch: bump that level, then enter
+                              the prerelease at <id>.1 (1.2.3 --major --preid rc ->
+                              2.0.0-rc.1). Alone, on a version that already has a
+                              prerelease: the same id increments the trailing
+                              counter (4.0.0-dev.6 -> 4.0.0-dev.7); a different id
+                              swaps it and resets the counter (2.0.0-alpha.3 +
+                              --preid rc -> 2.0.0-rc.1). Alone on a stable version
+                              is ambiguous and exits 2 — combine with a bump-level
+                              switch. Mutually exclusive with -v. <id> is validated
+                              against the SemVer prerelease grammar (dot-separated
+                              alphanumeric/hyphen identifiers, no leading-zero
+                              numeric parts) before anything is mutated.
     --allow-dirty             Skip the clean-working-tree check and release with
                               uncommitted changes to tracked files. Untracked files
                               never trigger the check. Also available as the
@@ -525,6 +539,22 @@ version, use `--major` / `--minor` / `--patch`. They bump the current
 version's matching component, drop any prerelease/build metadata
 (`1.2.3-dev.5 --patch` → `1.2.4`), and are mutually exclusive with each
 other and with `-v`. Combining more than one exits with code `2`.
+
+To **enter** or **advance** a prerelease line, add `--preid <id>`:
+
+| Command | Current | Result |
+| --- | --- | --- |
+| `--major --preid rc` | `1.2.3` | `2.0.0-rc.1` |
+| `--patch --preid beta` | `1.2.3` | `1.2.4-beta.1` |
+| `--preid dev` (alone) | `4.0.0-dev.6` | `4.0.0-dev.7` (same id → counter++) |
+| `--preid rc` (alone) | `2.0.0-alpha.3` | `2.0.0-rc.1` (different id → reset) |
+| `--preid rc` (alone) | `1.2.3` (stable) | exit `2` — ambiguous, combine with `--major`/`--minor`/`--patch` |
+
+`--preid` is mutually exclusive with `-v`, and `<id>` is validated against
+the SemVer prerelease grammar before anything is mutated. To graduate a
+prerelease back to a stable release, `--major`/`--minor`/`--patch` without
+`--preid` bumps from the stable core as usual, or pass an explicit
+`-v <version>` / accept the interactive prompt.
 
 ### Dry-run
 

--- a/README.md
+++ b/README.md
@@ -433,9 +433,10 @@ to the bump commit only; the annotated tag's message keeps its own knob,
                               exactly one line: the new version (no tag prefix, no
                               colour); everything else goes to stderr. Errors keep
                               the usual exit codes; a no-op run (nothing to release)
-                              prints nothing and exits 0. Requires --yes, -v, or
-                              --major/--minor/--patch, and refuses -l/--pause-changelog
-                              (a hidden prompt would hang the pipeline). CI capture:
+                              prints nothing and exits 0. Requires --yes, -v,
+                              --major/--minor/--patch, or --preid, and refuses
+                              -l/--pause-changelog (a hidden prompt would hang the
+                              pipeline). CI capture:
                                 NEW_VERSION=$(ver-bump --yes --quiet -p origin)
 -h, --help                    Show help message.
     --source <file.json>      Version source + primary bump target (default:

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -12,6 +12,7 @@ contract); IDs added after the PRD are backfilled here first.
 | [version-source](./version-source/requirements.md) | R-SRC | `version-source.bats` |
 | [bump-suggestion](./bump-suggestion/requirements.md) | R-BUMP | `bump-suggest.bats` |
 | [explicit-bump-switches](./explicit-bump-switches/requirements.md) | R-FORCE | `args.bats`, `bump-suggest.bats` |
+| [prerelease](./prerelease/requirements.md) | R-PRE | `args.bats`, `preid.bats` |
 | [cli-options](./cli-options/requirements.md) | R-OPT | `args.bats` |
 | [non-interactive](./non-interactive/requirements.md) | R-YES | `args.bats`, `config.bats` |
 | [dry-run](./dry-run/requirements.md) | R-DRY | `dryrun.bats` |

--- a/docs/features/prerelease/requirements.md
+++ b/docs/features/prerelease/requirements.md
@@ -1,0 +1,27 @@
+# Prerelease entry
+
+`R-BUMP-1` iterates an existing prerelease nicely (`4.0.0-dev.6` →
+`dev.7`), but there was no switch to **enter** one — `1.2.3` → `2.0.0-rc.1`
+required a hand-typed `-v`. `--preid <id>` closes that gap, composing with
+the existing `--major`/`--minor`/`--patch` switches rather than adding four
+npm-style `pre*` subcommand flags (issue #64).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-PRE-1 | `--preid <id>` with a level switch (`--major`/`--minor`/`--patch`): bump that level, then append `-<id>.1`. Example: `1.2.3` + `--major --preid rc` → `2.0.0-rc.1`. | ✅ shipped — `lib/version.sh` |
+| R-PRE-2 | `--preid <id>` alone on a version that already has a prerelease: same id → increment the counter (the R-BUMP-1 path, via `bump-prerelease`); different id → swap the id and reset the counter to `.1`. Example: `2.0.0-alpha.3` + `--preid rc` → `2.0.0-rc.1`. | ✅ shipped — `bump-preid`, `lib/validate.sh` |
+| R-PRE-3 | `--preid` alone on a **stable** version → exit `2` (ambiguous bump level; message names `--major`/`--minor`/`--patch`). | ✅ shipped — `lib/version.sh` |
+| R-PRE-4 | Conflicts with `-v <version>` → exit `2`, order-independent (extends the R-FORCE-2 mutual-exclusion matrix). | ✅ shipped — `lib/args.sh` |
+| R-PRE-5 | `<id>` is validated against the SemVer prerelease grammar (dot-separated alphanumeric/hyphen identifiers, no leading-zero numeric parts) at parse time, before any mutation. | ✅ shipped — `is_prerelease_id`, `lib/validate.sh` |
+| R-PRE-6 | Graduating out of a prerelease is unchanged: interactive prompt or `-v 2.0.0`. `--major`/`--minor`/`--patch` **without** `--preid` on a prerelease version bumps from the stable core (documented in `--help` and the README). | ✅ shipped (pre-existing `force-bump` behaviour) — `lib/usage.sh` |
+
+`PRE_ID` is CLI-only (reset in `process-arguments`, same rationale as
+`BUMP_LEVEL` — R-CFG-6): no env / `.ver-bumprc` contract.
+
+Modules: `lib/args.sh` (parse + validate + `-v` conflict), `lib/version.sh`
+(`process-version` composition), `lib/validate.sh` (`is_prerelease_id`,
+`bump-preid`), `lib/usage.sh` / `lib/completions.sh` / `README.md` (surface
+parity).
+
+Tests: `test/args.bats` (flag parsing), `test/preid.bats` (composition +
+semantics, unit and end-to-end).

--- a/docs/features/ui-output/requirements.md
+++ b/docs/features/ui-output/requirements.md
@@ -23,7 +23,7 @@ capture pattern.
 | ID | Requirement | Status |
 | --- | --- | --- |
 | R-OUT-1 | `-q`/`--quiet`: decorative output is routed off stdout; on success stdout carries exactly one line — the new version, no tag prefix, no colour codes. Errors keep going to stderr with the contract exit codes. | ✅ shipped — `test/quiet.bats` |
-| R-OUT-2 | `--quiet` and interactive prompts are incompatible by construction (a hidden prompt is a hung pipeline): `--quiet` without `--yes`, `-v`, or a forced bump level exits `2` naming the fix; `--quiet` with `-l`/`--pause-changelog` (flag or rc key) exits `2`; `--quiet --undo` without `--yes` exits `2`. | ✅ shipped — `test/quiet.bats` |
+| R-OUT-2 | `--quiet` and interactive prompts are incompatible by construction (a hidden prompt is a hung pipeline): `--quiet` without `--yes`, `-v`, a forced bump level, or `--preid` exits `2` naming the fix; `--quiet` with `-l`/`--pause-changelog` (flag or rc key) exits `2`; `--quiet --undo` without `--yes` exits `2`. | ✅ shipped — `test/quiet.bats`, `test/preid.bats` |
 | R-OUT-3 | Composes with `--dry-run`: stdout gets the would-be version; the `[dry-run]` side-effect lines target stderr (R-DRY-2), so the pipe stays clean. | ✅ shipped — `test/quiet.bats` |
 | R-OUT-4 | A quiet no-op (nothing to release, R-SAFE-14) prints **nothing** on stdout — the `no-release` token is rerouted with the rest of the decoration — and exits `0`, so `[ -z "$out" ]` is the CI branch test for "no release happened". | ✅ shipped — `test/quiet.bats` |
 

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -316,6 +316,36 @@ normalize-long-opts() {
       ;;
     esac
 
+    # --preid <id> / --preid=<id> — start or advance a prerelease line
+    # (R-PRE bucket, issue #64). Long-only value flag, same shape as
+    # --source. Grammar-validated against the SemVer prerelease identifier
+    # chain before any mutation (R-PRE-5) — is_prerelease_id lives in
+    # lib/validate.sh, sourced before lib/args.sh. The -v / --version
+    # conflict (R-PRE-4) is caught later when getopts processes -v, mirroring
+    # the --major/--minor/--patch-vs-v check above: PRE_ID is already set by
+    # the time normalize-long-opts has emitted -v into NORMALIZED_ARGV,
+    # regardless of which flag appeared first on the command line.
+    if [ "$arg" = "--preid" ] || [[ "$arg" == "--preid="* ]]; then
+      if [[ "$arg" == "--preid="* ]]; then
+        PRE_ID="${arg#--preid=}"
+        [ -z "$PRE_ID" ] && fail 2 \
+          "--preid= requires a value." \
+          "Pass a prerelease id: --preid <id> or --preid=<id>."
+      elif (( $# )) && [ "${1:0:1}" != "-" ]; then
+        PRE_ID="$1"; shift
+      else
+        fail 2 \
+          "Option --preid requires a value." \
+          "Pass a prerelease id: --preid <id> or --preid=<id>."
+      fi
+      if ! is_prerelease_id "$PRE_ID"; then
+        fail 2 \
+          "Invalid --preid value '${PRE_ID}': not a valid SemVer prerelease identifier." \
+          "Use dot-separated alphanumeric/hyphen identifiers with no leading-zero numeric parts, e.g. rc, beta, dev-2."
+      fi
+      continue
+    fi
+
     if [[ "$arg" == --*=* ]]; then
       name="${arg%%=*}"; name="${name#--}"
       val="${arg#*=}"
@@ -381,17 +411,18 @@ normalize-long-opts() {
 process-arguments() {
   local OPTIONS OPTIND OPTARG
 
-  # DO_RELEASE, BUMP_LEVEL, ALLOW_EMPTY, FLAG_QUIET, and FLAG_NOHOOKS are
-  # CLI-only switches with no env / .ver-bumprc contract. Reset them before
-  # parsing so an inherited exported var — or a .ver-bumprc assignment
+  # DO_RELEASE, BUMP_LEVEL, PRE_ID, ALLOW_EMPTY, FLAG_QUIET, and FLAG_NOHOOKS
+  # are CLI-only switches with no env / .ver-bumprc contract. Reset them
+  # before parsing so an inherited exported var — or a .ver-bumprc assignment
   # (load-config sources the rc as raw shell) — can't silently force a bump,
-  # publish a release, push an empty release, hide the run's output, or
-  # disable the release hooks with no flag on the command line. FLAG_QUIET
-  # follows the FLAG_YES rationale (R-YES-3): a hidden-output mode must be an
-  # explicit per-invocation choice.
+  # start/advance a prerelease, publish a release, push an empty release,
+  # hide the run's output, or disable the release hooks with no flag on the
+  # command line. FLAG_QUIET follows the FLAG_YES rationale (R-YES-3): a
+  # hidden-output mode must be an explicit per-invocation choice.
   DO_RELEASE=false
   DO_PR=false
   BUMP_LEVEL=
+  PRE_ID=
   ALLOW_EMPTY=false
   FLAG_QUIET=false
   FLAG_NOHOOKS=false
@@ -441,6 +472,11 @@ process-arguments() {
           fail 2 \
             "Conflicting flags: -v / --version and --${BUMP_LEVEL} are mutually exclusive." \
             "Pass either an explicit version (-v X.Y.Z) or a bump level (--${BUMP_LEVEL}), not both."
+        fi
+        if [ -n "${PRE_ID-}" ]; then
+          fail 2 \
+            "Conflicting flags: -v / --version and --preid are mutually exclusive." \
+            "Pass either an explicit version (-v X.Y.Z) or --preid (optionally with --major/--minor/--patch), not both."
         fi
         V_USR_SUPPLIED=$OPTARG
       ;;
@@ -521,10 +557,10 @@ process-arguments() {
         "--quiet is incompatible with -l/--pause-changelog (an interactive pause would hang a captured pipeline)." \
         "Drop -l/--pause-changelog (or unset FLAG_CHANGELOG_PAUSE in .ver-bumprc), or drop --quiet."
     fi
-    if [ "${FLAG_YES:-false}" != true ] && [ -z "${V_USR_SUPPLIED-}" ] && [ -z "${BUMP_LEVEL-}" ]; then
+    if [ "${FLAG_YES:-false}" != true ] && [ -z "${V_USR_SUPPLIED-}" ] && [ -z "${BUMP_LEVEL-}" ] && [ -z "${PRE_ID-}" ]; then
       fail 2 \
         "--quiet would hide the interactive version prompt (a hidden prompt is a hung pipeline)." \
-        "Add --yes to accept the suggested version, pass -v <version>, or force a level with --major/--minor/--patch."
+        "Add --yes to accept the suggested version, pass -v <version>, or force a level with --major/--minor/--patch/--preid."
     fi
   fi
 }

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -142,14 +142,14 @@ _ver_bump() {
             return 0
             ;;
         # Options that take a free-form argument — no completion
-        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo|--base)
+        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo|--base|--preid)
             return 0
             ;;
     esac
 
     opts="--version --message --file --source --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
-          --yes --quiet --undo --branch --pr --base --major --minor --patch --release \
+          --yes --quiet --undo --branch --pr --base --major --minor --patch --preid --release \
           --sign --allow-dirty --allow-empty --no-fetch --no-hooks \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -q -h"
@@ -190,6 +190,7 @@ _ver_bump() {
     '(--major --minor --patch -v --version)--major[force a major bump from the current version]' \
     '(--major --minor --patch -v --version)--minor[force a minor bump from the current version]' \
     '(--major --minor --patch -v --version)--patch[force a patch bump from the current version]' \
+    '(-v --version)--preid[start or advance a prerelease line]:id:' \
     '--release[publish a GitHub release for the new tag via gh]' \
     '--sign[create a signed tag (git tag -s) instead of annotated]' \
     '--allow-dirty[skip the clean-working-tree preflight]' \
@@ -231,6 +232,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd      -l major          -d 'Force a major bump from the current version'
     complete -c $_cmd      -l minor          -d 'Force a minor bump from the current version'
     complete -c $_cmd      -l patch          -d 'Force a patch bump from the current version'
+    complete -c $_cmd      -l preid          -r -d 'Start or advance a prerelease line'
     complete -c $_cmd      -l release        -d 'Publish a GitHub release for the new tag via gh'
     complete -c $_cmd      -l sign           -d 'Create a signed tag (git tag -s) instead of annotated'
     complete -c $_cmd      -l allow-dirty    -d 'Skip the clean-working-tree preflight'

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -119,7 +119,7 @@ usage() {
   print-opt-row "-l" "--pause-changelog" ""          "Pause before commit so CHANGELOG.md can be edited."
   print-opt-row "-h" "--help"          ""            "Show this help message."
   print-opt-row "-y" "--yes"           ""            "Skip interactive confirmation prompts."
-  print-opt-row "-q" "--quiet"         ""            "Suppress decoration; print only the new version on stdout (needs -y, -v, or a level)."
+  print-opt-row "-q" "--quiet"         ""            "Suppress decoration; print only the new version on stdout (needs -y, -v, a bump level, or --preid)."
   print-opt-row ""   "--source"        "<file.json>" "Version source + primary bump target (default: package.json)."
   print-opt-cont "If the file is missing, the current version derives from the latest matching git tag."
   print-opt-row ""   "--undo"          "[<version>]" "Locally delete release-X.Y.Z + tag vX.Y.Z (refuses if pushed/dirty)."

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -46,7 +46,7 @@ usage() {
   printf '\n%bUSAGE %b\n' "${S_HDR_CYAN-}" "${S_HDR_END-}"
   printf '  %b%s%b [-v <version>] [-m <message>] [-f <file.json>]... [-p <remote>] [-t <tag-prefix>] [-B <branch-prefix>] [-d] [-n] [-b] [-c] [-l] [-h]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
-  printf '  %b%s%b [--source <file.json>] [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--release] [--sign] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
+  printf '  %b%s%b [--source <file.json>] [--branch] [--pr] [--base <branch>] [--major | --minor | --patch] [--preid <id>] [--release] [--sign] [--completions <shell>] [--install-completions[=<shell>]] [--about]\n' \
     "${BOLD-}" "${SCRIPT_NAME}" "${RESET-}"
 
   # Column width for label + 2-space gutter. Longest label is
@@ -126,6 +126,11 @@ usage() {
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
   print-opt-row ""   "--patch"              ""            "Force a patch bump from the current version (mutually exclusive)."
+  print-opt-cont "Without --preid, any of the three drops an existing prerelease/build and bumps the stable core (1.2.3-dev.5 --patch -> 1.2.4)."
+  print-opt-row ""   "--preid"              "<id>"        "Start or advance a prerelease line; conflicts with -v."
+  print-opt-cont "With --major/--minor/--patch: bump that level, then enter <id>.1 (1.2.3 --major --preid rc -> 2.0.0-rc.1)."
+  print-opt-cont "Alone, on a version that already has a prerelease: same id increments the counter, a different id resets it to .1."
+  print-opt-cont "Alone, on a stable version: ambiguous -> exit 2 (combine with --major/--minor/--patch)."
   print-opt-row ""   "--allow-dirty"        ""            "Skip the clean-working-tree check (untracked files never trigger it)."
   print-opt-row ""   "--allow-empty"        ""            "Release even with no new commits since the previous tag."
   print-opt-row ""   "--no-fetch"           ""            "Skip the remote-sync preflight (no fetch / behind-upstream check)."

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -18,6 +18,16 @@ is_semver() {
   [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]
 }
 
+# Returns 0 if $1 is a valid SemVer 2.0 prerelease identifier chain — the
+# same grammar as the prerelease group inside is_semver's regex (kept in
+# sync deliberately): dot-separated alphanumeric/hyphen identifiers, no
+# leading-zero numeric identifiers. Used to validate --preid values before
+# any mutation (R-PRE-5). Examples: "rc", "beta.1", "dev-2" are valid;
+# "bad..id" (empty identifier) and "01" (leading-zero numeric) are not.
+is_prerelease_id() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*$ ]]
+}
+
 # Bump a SemVer prerelease version's trailing numeric counter.
 # Examples:
 #   1.2.3-dev.6         -> 1.2.3-dev.7
@@ -54,6 +64,36 @@ bump-prerelease() {
   local joined
   joined=$( IFS='.'; echo "${parts[*]}" )
   printf '%s' "${base}-${joined}${build}"
+}
+
+# Compose a --preid <id> value with a version that already has a prerelease
+# (R-PRE-2): same id as the current prerelease -> increment the trailing
+# counter (delegates to bump-prerelease, the existing R-BUMP-1 behaviour);
+# different id -> swap to <id>.1, resetting the counter. Build metadata
+# after '+' is preserved either way. Caller (process-version) only invokes
+# this once $1 is confirmed to have an existing prerelease segment
+# (R-PRE-3 handles the stable-version case separately).
+# Examples:
+#   bump-preid "4.0.0-dev.6"        dev -> 4.0.0-dev.7   (same id, counter++)
+#   bump-preid "2.0.0-alpha.3"      rc  -> 2.0.0-rc.1     (different id, reset)
+#   bump-preid "2.1.0-beta.3+b.sha" rc  -> 2.1.0-rc.1+b.sha
+bump-preid() {
+  local version="$1" want="$2" core build="" pre cur_id base
+  core="$version"
+  if [[ "$core" == *+* ]]; then
+    build="+${core#*+}"
+    core="${core%%+*}"
+  fi
+  if [[ "$core" == *-* ]]; then
+    pre="${core#*-}"
+    cur_id="${pre%%.*}"
+    if [ "$cur_id" = "$want" ]; then
+      bump-prerelease "$version"
+      return
+    fi
+  fi
+  base="${core%%-*}"
+  printf '%s-%s.1%s' "$base" "$want" "$build"
 }
 
 # Force a major / minor / patch bump on a SemVer string, dropping any

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -73,12 +73,22 @@ bump-prerelease() {
 # after '+' is preserved either way. Caller (process-version) only invokes
 # this once $1 is confirmed to have an existing prerelease segment
 # (R-PRE-3 handles the stable-version case separately).
+#
+# --preid is a full dot-separated identifier chain, so "same id" compares
+# the WHOLE current id — the prerelease string minus a single trailing
+# numeric counter segment — against $want, not just the first segment.
+# That keeps dotted ids intact (foo.bar.6 + foo.bar -> foo.bar.7) and makes
+# a prefix like "foo" count as DIFFERENT from "foo.bar" (foo.bar.6 + foo ->
+# foo.1). A current prerelease with no trailing numeric counter is its own
+# id (1.0.0-alpha + alpha -> alpha.1, the R-BUMP-1 append-".1" behaviour).
 # Examples:
-#   bump-preid "4.0.0-dev.6"        dev -> 4.0.0-dev.7   (same id, counter++)
-#   bump-preid "2.0.0-alpha.3"      rc  -> 2.0.0-rc.1     (different id, reset)
-#   bump-preid "2.1.0-beta.3+b.sha" rc  -> 2.1.0-rc.1+b.sha
+#   bump-preid "4.0.0-dev.6"        dev     -> 4.0.0-dev.7      (same id, counter++)
+#   bump-preid "1.2.3-foo.bar.6"    foo.bar -> 1.2.3-foo.bar.7  (dotted same id, counter++)
+#   bump-preid "1.2.3-foo.bar.6"    foo     -> 1.2.3-foo.1       (different id, reset)
+#   bump-preid "2.0.0-alpha.3"      rc      -> 2.0.0-rc.1        (different id, reset)
+#   bump-preid "2.1.0-beta.3+b.sha" rc      -> 2.1.0-rc.1+b.sha
 bump-preid() {
-  local version="$1" want="$2" core build="" pre cur_id base
+  local version="$1" want="$2" core build="" pre cur_id last_seg base
   core="$version"
   if [[ "$core" == *+* ]]; then
     build="+${core#*+}"
@@ -86,7 +96,14 @@ bump-preid() {
   fi
   if [[ "$core" == *-* ]]; then
     pre="${core#*-}"
-    cur_id="${pre%%.*}"
+    # The current id is the whole prerelease chain minus a trailing numeric
+    # counter segment (if any). Strip only when there's a dotted segment to
+    # strip, so a bare "alpha" stays "alpha".
+    cur_id="$pre"
+    if [[ "$pre" == *.* ]]; then
+      last_seg="${pre##*.}"
+      is_number "$last_seg" && cur_id="${pre%.*}"
+    fi
     if [ "$cur_id" = "$want" ]; then
       bump-prerelease "$version"
       return

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -30,10 +30,11 @@ process-version() {
 
     if [ -n "$V_PREV" ]; then
       echo -e "\nCurrent version read from <${S_VAL}${VER_FILE}${RESET}>: ${S_VAL}$V_PREV${RESET}"
-      # Only compute a suggestion when we'll actually prompt for it. With -v or
-      # --major/--minor/--patch the suggestion is discarded; running it anyway
-      # printed a contradictory "suggesting <level> bump" line and an extra git log.
-      if [ -z "$V_USR_SUPPLIED" ] && [ -z "${BUMP_LEVEL-}" ]; then
+      # Only compute a suggestion when we'll actually prompt for it. With -v,
+      # --major/--minor/--patch, or --preid the suggestion is discarded;
+      # running it anyway printed a contradictory "suggesting <level> bump"
+      # line and an extra git log.
+      if [ -z "$V_USR_SUPPLIED" ] && [ -z "${BUMP_LEVEL-}" ] && [ -z "${PRE_ID-}" ]; then
         set-v-suggest "$V_PREV" # check + compute next version from conventional commits (or patch +1)
       fi
     elif [ -z "$V_USR_SUPPLIED" ]; then
@@ -69,7 +70,7 @@ process-version() {
         V_PREV=""
       else
         echo -e "\n<${S_VAL}${VER_FILE}${RESET}> ${reason} — current version derived from git tag <${S_VAL}${derived_tag}${RESET}>: ${S_VAL}$V_PREV${RESET}"
-        if [ -z "$V_USR_SUPPLIED" ] && [ -z "${BUMP_LEVEL-}" ]; then
+        if [ -z "$V_USR_SUPPLIED" ] && [ -z "${BUMP_LEVEL-}" ] && [ -z "${PRE_ID-}" ]; then
           set-v-suggest "$V_PREV" # full suggestion machinery, unchanged (R-SRC-2)
         fi
       fi
@@ -86,24 +87,51 @@ process-version() {
   if [ -n "$V_USR_SUPPLIED" ]; then
     echo -e "\nVersion supplied via [-v]: ${S_VAL}${V_USR_SUPPLIED}${RESET}"
     V_NEW="${V_USR_SUPPLIED}"
-  elif [ -n "${BUMP_LEVEL-}" ]; then
-    # Forced bump via --major / --minor / --patch. Needs a SemVer V_PREV
-    # to bump from; argument-parse-time conflict checks already prevent
-    # combining this with -v.
+  elif [ -n "${BUMP_LEVEL-}" ] || [ -n "${PRE_ID-}" ]; then
+    # Forced bump via --major / --minor / --patch, and/or entering or
+    # advancing a prerelease line via --preid (R-PRE bucket, issue #64).
+    # Needs a SemVer V_PREV to bump from; argument-parse-time conflict
+    # checks already prevent combining either with -v.
     if [ -z "$V_PREV" ] || ! is_semver "$V_PREV"; then
       fail 3 \
-        "Cannot apply --${BUMP_LEVEL}: current version '${V_PREV}' is not a valid SemVer 2.0 version." \
+        "Cannot apply --${BUMP_LEVEL:-preid}: current version '${V_PREV}' is not a valid SemVer 2.0 version." \
         "Ensure ${VER_FILE} contains a SemVer \"version\" field, or pass an explicit -v <version>."
     fi
-    # force-bump returns 1 (empty output) on an unknown level. With the reset in
-    # process-arguments BUMP_LEVEL is always major/minor/patch here, but guard
-    # anyway so a bad value can never propagate an empty V_NEW into the tag/commit.
-    if ! V_NEW=$(force-bump "$V_PREV" "$BUMP_LEVEL") || [ -z "$V_NEW" ]; then
-      fail 3 \
-        "Cannot compute a '${BUMP_LEVEL}' bump from '${V_PREV}'." \
-        "Use --major, --minor, or --patch, or pass an explicit -v <version>."
+
+    if [ -n "${BUMP_LEVEL-}" ]; then
+      # force-bump returns 1 (empty output) on an unknown level. With the reset
+      # in process-arguments BUMP_LEVEL is always major/minor/patch here, but
+      # guard anyway so a bad value can never propagate an empty V_NEW into
+      # the tag/commit.
+      if ! V_NEW=$(force-bump "$V_PREV" "$BUMP_LEVEL") || [ -z "$V_NEW" ]; then
+        fail 3 \
+          "Cannot compute a '${BUMP_LEVEL}' bump from '${V_PREV}'." \
+          "Use --major, --minor, or --patch, or pass an explicit -v <version>."
+      fi
+      if [ -n "${PRE_ID-}" ]; then
+        # R-PRE-1: bump the level (force-bump already dropped any prerelease
+        # / build metadata), then enter the prerelease at <preid>.1.
+        V_NEW="${V_NEW}-${PRE_ID}.1"
+        echo -e "\n${S_LIGHT}Forced ${S_VAL}${BUMP_LEVEL}${RESET}${S_LIGHT} bump into prerelease ${S_VAL}${PRE_ID}${RESET}${S_LIGHT}: ${S_VAL}${V_PREV}${RESET}${S_LIGHT} ${I_ARROW-→} ${S_VAL}${V_NEW}${RESET}"
+      else
+        echo -e "\n${S_LIGHT}Forced ${S_VAL}${BUMP_LEVEL}${RESET}${S_LIGHT} bump: ${S_VAL}${V_PREV}${RESET}${S_LIGHT} ${I_ARROW-→} ${S_VAL}${V_NEW}${RESET}"
+      fi
+    else
+      # --preid alone, no --major/--minor/--patch (R-PRE-2 / R-PRE-3). Only
+      # meaningful on a version that already has a prerelease — strip build
+      # metadata first so a hyphen inside +build.info can't masquerade as one.
+      case "${V_PREV%%+*}" in
+        *-*)
+          V_NEW=$(bump-preid "$V_PREV" "$PRE_ID")
+          echo -e "\n${S_LIGHT}Prerelease ${S_VAL}${PRE_ID}${RESET}${S_LIGHT}: ${S_VAL}${V_PREV}${RESET}${S_LIGHT} ${I_ARROW-→} ${S_VAL}${V_NEW}${RESET}"
+        ;;
+        *)
+          fail 2 \
+            "--preid on a stable version ('${V_PREV}') is ambiguous." \
+            "Combine with --major, --minor, or --patch to enter a prerelease, e.g. --major --preid ${PRE_ID}."
+        ;;
+      esac
     fi
-    echo -e "\n${S_LIGHT}Forced ${S_VAL}${BUMP_LEVEL}${RESET}${S_LIGHT} bump: ${S_VAL}${V_PREV}${RESET}${S_LIGHT} ${I_ARROW-→} ${S_VAL}${V_NEW}${RESET}"
   else
     # Display a suggested version
     echo -ne "\n${S_QUESTION}Enter a new version number, <enter> for [${S_VAL}$V_SUGGEST${S_QUESTION}], or <esc> to quit:${RESET} "

--- a/test/args.bats
+++ b/test/args.bats
@@ -219,6 +219,60 @@ load 'test_helper'
   assert_output --partial "requires a file path"
 }
 
+# --preid <id> — issue #64. Semantics (R-PRE-1/2/3/6) live in preid.bats;
+# these are the flag-parsing cases CODE_STYLE requires here.
+
+@test "long options: --preid sets PRE_ID (space and = forms)" {
+  source ${profile_script}
+  process-arguments --preid rc
+  assert_equal "${PRE_ID}" "rc"
+  process-arguments --preid=beta
+  assert_equal "${PRE_ID}" "beta"
+}
+
+@test "long options: --preid without value exits 2" {
+  source ${profile_script}
+  run process-arguments --preid
+  assert_failure 2
+  assert_output --partial "Option --preid requires a value"
+}
+
+@test "long options: --preid= empty value exits 2" {
+  source ${profile_script}
+  run process-arguments --preid=
+  assert_failure 2
+  assert_output --partial "--preid= requires a value"
+}
+
+@test "long options: --preid rejects a value that isn't a SemVer prerelease identifier (R-PRE-5)" {
+  source ${profile_script}
+  run process-arguments --preid 'bad..id'
+  assert_failure 2
+  assert_output --partial "not a valid SemVer prerelease identifier"
+
+  run process-arguments --preid 01
+  assert_failure 2
+  assert_output --partial "not a valid SemVer prerelease identifier"
+}
+
+@test "process-arguments: --preid conflicts with -v, order-independent (R-PRE-4)" {
+  source ${profile_script}
+  run process-arguments --preid rc -v 2.0.0
+  assert_failure 2
+  assert_output --partial "Conflicting flags"
+
+  run process-arguments -v 2.0.0 --preid rc
+  assert_failure 2
+  assert_output --partial "Conflicting flags"
+}
+
+@test "process-arguments: resets a stale PRE_ID from the environment (R-CFG-6)" {
+  source ${profile_script}
+  PRE_ID="leaked"
+  process-arguments -d
+  assert_equal "${PRE_ID}" ""
+}
+
 @test "long options: --push <remote> sets push flag + dest" {
   source ${profile_script}
   process-arguments --push upstream

--- a/test/preid.bats
+++ b/test/preid.bats
@@ -66,6 +66,18 @@ preid_repo() {
   assert_equal "$(bump-preid '2.1.0-beta.3+build.sha' rc)"   "2.1.0-rc.1+build.sha"
 }
 
+@test "bump-preid: compares the whole dotted id, not just the first segment" {
+  source ${profile_script}
+  # Same dotted id -> increment the trailing counter.
+  assert_equal "$(bump-preid '1.2.3-foo.bar.6' foo.bar)" "1.2.3-foo.bar.7"
+  # A prefix of the current id is DIFFERENT -> swap + reset to .1.
+  assert_equal "$(bump-preid '1.2.3-foo.bar.6' foo)" "1.2.3-foo.1"
+  # And the reverse: the current id is a prefix of the wanted id.
+  assert_equal "$(bump-preid '1.2.3-foo.6' foo.bar)" "1.2.3-foo.bar.1"
+  # Dotted id with no trailing numeric counter -> R-BUMP-1 append ".1".
+  assert_equal "$(bump-preid '1.2.3-foo.bar' foo.bar)" "1.2.3-foo.bar.1"
+}
+
 # ── process-version composition (R-PRE-1) ───────────────────────────────────
 
 @test "process-version: --major --preid rc on a stable version enters a prerelease (R-PRE-1)" {

--- a/test/preid.bats
+++ b/test/preid.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+
+# --preid <id>: start or advance a prerelease line (R-PRE bucket, issue #64).
+# Composes with the existing --major/--minor/--patch bump-level switches:
+#   - level + --preid       -> bump the level, then enter <id>.1   (R-PRE-1)
+#   - --preid alone, already prerelease -> same id increments the counter,
+#     a different id swaps it and resets to .1                    (R-PRE-2)
+#   - --preid alone, stable -> ambiguous, exit 2                   (R-PRE-3)
+#   - --preid vs -v         -> mutually exclusive, exit 2          (R-PRE-4)
+#   - <id> grammar          -> validated before any mutation       (R-PRE-5)
+#   - level w/o --preid on a prerelease -> bumps the stable core   (R-PRE-6)
+#
+# Flag-parsing coverage (space/= forms, missing/empty value, the -v
+# conflict, the PRE_ID env-reset) lives in args.bats per CODE_STYLE; this
+# file covers the composition semantics, unit-level and end-to-end.
+
+load 'test_helper'
+
+# Scratch repo with package.json pinned to $1 (default 1.2.3), committed —
+# process-version's forced/preid paths never consult conventional commits,
+# so no tag or extra history is needed for the e2e cases below.
+preid_repo() {
+  local ver="${1:-1.2.3}"
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "%s" }\n' "$ver" > package.json
+  git add package.json && git commit -qm "chore: bumped to ${ver}"
+}
+
+# ── is_prerelease_id — grammar validation (R-PRE-5) ─────────────────────────
+
+@test "is_prerelease_id: accepts and rejects per the SemVer prerelease grammar" {
+  source ${profile_script}
+  is_prerelease_id "rc"      || return 1
+  is_prerelease_id "beta.1"  || return 1
+  is_prerelease_id "dev-2"   || return 1
+  is_prerelease_id "0"       || return 1
+  is_prerelease_id "alpha.0" || return 1
+
+  ! is_prerelease_id ""        || return 1
+  ! is_prerelease_id "bad..id" || return 1
+  ! is_prerelease_id "01"      || return 1
+  ! is_prerelease_id "rc."     || return 1
+  ! is_prerelease_id ".rc"     || return 1
+}
+
+# ── bump-preid — counter increment vs id swap (R-PRE-2) ─────────────────────
+
+@test "bump-preid: same id increments the trailing counter" {
+  source ${profile_script}
+  assert_equal "$(bump-preid '4.0.0-dev.6' dev)" "4.0.0-dev.7"
+  assert_equal "$(bump-preid '2.0.0-alpha.3' alpha)" "2.0.0-alpha.4"
+  assert_equal "$(bump-preid '1.0.0-alpha' alpha)" "1.0.0-alpha.1"
+}
+
+@test "bump-preid: different id swaps and resets the counter to .1" {
+  source ${profile_script}
+  assert_equal "$(bump-preid '2.0.0-alpha.3' rc)" "2.0.0-rc.1"
+  assert_equal "$(bump-preid '1.0.0-alpha' beta)" "1.0.0-beta.1"
+}
+
+@test "bump-preid: preserves build metadata in both branches" {
+  source ${profile_script}
+  assert_equal "$(bump-preid '2.1.0-beta.3+build.sha' beta)" "2.1.0-beta.4+build.sha"
+  assert_equal "$(bump-preid '2.1.0-beta.3+build.sha' rc)"   "2.1.0-rc.1+build.sha"
+}
+
+# ── process-version composition (R-PRE-1) ───────────────────────────────────
+
+@test "process-version: --major --preid rc on a stable version enters a prerelease (R-PRE-1)" {
+  source ${profile_script}
+  V_TEST="1.2.3"
+  create_ver_file
+  BUMP_LEVEL="major"
+  PRE_ID="rc"
+  process-version
+  assert_equal "${V_NEW}" "2.0.0-rc.1"
+}
+
+@test "process-version: --patch --preid beta on a stable version enters a prerelease (R-PRE-1)" {
+  source ${profile_script}
+  V_TEST="1.2.3"
+  create_ver_file
+  BUMP_LEVEL="patch"
+  PRE_ID="beta"
+  process-version
+  assert_equal "${V_NEW}" "1.2.4-beta.1"
+}
+
+@test "process-version: --minor --preid on an existing prerelease drops it first, then re-enters (R-PRE-1 + R-PRE-6)" {
+  source ${profile_script}
+  V_TEST="4.0.0-rc.1"
+  create_ver_file
+  BUMP_LEVEL="minor"
+  PRE_ID="alpha"
+  process-version
+  assert_equal "${V_NEW}" "4.1.0-alpha.1"
+}
+
+# ── process-version composition: --preid alone (R-PRE-2 / R-PRE-3) ─────────
+
+@test "process-version: --preid alone, same id increments the counter (R-PRE-2)" {
+  source ${profile_script}
+  V_TEST="4.0.0-dev.6"
+  create_ver_file
+  PRE_ID="dev"
+  process-version
+  assert_equal "${V_NEW}" "4.0.0-dev.7"
+}
+
+@test "process-version: --preid alone, different id swaps and resets (R-PRE-2)" {
+  source ${profile_script}
+  V_TEST="2.0.0-alpha.3"
+  create_ver_file
+  PRE_ID="rc"
+  process-version
+  assert_equal "${V_NEW}" "2.0.0-rc.1"
+}
+
+@test "process-version: --preid alone preserves build metadata (R-PRE-2)" {
+  source ${profile_script}
+  V_TEST="2.1.0-beta.3+build.sha"
+  create_ver_file
+  PRE_ID="beta"
+  process-version
+  assert_equal "${V_NEW}" "2.1.0-beta.4+build.sha"
+}
+
+@test "process-version: --preid alone on a stable version exits 2, naming the fix (R-PRE-3)" {
+  source ${profile_script}
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  V_TEST="1.2.3"
+  create_ver_file
+  PRE_ID="rc"
+
+  run process-version
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "ambiguous"
+  assert_output --partial "--major"
+  assert_output --partial "--minor"
+  assert_output --partial "--patch"
+}
+
+@test "process-version: --preid suppresses the conventional-commit suggestion" {
+  source ${profile_script}
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo"
+  V_TEST="4.0.0-dev.6"
+  create_ver_file
+  # A feat: commit after the tag would make set-v-suggest print "suggesting
+  # ... bump" — --preid (like --major/--minor/--patch) must skip that.
+  git tag -a v4.0.0-dev.6 -m "v4.0.0-dev.6"
+  git commit -q --allow-empty -m "feat: something"
+  PRE_ID="dev"
+
+  run process-version
+  assert_success
+  strip_ansi_output
+  refute_output --partial "suggesting"
+  assert_output --partial "4.0.0-dev.7"
+}
+
+# ── End-to-end CLI: quiet-mode bare-version trick (cf. quiet.bats) ─────────
+
+@test "e2e: --quiet --major --preid rc prints the entered prerelease (R-PRE-1)" {
+  preid_repo "1.2.3"
+
+  run bash -c '"$1" --quiet --major --preid rc -d -c -p origin >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "2.0.0-rc.1"
+}
+
+@test "e2e: --quiet --patch --preid beta prints the entered prerelease (R-PRE-1)" {
+  preid_repo "1.2.3"
+
+  run bash -c '"$1" --quiet --patch --preid beta -d -c -p origin >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "1.2.4-beta.1"
+}
+
+@test "e2e: --quiet --preid dev alone advances an existing prerelease (R-PRE-2)" {
+  preid_repo "4.0.0-dev.6"
+
+  run bash -c '"$1" --quiet --preid dev -d -c -p origin >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "4.0.0-dev.7"
+}
+
+@test "e2e: --quiet --preid rc alone swaps a different existing prerelease id (R-PRE-2)" {
+  preid_repo "2.0.0-alpha.3"
+
+  run bash -c '"$1" --quiet --preid rc -d -c -p origin >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run cat "$BATS_TEST_TMPDIR/out"
+  assert_output "2.0.0-rc.1"
+}
+
+@test "e2e: --preid alone on a stable version exits 2 (R-PRE-3)" {
+  preid_repo "1.2.3"
+
+  run ${profile_script} --preid rc -d -c
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "ambiguous"
+}
+
+@test "e2e: --preid rc -v 2.0.0 exits 2 without mutating the repo (R-PRE-4)" {
+  preid_repo "1.2.3"
+
+  run ${profile_script} --preid rc -v 2.0.0 -d -c
+  assert_failure 2
+
+  run git status --porcelain
+  assert_output ""
+  run jq -r '.version' package.json
+  assert_output "1.2.3"
+}
+
+@test "e2e: --preid 'bad..id' exits 2 before any mutation (R-PRE-5)" {
+  preid_repo "1.2.3"
+
+  run ${profile_script} --preid 'bad..id' -d -c
+  assert_failure 2
+
+  run git status --porcelain
+  assert_output ""
+  run jq -r '.version' package.json
+  assert_output "1.2.3"
+}


### PR DESCRIPTION
## Summary

R-BUMP-1 iterates an existing prerelease nicely (`4.0.0-dev.6` → `dev.7`), but there was no switch to **enter** one: `1.2.3` → `2.0.0-rc.1` required a hand-typed `-v`. This adds `--preid <id>`, composing with the existing `--major`/`--minor`/`--patch` switches, instead of four npm-style `pre*` subcommand flags.

- `--major|--minor|--patch --preid <id>` — bump that level, then enter the prerelease at `<id>.1`.
- `--preid <id>` alone on a version that already has a prerelease — same id increments the counter (existing R-BUMP-1 path); a different id swaps it and resets to `.1`.
- `--preid <id>` alone on a stable version — ambiguous, exits `2` naming the fix.
- `--preid` conflicts with `-v <version>` — exits `2`, order-independent.
- `<id>` is validated against the SemVer prerelease grammar before any mutation.
- Graduating a prerelease, and `--major/--minor/--patch` *without* `--preid`, are unchanged (already handled by `force-bump` dropping the prerelease/build metadata).

## R-PRE coverage

| ID | Requirement | Tests |
| --- | --- | --- |
| R-PRE-1 | level + `--preid` → bump level, enter `<id>.1` | `preid.bats` (process-version + e2e) |
| R-PRE-2 | `--preid` alone on an existing prerelease: same id → counter++, different id → swap + reset | `preid.bats` (`bump-preid` unit + process-version + e2e) |
| R-PRE-3 | `--preid` alone on a stable version → exit 2, ambiguous | `preid.bats` |
| R-PRE-4 | conflicts with `-v`, order-independent → exit 2 | `args.bats`, `preid.bats` |
| R-PRE-5 | `<id>` grammar validated before any mutation | `args.bats` (`is_prerelease_id` invalid cases), `preid.bats` |
| R-PRE-6 | level switches without `--preid` still bump from the stable core; documented in `--help`/README | `version.bats` (pre-existing `force-bump` coverage), `lib/usage.sh` |

Also widened the `--quiet` + interactive-prompt guard (R-OUT-2, `lib/args.sh`) to treat `--preid` as a non-interactive path, same as a forced bump level — otherwise `--quiet --preid dev` on an existing prerelease would incorrectly demand `--yes`.

## Test plan

- `pnpm lint` (shellcheck -x): zero warnings.
- `pnpm tests:run`: full suite **443 → 468**, all green (25 new: `test/args.bats` +6 flag-parsing cases, `test/preid.bats` +19 new file covering grammar validation, `bump-preid` composition, `process-version` semantics, and end-to-end CLI runs).
- Every R-PRE-1..6 ID is mapped to at least one test (table above); `docs/features/prerelease/requirements.md` carries the same mapping as the living contract.
- help↔README flag-parity test (`args.bats`) stays green with `--preid` added to both.

Refs #64.