### PR TITLE
refactor(ui): theme-adaptive output — kill fixed-fg tokens, soften prompts, group changelog

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -54,21 +54,27 @@ already in the tree — new code should match, not invent.
 Locked in by [test/ui.bats](../test/ui.bats) — changes here require updating
 those regression tests.
 
-- **Never** reference raw colour vars (`GREEN`, `RED`, …) outside
-  [lib/styles.sh](../lib/styles.sh). Use the semantic `S_*` tokens.
+- **Never** reference raw colour vars (`GREEN`, `RED`, `WHITE`, `LIGHTGRAY`, …)
+  outside [lib/styles.sh](../lib/styles.sh). Use the semantic `S_*` tokens.
 - **Narrative text = no colour.** Colour is reserved for:
   - interpolated values → `S_VAL` (green)
-  - prompts → `S_QUESTION`
+  - emphasis → `S_NORM` (bold of the terminal's own fg — never a fixed
+    colour; the old `WHITE`/`1;37` hardcode fought light/dark themes)
+  - soft (confirmation) prompts → a coloured leading glyph (`S_PROMPT` +
+    `I_PROMPT`), then default-fg question text, the value in `S_VAL`, and
+    the choice hint (e.g. `[N/y]`) in `S_DIM` — not a whole-line colour wrap
   - warnings → `S_ATTN` / `S_WARN` + plain body
   - errors → via `fail` (uses `S_ERROR`)
-  - dim markers → `S_LIGHT` (`[dry-run]`, `Option set:`)
+  - dim markers → `S_LIGHT` (`[dry-run]`, `Option set:`) — theme-adaptive
+    dim, never the old fixed `LIGHTGRAY`/`0;37`
 - **`S_NOTICE` is deprecated** — do not use on new lines.
 - Every style variable must be gated by the `USE_COLOR` check in
   [lib/styles.sh](../lib/styles.sh) so `NO_COLOR` / piping / non-TTY strips
   ANSI (`CLICOLOR_FORCE` / `FORCE_COLOR` force it on).
 - Use `log_success` / `log_warn` / `log_error` / `log_info` / `log_trace`
   instead of ad-hoc `echo -e` with inline tokens. Reach for `section` /
