### PR TITLE
fix(bump): stop a jq failure silently truncating the file it edits

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -273,15 +273,19 @@ bump-json-files() {
       elif [ "$V_PREV" = "$V_NEW" ]; then
         echo -e "\n${I_WARN} ${S_WARN}File <${S_QUESTION}$FILE${S_WARN}> already contains version ${S_NORM}$V_PREV"
       else
-        # Write to output file
-        FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" > "${FILE}.temp" )
+        # Write to output file. jq's stdout is the rewritten JSON and goes to
+        # the temp file, so 2>&1 has to come first for the substitution to
+        # capture stderr — the errors the -z check below is testing for.
+        FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" 2>&1 > "${FILE}.temp" )
 
         if [ -z "$FILE_MSG" ]; then
           echo -e "\n${I_OK} ${S_NOTICE}Updated file <${S_NORM}$FILE${S_NOTICE}> from ${S_QUESTION}$V_PREV ${S_NOTICE}-> ${S_QUESTION}$V_NEW"
-          # rm -f "${FILE}.temp"
           mv -f "${FILE}.temp" "${FILE}"
           # Add file change to commit message:
           GIT_MSG+="updated $FILE, "
+        else
+          echo -e "\n${I_STOP} ${S_ERROR}Error updating version in file <${S_NORM}$FILE${S_ERROR}>:\n${S_WARN}$FILE_MSG"
+          rm -f "${FILE}.temp"
         fi
       fi
 

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -273,12 +273,12 @@ bump-json-files() {
       elif [ "$V_PREV" = "$V_NEW" ]; then
         echo -e "\n${I_WARN} ${S_WARN}File <${S_QUESTION}$FILE${S_WARN}> already contains version ${S_NORM}$V_PREV"
       else
-        # Write to output file. jq's stdout is the rewritten JSON and goes to
-        # the temp file, so 2>&1 has to come first for the substitution to
-        # capture stderr — the errors the -z check below is testing for.
-        FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" 2>&1 > "${FILE}.temp" )
-
-        if [ -z "$FILE_MSG" ]; then
+        # Gate the move on jq's exit status, not on whether it said anything.
+        # Silence is not success: a jq killed by a signal writes no stderr and
+        # still leaves a partial temp file. 2>&1 comes before the redirect so
+        # stdout (the rewritten JSON) reaches the temp file while stderr is
+        # captured for the error message below.
+        if FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" 2>&1 > "${FILE}.temp" ); then
           echo -e "\n${I_OK} ${S_NOTICE}Updated file <${S_NORM}$FILE${S_NOTICE}> from ${S_QUESTION}$V_PREV ${S_NOTICE}-> ${S_QUESTION}$V_NEW"
           mv -f "${FILE}.temp" "${FILE}"
           # Add file change to commit message:


### PR DESCRIPTION
## The bug

`do-packagefile-bump` captures `jq` in a command substitution whose stdout is redirected to the temp file:

```sh
FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" > "${FILE}.temp" )

if [ -z "$FILE_MSG" ]; then          # always true — FILE_MSG can never be set
  echo "Updated file ..."            # so every run claims success
  mv -f "${FILE}.temp" "${FILE}"     # and moves the temp over the original
  GIT_MSG+="updated $FILE, "
fi                                   # no else
```

`FILE_MSG` is always empty, because jq's stdout goes to the file, not the substitution. So the guard is always true, there's no `else`, and **every run takes the success path** — including the runs where jq failed and the temp file is empty.

## What that costs

A malformed JSON file gets replaced with a truncated one, and the script says it worked:

```
before: 49 bytes  ({"version":"1.0.0","name":"x"} + trailing garbage)
jq: parse error: Invalid numeric literal at line 2, column 9
reports: ✅ Updated file <pkg.json> from 1.0.0 -> 2.0.0
after:  40 bytes                                          ← the file is now damaged
```

The user sees a green tick and a broken `package.json`, mid-release, with the original gone.

## The fix

The `-z` test states the intent: `FILE_MSG` was meant to hold jq's *error* output. It never could, because stderr was never captured. Ordering `2>&1` **before** the redirect sends stdout to the temp file and stderr to the substitution, which is what the guard has always been asking for:

```sh
FILE_MSG=$( jq --arg V_NEW "$V_NEW" '.version = $V_NEW' "$FILE" 2>&1 > "${FILE}.temp" )
```

Plus the missing `else`, so a failure reports itself and clears the temp file rather than leaving it behind. **The success path is unchanged** — on success jq writes nothing to stderr, `FILE_MSG` is empty exactly as before, and the same branch runs.

| jq outcome | Before | After |
| --- | --- | --- |
| success | "Updated file", `mv` | unchanged |
| parse error | **"Updated file", `mv`s a truncated file** | reports the error, file untouched, temp removed |

## Also unblocks CI

`SC2327` and `SC2328` fire on this exact line and are the **only** two shellcheck findings in the file. They fail `Run Shellcheck on macos-latest` on every PR — shellcheck added these checks and `main` went red underneath, but the job only runs on PRs, so `main` looks green. This clears both.

30 bats tests pass.