### PR TITLE
test(tests): stop ver-bump fail() from shadowing bats-support fail()

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -132,6 +132,12 @@ pipe them cleanly.
   after `run` so ANSI escapes don't break `--partial` matches.
 - Test the **error path with the hint** when `fail` is involved —
   regressions in hints are the easiest way to degrade UX silently.
+- Inside a test body, use `bats_fail "<message>"` to force a failure
+  through bats' reporter — not bare `fail`. Once a test `source`s
+  ver-bump's libs, `fail` is ver-bump's own `<code> <msg> [<hint>]`
+  error helper (asserted via `run`), which shadows bats-support's
+  `fail <message>`. `test_helper.bash` captures bats-support's original
+  as `bats_fail` before that can happen (see `test/fail-shadowing.bats`).
 
 ### What requires tests
 

--- a/test/args.bats
+++ b/test/args.bats
@@ -563,7 +563,7 @@ load 'test_helper'
   for flag in $flags; do
     [[ "$flag" == "--name" ]] && continue
     grep -qF -- "$flag" "${repo_dir}/README.md" \
-      || fail "Flag ${flag} appears in --help but not in README.md"
+      || bats_fail "Flag ${flag} appears in --help but not in README.md"
   done
 }
 

--- a/test/fail-shadowing.bats
+++ b/test/fail-shadowing.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+# Regression coverage for #78.
+#
+# Tests source ver-bump's libraries to unit-test functions, which brings in
+# `fail` from lib/errors.sh (signature: `fail <exit-code> <msg> [<hint>]`).
+# That shadows bats-support's `fail <message>` (used inside a test body to
+# force a failure through bats' own reporter), so a deliberately-failing
+# assertion in a sourcing test would invoke ver-bump's exit-code machinery
+# instead — garbling the failure output.
+#
+# test/test_helper.bash's setup() captures bats-support's fail as `bats_fail`
+# immediately after bats-support loads, before any test can source ver-bump's
+# libs. This file proves the fix: `bats_fail` keeps working after ver-bump's
+# `fail` is sourced, ver-bump's own `fail` keeps its exit-code contract via
+# `run`, and the two coexist in the same test shell.
+
+load 'test_helper'
+
+@test "bats_fail: identical to bats-support's fail before any ver-bump lib is sourced" {
+  # Sanity check on the capture itself: at this point nothing has sourced
+  # ver-bump's lib/errors.sh yet, so `fail` is still bats-support's — the
+  # captured `bats_fail` copy must match it body-for-body.
+  assert_equal "$(declare -f bats_fail | sed '1s/^bats_fail /fail /')" "$(declare -f fail)"
+}
+
+@test "sourcing ver-bump's lib/errors.sh shadows fail() but leaves bats_fail() untouched" {
+  local bats_fail_before
+  bats_fail_before="$(declare -f bats_fail)"
+
+  source ${profile_script}
+
+  # `fail` in this shell is now ver-bump's exit-code helper (lib/errors.sh) ...
+  local vb_fail_body
+  vb_fail_body="$(declare -f fail)"
+  [[ "$vb_fail_body" == *'exit "$code"'* ]]
+
+  # ... while the captured bats_fail is byte-for-byte unchanged.
+  assert_equal "$(declare -f bats_fail)" "$bats_fail_before"
+}
+
+@test "bats_fail: forces a bats-support-style failure through bats' reporter after ver-bump libs are sourced" {
+  source ${profile_script}
+
+  # bats-support's fail() prints the message to stderr and returns 1 — it
+  # never exits the process. That's the contract bats_fail must preserve.
+  run bats_fail "forced failure for regression coverage"
+  assert_equal "$status" 1
+  assert_output --partial "forced failure for regression coverage"
+}
+
+@test "collision proof: a bare fail() call after sourcing is ver-bump's and garbles a forced-failure message" {
+  source ${profile_script}
+
+  # This is the bug #78 describes: calling the bats-support idiom `fail
+  # "<message>"` directly (instead of `bats_fail`) now hits ver-bump's
+  # `fail <code> <msg> [<hint>]`. The single string argument is treated as
+  # the exit code, so bash's own `exit` builtin rejects it — the process
+  # exits 2 with a bash usage error, not bats-support's clean status 1 +
+  # message.
+  run fail "would-be forced failure message"
+  assert_not_equal "$status" 1
+  assert_output --partial "numeric argument required"
+}
+
+@test "coexistence: ver-bump's fail still enforces its exit-code contract via run" {
+  source ${profile_script}
+
+  run fail 3 "precondition failed" "a helpful hint"
+  assert_failure 3
+  assert_output --partial "Error:"
+  assert_output --partial "precondition failed"
+  assert_output --partial "Hint: a helpful hint"
+
+  # bats_fail is unaffected by the run above — still bats-support's helper.
+  run bats_fail "second forced failure in the same test"
+  assert_equal "$status" 1
+  assert_output --partial "second forced failure in the same test"
+}