-  `subsection` pills for headings, not `echo "------"`.
+  `subsection` pills for headings, not `echo "------"` — one pill per grouped
+  step (e.g. the changelog write), not a pill for every micro-step.
 
 ### Comments
 

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -224,6 +224,7 @@ _changelog-grouped-section() {
 # pause and staging behaviour (R-CHLOG-5).
 do-changelog() {
   [ "$FLAG_NOCHANGELOG" = true ] && return
+  subsection "changelog"
   local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP
 
   RANGE=$([ "$(git tag -l "${TAG_PREFIX}${V_PREV}")" ] && echo "${TAG_PREFIX}${V_PREV}..HEAD")
@@ -284,8 +285,14 @@ do-changelog() {
   fi
 
   if [ "$FLAG_DRYRUN" = true ]; then
-    printf '%b[dry-run]%b would replace CHANGELOG.md with:\n' "${S_LIGHT}" "${RESET}" >&2
-    cat "$TMP" >&2
+    # Subordinate to the "changelog" pill above: header via log_trace (dim
+    # ↳, keeps the "[dry-run]" marker text R-DRY-2 requires), preview body
+    # as a dim, 2-space-indented block — so the whole changelog step reads
+    # as one grouped unit rather than narrative-coloured output.
+    log_trace "[dry-run] would replace CHANGELOG.md with:" >&2
+    while IFS= read -r _chlog_line || [ -n "$_chlog_line" ]; do
+      printf '  %b%s%b\n' "${S_DIM-}" "$_chlog_line" "${RESET-}" >&2
+    done < "$TMP"
     rm -f "$TMP"
   else
     mv -f "$TMP" CHANGELOG.md

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -225,7 +225,7 @@ _changelog-grouped-section() {
 do-changelog() {
   [ "$FLAG_NOCHANGELOG" = true ] && return
   subsection "changelog"
-  local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP
+  local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP _chlog_line
 
   RANGE=$([ "$(git tag -l "${TAG_PREFIX}${V_PREV}")" ] && echo "${TAG_PREFIX}${V_PREV}..HEAD")
   if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -126,7 +126,8 @@ do-push() {
   if [ "$FLAG_PUSH" = true ]; then
     CONFIRM="Y"
   else
-    echo -ne "\n${S_QUESTION}Push branch + tags to <${S_VAL}${PUSH_DEST}${S_QUESTION}>? [${S_NORM}N/y${S_QUESTION}]:${RESET} "
+    printf '\n%b%s%b Push branch + tags to <%b%s%b>? %b[N/y]%b ' \
+      "${S_PROMPT-}" "${I_PROMPT-}" "${RESET-}" "${S_VAL-}" "${PUSH_DEST}" "${RESET-}" "${S_DIM-}" "${RESET-}"
     read -r CONFIRM
   fi
 
@@ -520,7 +521,8 @@ do-undo() {
   fi
 
   if [ "${FLAG_YES:-false}" != true ]; then
-    printf '\n%bProceed?%b [y/N] ' "${S_QUESTION-}" "${RESET-}"
+    printf '\n%b%s%b Proceed? %b[y/N]%b ' \
+      "${S_PROMPT-}" "${I_PROMPT-}" "${RESET-}" "${S_DIM-}" "${RESET-}"
     read -r reply
     case "${reply}" in
       y|Y|yes|YES) ;;

--- a/lib/icons.sh
+++ b/lib/icons.sh
@@ -12,6 +12,7 @@ I_BULLET="•"   # bullet / list marker
 I_ARROW="→"    # right-pointing flow (e.g. "1.0.0 → 1.0.1")
 I_QUESTION="?" # interactive prompt
 I_TRACE="↳"   # trailing / subordinate detail (indented under a status line)
+I_PROMPT="?"   # leading glyph on soft (confirmation) prompts, paired with S_PROMPT
 
 # Back-compat aliases — call sites in lib/helpers.sh still reference these.
 # Removed in a later phase when all call sites migrate to log_* helpers.

--- a/lib/icons.sh
+++ b/lib/icons.sh
@@ -12,7 +12,7 @@ I_BULLET="•"   # bullet / list marker
 I_ARROW="→"    # right-pointing flow (e.g. "1.0.0 → 1.0.1")
 I_QUESTION="?" # interactive prompt
 I_TRACE="↳"   # trailing / subordinate detail (indented under a status line)
-I_PROMPT="?"   # leading glyph on soft (confirmation) prompts, paired with S_PROMPT
+I_PROMPT="$I_QUESTION" # leading glyph on soft (confirmation) prompts, paired with S_PROMPT
 
 # Back-compat aliases — call sites in lib/helpers.sh still reference these.
 # Removed in a later phase when all call sites migrate to log_* helpers.

--- a/lib/styles.sh
+++ b/lib/styles.sh
@@ -63,9 +63,10 @@ fi
 
 # Preset styles (character-level) — semantic aliases. Call sites reference
 # these rather than raw colour vars so a single edit here re-skins the tool.
-S_NORM="${WHITE}"
-S_LIGHT="${LIGHTGRAY}"
+S_NORM="${BOLD}"      # emphasis = bold of the terminal's own fg (no colour)
+S_LIGHT="${DIM}"      # markers/secondary = dim the terminal fg (theme-adaptive)
 S_QUESTION="${YELLOW}"
+S_PROMPT="${CYAN}"    # accent for the leading prompt glyph only
 S_WARN="${LIGHTRED}"
 S_ERROR="${RED}"
 S_DIM="${DIM}"

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -134,7 +134,11 @@ process-version() {
     fi
   else
     # Display a suggested version
-    echo -ne "\n${S_QUESTION}Enter a new version number, <enter> for [${S_VAL}$V_SUGGEST${S_QUESTION}], or <esc> to quit:${RESET} "
+    printf '\n%b%s%b Enter a new version number, %b<enter> for [%b%s%b], or <esc> to quit:%b ' \
+      "${S_PROMPT-}" "${I_PROMPT-}" "${RESET-}" \
+      "${S_DIM-}" \
+      "${S_VAL-}" "$V_SUGGEST" "${RESET-}${S_DIM-}" \
+      "${RESET-}"
 
     # Two-stage read:
     #   1. Capture a single keystroke silently. If ESC → abort instantly.

--- a/test/ui.bats
+++ b/test/ui.bats
@@ -55,7 +55,12 @@ ui_repo() {
   # tokens S_NORM/S_LIGHT used to hardcode — they fought the terminal's own
   # theme. S_NORM/S_LIGHT now alias BOLD/DIM instead; guard against a raw
   # fixed-fg reference creeping back into a call site.
-  run bash -c "grep -rlnE --include='*.sh' '\\bWHITE\\b|\\bLIGHTGRAY\\b' '${repo_dir}/lib' '${repo_dir}/ver-bump.sh' | grep -v '/lib/styles.sh\$'"
+  #
+  # -w (whole-word), NOT '\b': \b is not a POSIX ERE metacharacter, so its
+  # meaning varies by grep (GNU vs BSD) — a guard built on it can silently
+  # stop matching. -w matches WHITE/LIGHTGRAY only as complete identifiers,
+  # so ${WHITE} is caught while a longer name like LIGHTWHITE is not.
+  run bash -c "grep -rlnwE --include='*.sh' 'WHITE|LIGHTGRAY' '${repo_dir}/lib' '${repo_dir}/ver-bump.sh' | grep -v '/lib/styles.sh\$'"
   assert_failure
 }
 
@@ -85,8 +90,11 @@ ui_repo() {
 @test "UI: fail() emphasises the message in bold, not fixed-white (1;37)" {
   run env CLICOLOR_FORCE=1 "${profile_script}" --release=yes
   assert_failure 2
-  # S_ERROR icon+"Error:", then S_NORM (bold, \e[1m) wraps the message body.
-  assert_output --partial $'\033[0;31m\xe2\x9c\x96 Error:\033[1m Option --release doesn\'t take a value.\033[0m'
+  # Assert the STYLING only, not the wording: the "Error:" label is followed
+  # immediately by S_NORM = bold (\e[1m), and the body is never wrapped in
+  # the old fixed bold-white (\e[1;37m). Unrelated copy changes to the
+  # message must not break this guard.
+  assert_output --partial $'Error:\033[1m'
   refute_output --partial $'\033[1;37m'
 }
 

--- a/test/ui.bats
+++ b/test/ui.bats
@@ -2,21 +2,38 @@
 
 # UI / colour discipline regression guards. These tests do not exercise
 # behaviour — they lock in the "plain narrative, colour for values only"
-# convention so future edits don't drift back to the whole-line-green
-# style the refactor cleaned up.
+# convention so future edits don't drift back to fixed-fg tokens or
+# whole-line colour wraps.
 #
 # Rule of thumb:
 #   - Narrative text       → no style token
-#   - Interpolated values  → S_NORM (reset after)
-#   - User prompts         → S_QUESTION
-#   - Warning bodies       → S_WARN "Warning:" prefix + plain body
-#   - Errors               → via fail helper (S_ERROR label)
-#   - Dim markers          → S_LIGHT ("[dry-run]", "Option set:")
+#   - Emphasis              → S_NORM (bold of the terminal's own fg — never
+#                              a fixed colour like the old WHITE/1;37)
+#   - Interpolated values  → S_VAL (green)
+#   - Soft prompts          → S_PROMPT-accented leading glyph (I_PROMPT),
+#                              then default-fg question text, value in
+#                              S_VAL, choice hint (e.g. "[N/y]") in S_DIM
+#   - Warning bodies        → S_WARN "Warning:" prefix + plain body
+#   - Errors                → via fail helper (S_ERROR label, S_NORM body)
+#   - Dim markers            → S_LIGHT ("[dry-run]", "Option set:") — a
+#                              theme-adaptive dim, never the old fixed
+#                              LIGHTGRAY/0;37
 #
-# `S_NOTICE` and raw `GREEN` are both forbidden on narrative lines.
-# Help output in usage() is out of scope and allowed to keep BOLD headers.
+# `S_NOTICE` and raw `GREEN`/`WHITE`/`LIGHTGRAY` are all forbidden on call
+# sites outside styles.sh. Help output in usage() is out of scope and
+# allowed to keep BOLD headers.
 
 load 'test_helper'
+
+# Scratch repo with a committed package.json at 1.0.0 — clean tree, no
+# tags, so a full live/dry-run release can proceed through do-push.
+ui_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.0.0" }\n' > package.json
+  git add package.json && git commit -qm "chore: seed package.json"
+}
 
 @test "UI: no S_NOTICE references in lib/*.sh (except styles.sh) or ver-bump.sh" {
   # S_NOTICE was the whole-line green narrative token. The refactor stripped
@@ -30,6 +47,15 @@ load 'test_helper'
   # GREEN is defined in styles.sh (fine) but must not be used directly in
   # narrative echoes anywhere else.
   run bash -c "grep -rln --include='*.sh' 'GREEN' '${repo_dir}/lib' '${repo_dir}/ver-bump.sh' | grep -v '/lib/styles.sh\$'"
+  assert_failure
+}
+
+@test "UI: no raw WHITE or LIGHTGRAY references outside lib/styles.sh" {
+  # WHITE (bold fixed-white, 1;37) and LIGHTGRAY (fixed 0;37) were the
+  # tokens S_NORM/S_LIGHT used to hardcode — they fought the terminal's own
+  # theme. S_NORM/S_LIGHT now alias BOLD/DIM instead; guard against a raw
+  # fixed-fg reference creeping back into a call site.
+  run bash -c "grep -rlnE --include='*.sh' '\\bWHITE\\b|\\bLIGHTGRAY\\b' '${repo_dir}/lib' '${repo_dir}/ver-bump.sh' | grep -v '/lib/styles.sh\$'"
   assert_failure
 }
 
@@ -52,4 +78,49 @@ load 'test_helper'
   local total=0 line
   while IFS= read -r line; do total=$((total + line)); done <<< "${output}"
   [ "${total}" -ge 6 ]
+}
+
+# ── Runtime ANSI assertions — force colour, decode real escape bytes ──────
+
+@test "UI: fail() emphasises the message in bold, not fixed-white (1;37)" {
+  run env CLICOLOR_FORCE=1 "${profile_script}" --release=yes
+  assert_failure 2
+  # S_ERROR icon+"Error:", then S_NORM (bold, \e[1m) wraps the message body.
+  assert_output --partial $'\033[0;31m\xe2\x9c\x96 Error:\033[1m Option --release doesn\'t take a value.\033[0m'
+  refute_output --partial $'\033[1;37m'
+}
+
+@test "UI: [dry-run] marker renders dim (\\e[2m), not fixed grey (0;37)" {
+  ui_repo
+  run env CLICOLOR_FORCE=1 "${profile_script}" -d -p origin -y -v 1.0.1
+  assert_success
+  assert_output --partial $'\033[2m[dry-run]\033[0m'
+  refute_output --partial $'\033[0;37m'
+}
+
+@test "UI: push prompt shows the S_PROMPT-accented glyph + default-fg question text" {
+  ui_repo
+  run bash -c "echo n | env CLICOLOR_FORCE=1 '${profile_script}' -d -y -v 1.0.1"
+  assert_failure 5
+  # Cyan glyph (S_PROMPT+I_PROMPT), reset, then the question in the
+  # terminal's own default fg (no colour wrap) up to the S_VAL-accented
+  # PUSH_DEST value.
+  assert_output --partial $'\033[0;36m?\033[0m Push branch + tags to <\033[0;32morigin\033[0m>? \033[2m[N/y]\033[0m'
+  # No more whole-line yellow (old S_QUESTION) wrap on this prompt.
+  refute_output --partial $'\033[1;33mPush branch'
+}
+
+@test "UI: changelog step emits a green CHANGELOG subsection pill" {
+  ui_repo
+  run bash -c "echo n | env CLICOLOR_FORCE=1 '${profile_script}' -d -y -v 1.0.1"
+  assert_failure 5
+  # subsection() renders an inverted bold-green pill: \e[7;1;32m TEXT \e[0m
+  assert_output --partial $'\033[7;1;32m CHANGELOG \033[0m'
+}
+
+@test "UI: NO_COLOR strips all ANSI, including the new tokens" {
+  ui_repo
+  run bash -c "echo n | env NO_COLOR=1 CLICOLOR_FORCE=1 '${profile_script}' -d -y -v 1.0.1"
+  assert_failure 5
+  refute_output --partial $'\033['
 }


### PR DESCRIPTION
## Why

Maintainer-requested restyle (no linked issue). A dry-run + ANSI inspection
turned up two problems in `lib/styles.sh`:

- `S_NORM="${WHITE}"` and `S_LIGHT="${LIGHTGRAY}"` hardcode a **fixed**
  foreground colour (`\e[1;37m` bold-white, `\e[0;37m` grey). That fights
  the user's own terminal theme — bold-white is near-invisible on light
  themes and harsh on dark ones — and it violates this repo's own
  "narrative = no colour, colour is for values only" convention
  (`docs/CODE_STYLE.md` §UI / colour discipline, locked in by
  `test/ui.bats`).
- Confirmation prompts wrapped the **entire line** in bold-yellow
  (`S_QUESTION`), which reads as a warning banner for what is a routine
  yes/no question (push confirm, undo confirm, version entry).

This PR is a pure restyle: no flags, defaults, exit codes, or prompt
wording changed — only the ANSI applied to existing output.

## What changed

- **`lib/styles.sh`** — `S_NORM` now aliases `BOLD` (bold of the terminal's
  own fg) instead of `WHITE`; `S_LIGHT` now aliases `DIM` instead of
  `LIGHTGRAY`. Added `S_PROMPT="${CYAN}"`, a small accent reserved for the
  leading glyph on soft prompts. All three inherit the existing
  `USE_COLOR` gate transitively (same pattern as every other `S_*` token),
  so `NO_COLOR` / non-TTY / piping still strips everything.
- **`lib/icons.sh`** — added `I_PROMPT="?"`, the glyph paired with
  `S_PROMPT`.
- **`lib/git-actions.sh`** — the push-confirm prompt (`do-push`) and the
  `--undo` `Proceed?` prompt now render as: coloured glyph → default-fg
  question text → `S_VAL`-accented value → dim choice hint (`[N/y]` /
  `[y/N]`). Converted from `echo -e`/mixed `printf` to `printf` per
  `docs/CODE_STYLE.md`. Wording and the `read` logic that follows are
  byte-identical — only the styling changed.
- **`lib/version.sh`** — the "Enter a new version number…" prompt gets the
  same treatment: glyph, default-fg question, `S_VAL` for the suggested
  version, `S_DIM` for the `<enter>…<esc>…` guidance clause.
- **`lib/changelog.sh`** — `do-changelog` now opens with a single green
  `subsection "changelog"` pill (existing `lib/ui.sh` helper), and the
  dry-run "would replace CHANGELOG.md with" preview renders as a dim,
  indented block (header via `log_trace`, still `>&2` and still carrying
  the literal `[dry-run]` marker text required by R-DRY-2) instead of a
  bare `cat` dump. This is the *only* pill added — bump/commit/tag/push
  keep their plain `✔` status lines, per the "tasteful, not every
  micro-step" instruction. The top-level `VERIFY`/`RELEASE`/`DONE` cyan
  pills are untouched.
- **`test/ui.bats`** — kept the 4 existing source-level regression guards
  (S_NOTICE, raw GREEN, `Option set:` dim prefix, `[dry-run]` dim marker)
  and added 6 new tests: a source guard against raw `WHITE`/`LIGHTGRAY`
  creeping back in, plus 5 runtime tests that force colour
  (`CLICOLOR_FORCE=1`) against a real scratch-repo run and decode the
  actual ANSI bytes — bold emphasis (no `1;37`), dim `[dry-run]` marker
  (no `0;37`), the push prompt's cyan glyph + default-fg text, the green
  `CHANGELOG` subsection pill, and a full `NO_COLOR` byte-clean check.
- **`docs/CODE_STYLE.md`** — updated the UI/colour discipline section to
  describe the new emphasis/prompt/marker conventions (it explicitly says
  changes here require updating `test/ui.bats`, which this PR does).

## Before / after (forced colour, `\e` = `\x1b`)

Both captured from the same scratch repo (`package.json` at `1.2.3` + 3
conventional commits) via:
`CLICOLOR_FORCE=1 ./ver-bump.sh -d -y -v 1.3.0 </dev/null 2>&1 | sed 's/\x1b/\\e/g'`

```diff
- \e[0;37mOption set:\e[0m dry-run — no files, commits, tags, or pushes will be made.
+ \e[2mOption set:\e[0m dry-run — no files, commits, tags, or pushes will be made.

  \e[7;1;36m RELEASE \e[0m
- \e[0;37m[dry-run]\e[0m would set .version = '\e[0;32m1.3.0\e[0m' in package.json
+ \e[2m[dry-run]\e[0m would set .version = '\e[0;32m1.3.0\e[0m' in package.json

+ \e[7;1;32m CHANGELOG \e[0m
+
  No existing [\e[0;32mCHANGELOG.md\e[0m] found — creating one.
- \e[0;37m[dry-run]\e[0m would replace CHANGELOG.md with:
- ## 1.3.0 (2026-07-15)
+     \e[2m↳ [dry-run] would replace CHANGELOG.md with:\e[0m
+   \e[2m## 1.3.0 (2026-07-15)\e[0m

- \e[1;33mPush branch + tags to <\e[0;32morigin\e[1;33m>? [\e[1;37mN/y\e[1;33m]:\e[0m 
+ \e[0;36m?\e[0m Push branch + tags to <\e[0;32morigin\e[0m>? \e[2m[N/y]\e[0m 

- \e[0;31m✖ Error:\e[1;37m push declined\e[0m
+ \e[0;31m✖ Error:\e[1m push declined\e[0m
```

Note the before push-prompt line: the whole line (question text, angle
brackets, choice hint) is stuck inside one `\e[1;33m` (bold-yellow) run,
with the old `\e[1;37m` (fixed bold-white) marking the `N/y` hint — that's
the "warning banner for a routine question" this PR fixes. After: a single
cyan glyph, then plain question text in the terminal's own fg, the value
still green, and a dim (not fixed-grey) choice hint.

`NO_COLOR=1` confirmed byte-clean on the same scratch run (0 occurrences
of `\x1b` in the captured output, exit code unaffected).

## Test plan

- `shellcheck -x -e SC1017 ./ver-bump.sh ./install.sh ./lib/*.sh` → 0
  warnings (same invocation as `pnpm lint`).
- `./test/bats/bin/bats ./test/*.bats`:
  - baseline (`origin/develop`): **474 passed, 0 failed**
  - this branch: **480 passed, 0 failed** (the 6 new `test/ui.bats` cases;
    no regressions anywhere else in the suite)
- Manual: scratch repo (`package.json` 1.2.3 + `chore:`/`feat:`/`fix:`
  commits), `./ver-bump.sh -d -y -v 1.3.0`:
  - `CLICOLOR_FORCE=1 … | sed 's/\x1b/\\e/g'` → confirmed the ANSI above.
  - `NO_COLOR=1 …` → confirmed 0 escape bytes in the output (plain text,
    pills render as ` TEXT ` with no colour, `[dry-run]`/`✔`/`✖`/`?` all
    plain).

Not merging — opening for review.
