### PR TITLE
docs(usage): make the help match what getopts actually accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ $ npm install -g ver-bump
 ### CLI
 
 ```sh
-$ ver-bump [-v <version no.>] [-m <release message>] [-j <file1>] [-j <file2>].. [-n] [-p] [-b] [-h]
+$ ver-bump [-v <version no.>] [-m <release message>] [-f <file1>] [-f <file2>].. [-p <repository alias>] [-n] [-c] [-b] [-l] [-h]
 ```
 
 ## Options

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -48,8 +48,9 @@ usage() {
   echo -e "$S_WARN-f$S_NORM <filename.json>\tUpdate version number inside JSON files."\
           "\n\t\t\tFor multiple files, add a separate -f option for each one, for example:"\
           "\n\t\t\t${S_NORM}ver-bump -f src/plugin/package.json -f composer.json"
-  echo -e "$S_WARN-p$S_NORM <repository alias>\tPush release branch and tags to that remote, bypassing the prompt."\
-          "\n\t\t\tThe alias is required, for example: ${S_NORM}ver-bump -p origin"
+  echo -e "$S_WARN-p$S_NORM <repository alias>\tPush the new tag to that remote, bypassing the prompt."\
+          "\n\t\t\tThe alias is required, for example: ${S_NORM}ver-bump -p origin"\
+          "\n\t\t\t${S_NORM}Pushes the tag only. Push the commit yourself, eg git push --follow-tags."
   echo -e "$S_WARN-n$S_NORM \t\t\tDisable commit after tagging release."
   echo -e "$S_WARN-b$S_NORM \t\t\tDisable commit to a new release-x.x.x branch."
   echo -e "$S_WARN-c$S_NORM \t\t\tDisable updating CHANGELOG.md automatically with new commits since last release tag."

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -40,7 +40,7 @@ usage() {
           "\nIt does several things that are typically required for releasing a Git repository, like git tagging, automatic updating of CHANGELOG.md, and incrementing the version number in various JSON files."
 
   echo -e "\n${S_NORM}${BOLD}Usage:${RESET}"\
-          "\n${SCRIPT_NAME} [-v <version number>] [-m <release message>] [-j <file1>] [-j <file2>].. [-n] [-c] [-p] [-h]" 1>&2; 
+          "\n${SCRIPT_NAME} [-v <version number>] [-m <release message>] [-f <file1>] [-f <file2>].. [-p <repository alias>] [-n] [-c] [-b] [-l] [-h]" 1>&2;
 
   echo -e "\n${S_NORM}${BOLD}Options:${RESET}"
   echo -e "$S_WARN-v$S_NORM <version number>\tSpecify a manual version number"
@@ -48,7 +48,8 @@ usage() {
   echo -e "$S_WARN-f$S_NORM <filename.json>\tUpdate version number inside JSON files."\
           "\n\t\t\tFor multiple files, add a separate -f option for each one, for example:"\
           "\n\t\t\t${S_NORM}ver-bump -f src/plugin/package.json -f composer.json"
-  echo -e "$S_WARN-p$S_NORM \t\t\tPush release branch to ORIGIN."
+  echo -e "$S_WARN-p$S_NORM <repository alias>\tPush release branch and tags to that remote, bypassing the prompt."\
+          "\n\t\t\tThe alias is required, for example: ${S_NORM}ver-bump -p origin"
   echo -e "$S_WARN-n$S_NORM \t\t\tDisable commit after tagging release."
   echo -e "$S_WARN-b$S_NORM \t\t\tDisable commit to a new release-x.x.x branch."
   echo -e "$S_WARN-c$S_NORM \t\t\tDisable updating CHANGELOG.md automatically with new commits since last release tag."


### PR DESCRIPTION
## What changed and why

The usage block advertises two flags the parser doesn't implement. Both fail in ways that look like the user's mistake rather than a doc bug.

### `-p` is documented bare, but its argument is mandatory

The help says `-p    Push release branch to ORIGIN.` The parser says otherwise:

```sh
while getopts ":v:p:m:f:hbncl" OPTIONS; do
#                ^ the colon after p makes the argument mandatory
```

So a bare `-p` swallows the next token as its destination. Following the help exactly:

```
$ ver-bump -b -p -v 1.1.0
Pushing files + tags to <-v>...            # -v became -p's argument
fatal: '-v' does not appear to be a git repository
✅ Bumped 1.0.0 -> 1.0.1                    # no version supplied → patch fallback
```

Three failures at once: the destination became the literal `-v`, no version reached the parser, and it silently fell back to a patch bump. **It only stayed local because `-v` isn't a real remote.** Against a valid one, the wrong version publishes and the tag is wrong. That's the case worth closing — quiet and wrong beats loud and wrong for damage.

Found while cutting a release in another repo whose script followed this help.

### The tests already agreed with the parser

```
test/ver-bump.bats:126:  assert_failure 1 --partial "Option -p requires an argument."
test/ver-bump.bats:129:  @test "process-arguments: -p <repo destination>: succeed when supplying a destination"
```

The parser and the suite have always agreed. Only the help was wrong, so **this PR changes the help to match them — no behaviour changes.** The README disagreed with itself too: line 173 documented `-p <repository alias>`, while line 161's usage line showed a bare `[-p]`.

### `-j <file1>` doesn't exist

The usage line offers `-j`. The flag is `-f`, per both the option list directly beneath it and the parser. Copying the usage line gets you `illegal option`. Also added `-b` and `-l`, which are implemented and were undocumented.

## Result

```
ver-bump [-v <version number>] [-m <release message>] [-f <file1>] [-f <file2>].. [-p <repository alias>] [-n] [-c] [-b] [-l] [-h]
...
-p <repository alias>   Push release branch and tags to that remote, bypassing the prompt.
                        The alias is required, for example: ver-bump -p origin
```

**All 30 bats tests pass.** Usage text only.

## One thing worth a separate look

Running `bats test/ver-bump.bats` **rewrites and `git add`s the repo's own `CHANGELOG.md`** — the `do-changelog` test writes to the real file rather than a fixture, and leaves it staged. I reverted it here so this diff stays docs-only, but a test suite that mutates tracked files will eventually get committed by accident. Not fixed in this PR since it's unrelated to the help text.