--- a/test/fail-shadowing.bats
+++ b/test/fail-shadowing.bats
@@ -25,18 +25,23 @@ load 'test_helper'
 }
 
 @test "sourcing ver-bump's lib/errors.sh shadows fail() but leaves bats_fail() untouched" {
-  local bats_fail_before
-  bats_fail_before="$(declare -f bats_fail)"
+  # Capture bats-support's fail BEFORE any ver-bump lib is sourced — at this
+  # point `fail` is still bats-support's. We compare against this captured
+  # definition rather than matching any specific line of ver-bump's fail, so
+  # the test proves the *collision* without coupling to fail()'s internals: a
+  # contract-preserving refactor of ver-bump's fail must not break it.
+  local support_fail support_fail_body
+  support_fail="$(declare -f fail)"
+  support_fail_body="$(declare -f fail | sed '1d')" # body only; name line differs
 
   source ${profile_script}
 
-  # `fail` in this shell is now ver-bump's exit-code helper (lib/errors.sh) ...
-  local vb_fail_body
-  vb_fail_body="$(declare -f fail)"
-  [[ "$vb_fail_body" == *'exit "$code"'* ]]
+  # The shadow happened: fail's definition now DIFFERS from bats-support's.
+  assert_not_equal "$(declare -f fail)" "$support_fail"
 
-  # ... while the captured bats_fail is byte-for-byte unchanged.
-  assert_equal "$(declare -f bats_fail)" "$bats_fail_before"
+  # The capture survived: bats_fail's body still MATCHES bats-support's fail
+  # (compare bodies — the `bats_fail`/`fail` name line necessarily differs).
+  assert_equal "$(declare -f bats_fail | sed '1d')" "$support_fail_body"
 }
 
 @test "bats_fail: forces a bats-support-style failure through bats' reporter after ver-bump libs are sourced" {

--- a/test/sandbox.bats
+++ b/test/sandbox.bats
@@ -44,7 +44,7 @@ sandbox_dir_from_output() {
 
   # ... which lives outside the host checkout ...
   case "$dir" in
-    "${repo_dir}"*) fail "sandbox dir ${dir} is inside the host repo" ;;
+    "${repo_dir}"*) bats_fail "sandbox dir ${dir} is inside the host repo" ;;
   esac
 
   # ... and was wiped by the EXIT trap
@@ -85,7 +85,7 @@ sandbox_dir_from_output() {
     grep -q -- '---' "$out" 2>/dev/null && break
     sleep 0.1
   done
-  grep -q -- '---' "$out" || { exec 9>&-; fail "sandbox never reached ver-bump (out: $(cat "$out"))"; }
+  grep -q -- '---' "$out" || { exec 9>&-; bats_fail "sandbox never reached ver-bump (out: $(cat "$out"))"; }
 
   dir="$(sed -n 's/^sandbox: \(\/.*\)$/\1/p' "$out" | head -n 1)"
   [ -n "$dir" ]
@@ -130,7 +130,7 @@ sandbox_dir_from_output() {
   local dir
   dir="$(sandbox_dir_from_output)"
   case "$dir" in
-    ""|"${repo_dir}"*) fail "sandbox dir '${dir}' is missing or inside the host repo" ;;
+    ""|"${repo_dir}"*) bats_fail "sandbox dir '${dir}' is missing or inside the host repo" ;;
   esac
 
   run "$(sandbox_script)" -v not-semver

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -14,6 +14,16 @@ setup() {
   load './test_helper/bats-support/load'
   load './test_helper/bats-assert/load'
 
+  # Capture bats-support's fail() under a test-only name right after it's
+  # loaded, before any test can `source ${profile_script}` and pull in
+  # ver-bump's own `fail` from lib/errors.sh (signature: `fail <code> <msg>
+  # [<hint>]`), which would otherwise shadow bats-support's `fail <message>`
+  # (used to force a failure through bats's reporter). Tests that need to
+  # force a failure call `bats_fail "message"` instead of bare `fail`, so the
+  # forced-failure path keeps working regardless of load order within the
+  # test body. See docs/CODE_STYLE.md §Testing.
+  eval "bats_fail() $(declare -f fail | sed '1d')"
+
   repo_dir=$PWD
   profile_script="$repo_dir/ver-bump.sh"
 


### PR DESCRIPTION
## Investigation

`grep -rn '\bfail\b' test/` to find bare single-arg `fail "<message>"` calls used to force a test failure (the bats-support idiom), as opposed to `run fail <code> <msg>` (which exercises ver-bump's own `fail` under test):

- `test/sandbox.bats:47`, `:88`, `:133` — bare `fail "…"` forcing a failure inside `case`/`||` guards.
- `test/args.bats:566` — bare `fail "Flag ${flag} appears in --help but not in README.md"`.

**The collision is currently latent, not active.** None of those four call sites live in a test body that also does `source ${profile_script}`:
- `test/sandbox.bats` never sources ver-bump's libs anywhere in the file — every test drives `dev/sandbox.sh` as a subprocess via `run`.
- The one `args.bats` site (`help↔README flag parity`) only calls `get_help_msg` (`${profile_script} -h` as a subprocess), never `source`.

So today's suite is green either way. But it's a live trap: adding `source ${profile_script}` to any of those tests (a completely idiomatic, common pattern elsewhere in this suite) would silently swap bats-support's clean "return 1 + message on stderr" for ver-bump's `fail <code> <msg> [<hint>]`, which treats the lone message string as `$1` (the exit code) and hits bash's own `exit: <msg>: numeric argument required` — garbling the failure instead of reporting it through bats' reporter. Confirmed this exact failure mode by hand:

```
$ bash -c 'source lib/errors.sh; fail "would-be forced failure message"'
 Error: 
lib/errors.sh: line 26: exit: would-be forced failure message: numeric argument required
STATUS=2
```

## Approach chosen

Went with the **test-helper capture** approach (option 2 in the issue), not the root-cause `vb_fail` rename (option 1). `fail` has 96 call sites across `ver-bump.sh` and 11 files under `lib/`; a full rename is mechanical but touches every error path in the tool for a bug that's entirely test-infrastructure-scoped. The lowest-blast-radius fix keeps production code (and the exit-code contract in `lib/errors.sh` / `docs/CODE_STYLE.md`) completely untouched.

**Changes:**
- `test/test_helper.bash`: `setup()` now captures bats-support's `fail` under `bats_fail` immediately after `load './test_helper/bats-support/load'` — i.e. before any test body gets a chance to `source ${profile_script}` and redefine `fail`. Implemented via `eval "bats_fail() $(declare -f fail | sed '1d')"`, so `bats_fail` is byte-for-byte bats-support's `fail`, just under a name ver-bump's libs never touch.
- `test/sandbox.bats` (×3) and `test/args.bats` (×1): the four forced-failure call sites now call `bats_fail` instead of bare `fail`.
- `docs/CODE_STYLE.md` §Testing: documented the pattern — use `bats_fail` to force a failure inside a test; ver-bump's `fail` is the production error helper and is asserted via `run`.

## Regression test — `test/fail-shadowing.bats`

Five cases proving the acceptance criterion and the coexistence requirement:

1. `bats_fail` is byte-for-byte bats-support's `fail`, confirmed before anything sources ver-bump's libs (sanity check on the capture).
2. After `source ${profile_script}`, `fail` in that shell is demonstrably ver-bump's (`declare -f fail` contains `exit "$code"`), while `declare -f bats_fail` is unchanged from the pre-source capture.
3. After sourcing, `run bats_fail "…"` still returns status 1 with the message in `$output` — bats-support's contract, unaffected by the shadow.
4. **Collision proof**: after sourcing, `run fail "would-be forced failure message"` (i.e. what the old call sites did) returns a non-1 status and `$output` contains `"numeric argument required"` — demonstrating the exact garbling the issue describes, absent the fix.
5. Coexistence: `run fail 3 "precondition failed" "a helpful hint"` still asserts `assert_failure 3` with the message/hint intact (ver-bump's exit-code contract, unchanged), and `bats_fail` still works afterward in the same test shell.

## Test plan

- `pnpm lint` (shellcheck -x on `ver-bump.sh`, `install.sh`, `lib/*.sh`) — zero warnings.
- `pnpm tests:run` — before → after: **469/469 → 474/474**, 0 failures (the 5 new cases are `test/fail-shadowing.bats`; all pre-existing tests remain green, confirming the call-site edits are behavior-preserving).

Refs #78.