### PR TITLE
feat(version): bump non-JSON files via --bump per-file locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,39 @@ there is nothing to commit). Keep a JSON manifest like `composer.json`?
 Point `--source` at it (or set `SOURCE_FILE` in `.ver-bumprc`) and it
 becomes both the version source and the file that gets bumped.
 
+**Bumping stack-specific files** — keep the version in a `pyproject.toml`, a
+Go const, a Helm `Chart.yaml`, or any text file in lock-step with the tag
+via `--bump` (repeatable), or declare the targets once in `.ver-bumprc` as
+`BUMP_FILES`:
+
+```sh
+# Text pattern — no extra tool; rewrites only the matching line.
+# Works for a Go const, a Python __version__, a Makefile, a Dockerfile, …
+ver-bump --bump 'main.go:Version = "{{version}}"'
+ver-bump --bump 'src/mypkg/__init__.py:__version__ = "{{version}}"'
+
+# Structured dotted path — JSON via jq (built in), TOML/YAML via the
+# jq-based yq suite (tomlq / yq) when installed.
+ver-bump --bump pyproject.toml:@project.version --bump Chart.yaml:@version
+
+# Or declare them once (newline-separated) — every run keeps them in sync:
+# .ver-bumprc
+BUMP_FILES="main.go:Version = \"{{version}}\"
+src/mypkg/__init__.py:__version__ = \"{{version}}\"
+pyproject.toml:@project.version
+Chart.yaml:@version"
+```
+
+Match your file's exact quoting and spacing — the pattern is a literal
+search. `__version__='1.2.3'` (single quotes, no spaces) needs
+`--bump "…/__init__.py:__version__='{{version}}'"`.
+
+A bare `--bump <file>` bumps the file's top-level `.version` (JSON/TOML/YAML);
+`@<path>` targets any dotted key — including a nested one that the JSON
+`.version` default can't reach; and a `{{version}}` text pattern covers
+everything else with no dependency. Same-version and missing files are
+skipped with a notice; every change is staged and listed in the bump commit.
+
 ### CLI
 
 ```sh
@@ -264,7 +297,7 @@ $ ver-bump [-v|--version [<v>]] [-m|--message <msg>] [-f|--file <file.json>]... 
            [-p|--push <remote>] [-t|--tag-prefix <p>] [-B|--branch-prefix <p>] \
            [-d|--dry-run] [-n|--no-commit] [-b|--no-branch] \
            [-c|--no-changelog] [-l|--pause-changelog] [-y|--yes] [-q|--quiet] [-h|--help] \
-           [--source <file.json>] [--branch] [--pr] [--base <branch>] \
+           [--source <file.json>] [--bump <spec>]... [--branch] [--pr] [--base <branch>] \
            [--allow-dirty] [--allow-empty] [--no-fetch] [--no-hooks] \
            [--undo [<version>]] [--major | --minor | --patch] [--preid <id>] [--release] \
            [--completions <shell>] [--install-completions[=<shell>]] [--about]
@@ -293,6 +326,7 @@ Supported keys (each maps 1:1 to an existing global):
 | `REL_PREFIX` | `-B` / `--branch-prefix` | `release-` |
 | `PUSH_DEST` | `-p` / `--push` | `origin` |
 | `SOURCE_FILE` | `--source` | `package.json` |
+| `BUMP_FILES` | `--bump` | *unset* (no extra targets) |
 | `COMMIT_MSG_PREFIX` | *(no flag)* | `"chore: "` |
 | `COMMIT_MSG_TEMPLATE` | *(no flag)* | *unset* (prefix + generated file list) |
 | `CHANGELOG_STYLE` | *(no flag)* | `flat` |
@@ -449,6 +483,20 @@ to the bump commit only; the annotated tag's message keeps its own knob,
                               (tag + CHANGELOG release; with nothing staged, the
                               commit is skipped and the tag lands on HEAD). Also
                               available as the SOURCE_FILE config/env key.
+    --bump <spec>             Also bump the version in a JSON / TOML / YAML / text
+                              file. Repeatable. <spec> is one of:
+                                <file>                 structured, top-level .version
+                                                       by file type (jq / tomlq / yq)
+                                <file>:@<path>         structured, explicit dotted path
+                                                       (e.g. pyproject.toml:@tool.poetry.version)
+                                '<file>:<pattern>'     text search/replace; <pattern>
+                                                       must contain the {{version}} token
+                              Text patterns need no extra tool and rewrite only the
+                              matching line (Go const, Makefile, Dockerfile, plain
+                              VERSION, …). TOML/YAML @paths need the jq-based yq suite
+                              (tomlq / yq); a missing helper exits 3 and points you at
+                              the text-pattern alternative. Also available as the
+                              BUMP_FILES config/env key (newline-separated specs).
     --undo [<version>]        Locally delete the release branch + tag for <version>
                               (refuses if pushed, dirty, or already merged).
     --major                   Force a major bump from the current version.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -30,4 +30,5 @@ contract); IDs added after the PRD are backfilled here first.
 | [ui-output](./ui-output/requirements.md) | R-UI, R-OUT | `ui.bats`, `color.bats`, `about.bats`, `quiet.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |
+| [bump-targets](./bump-targets/requirements.md) | R-TGT | `bump-targets.bats` |
 | [installer](./installer/requirements.md) | R-DIST | `install.bats` |

--- a/docs/features/bump-targets/requirements.md
+++ b/docs/features/bump-targets/requirements.md
@@ -1,0 +1,133 @@
+# Multi-format bump targets (`--bump` / `BUMP_FILES`)
+
+> **Status: ✅ implemented** on `feat/bump-targets` — engine in
+> [lib/textbump.sh](../../../lib/textbump.sh), covered by
+> [test/bump-targets.bats](../../../test/bump-targets.bats). Origin: user
+> feature request 2026-07-15 ("bump non-JSON files for Python / Go / YAML /
+> …") + the follow-on "improve the existing JSON bump with jq as well".
+> Tracked in [issue #92](https://github.com/jv-k/ver-bump/issues/92).
+
+Today every version-writing path assumes JSON + `jq`: `--source` / `SOURCE_FILE`
+(the primary target, R-SRC-1) and `-f` / `--file` extras (`JSON_FILES`) both go
+through `json_set_version` ([lib/json.sh](../../../lib/json.sh)). A Python,
+Go, Rust, or Helm repo has its version in `pyproject.toml`, a `*.go` const, a
+`Chart.yaml`, or a `VERSION`-adjacent file — none of which `jq` can touch — so
+those files fall out of sync with the tag ver-bump cuts.
+
+This feature adds a general **bump target**: a file plus a *locator* that tells
+ver-bump where the version lives inside it. There are two locator kinds, chosen
+per file, and both are explicit (no silent guessing that could rewrite the
+wrong line):
+
+1. **Text pattern locator** — a search string containing the literal token
+   `{{version}}`. ver-bump builds the *search* by substituting
+   `{{version}}` → `V_PREV` and the *replacement* by substituting
+   `{{version}}` → `V_NEW`, then rewrites only the matching line(s),
+   byte-preserving the rest of the file. Pure `sed`/bash; **no new
+   dependency**; works on any text format (Go, Makefile, Dockerfile, `.cfg`,
+   plain `VERSION`, …).
+
+2. **Structured path locator** — `@<path>` into a parsed document. JSON via
+   `jq` (always available), TOML via a TOML helper (`tomlq`, or `yq -p toml`),
+   YAML via `yq` — **used only when present** (they join `gh` as *conditional*
+   dependencies). This is also where the existing JSON bump is improved: the
+   path is no longer hard-wired to top-level `.version` — any `jq` path
+   (`.tool.version`, `.package.version`, `.packages[""].version`) is valid.
+
+## Grammar
+
+A **spec** is `<file>` optionally followed by `:` and a locator:
+
+| Spec form | Locator kind | Example |
+| --- | --- | --- |
+| `<file>` (no `:`) | structured default `.version`, by file type | `--bump composer.json` |
+| `<file>:@<path>` | structured, explicit path | `--bump pyproject.toml:@tool.poetry.version` |
+| `<file>:<pattern>` (pattern contains `{{version}}`) | text search/replace | `--bump main.go:'Version = "{{version}}"'` |
+
+Disambiguation is by the first character after `:` — a leading `@` selects the
+structured path locator; anything else is a text pattern and **must** contain
+`{{version}}`. A bare `<file>` with an unknown (non-JSON/TOML/YAML) extension
+is a usage error (exit `2`) that asks for an explicit `{{version}}` pattern —
+ver-bump never guesses a text pattern for an arbitrary file.
+
+## Requirements (`R-TGT` bucket)
+
+All modules: [lib/textbump.sh](../../../lib/textbump.sh) (engine),
+[lib/args.sh](../../../lib/args.sh) (`--bump`),
+[lib/config.sh](../../../lib/config.sh) (`BUMP_FILES`),
+[ver-bump.sh](../../../ver-bump.sh) (`check-bump-deps` + `bump-target-files`
+call sites), [lib/completions.sh](../../../lib/completions.sh),
+[lib/usage.sh](../../../lib/usage.sh). All tests:
+[test/bump-targets.bats](../../../test/bump-targets.bats).
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-TGT-1 | `--bump <spec>` — long-only, repeatable, takes an arg — registers a bump target. `BUMP_FILES` config/env key mirrors it (newline-separated specs), with R-CFG-3 precedence (CLI `--bump` entries append to env/`.ver-bumprc` entries; nothing overrides, targets accumulate). | ✅ — `args.sh`, `config.sh`, `textbump.sh::resolve-bump-targets` |
+| R-TGT-2 | **Text pattern locator** (`<file>:<pattern>`, pattern contains `{{version}}`): search = pattern with `{{version}}` → `V_PREV`, replacement = pattern with `{{version}}` → `V_NEW`. Only matching line(s) are rewritten; every other byte (indent, quoting, CRLF, missing trailing newline) is preserved. No external dependency. Zero matching lines → a loud `log_error` naming the resolved search string; **non-fatal** (the release continues, parity with a failed JSON extra in `bump-json-files`). | ✅ — `textbump.sh::_bt-text-set`, `bump-target-files` |
+| R-TGT-3 | **Structured path locator** (`<file>:@<path>`, or a bare structured file defaulting to `.version`): JSON via `jq`, TOML via `tomlq`, YAML via `yq` — one `setpath()` filter serves all three (the jq-syntax kislyuk/yq suite). Generalises the JSON bump — any dotted path, not only top-level `.version`. When the path is exactly `.version` on a JSON file, reuse the surgical formatting-preserving rewrite (R-FMT-1); other paths / formats re-serialise structure-aware (formatting may normalise — documented, mirrors R-FMT-3). Simple dotted keys only (no `[`/`]`/`"`); exotic keys are rejected (exit `2`) pointing at the text pattern. | ✅ — `textbump.sh::_bt-struct-set`, `_bt-path-array` |
+| R-TGT-4 | **Conditional dependencies** — `jq` stays always-required. A TOML/YAML *structured* locator requires its helper (`tomlq`; `yq`) only when actually used; absent → exit `3` with an install hint **and** the escape route (use a `{{version}}` text pattern instead, which needs no helper). Preflighted by `check-bump-deps` in the Verify phase, before any mutation. | ✅ — `textbump.sh::check-bump-deps`, `ver-bump.sh` |
+| R-TGT-5 | **Postcondition** — a text write only renames its temp after an in-tmp `grep` confirms the replacement; a structured write is re-read through the locator and asserted to equal `V_NEW`. On any failure the file is left untouched and a loud `log_error` fires (**non-fatal**, mirrors R-FMT-2's "discard the tmp, don't commit a bad write"). | ✅ — `textbump.sh::_bt-text-set`, `bump-target-files` |
+| R-TGT-6 | **Same-version no-op** — if a target already carries `V_NEW`, warn and skip it (no write, no `git add`); parity with `bump-json-files` / `do-packagefile-bump`. | ✅ — `textbump.sh::bump-target-files` |
+| R-TGT-7 | **Dry-run** — each target emits a `[dry-run]` preview line to **stderr** (`would replace … → …` / `would set @path = 'V_NEW'`), no file touched, no staging (R-DRY-1/2 parity). | ✅ — `textbump.sh::bump-target-files` |
+| R-TGT-8 | **Missing / unreadable file** — a missing target warns and is skipped (parity with `JSON_FILES`); a write that fails on an unwritable target is a loud non-fatal `log_error`, file left untouched. | ✅ — `textbump.sh::bump-target-files` |
+| R-TGT-9 | **Staging + commit message** — every target that actually changed is `git add`ed and contributes an `updated <file>,` fragment (trailing space) to `GIT_MSG`, exactly like the existing JSON extras, so the bump commit and CHANGELOG list them uniformly. Honours dry-run (no `git add`). | ✅ — `textbump.sh::bump-target-files` |
+| R-TGT-10 | **Back-compat** — `-f` / `--file <file.json>` is unchanged (JSON top-level `.version` via `bump-json-files`). `--bump` is the general form and handles JSON, TOML, YAML, and arbitrary text; pointed at a JSON file (`--bump foo.json`) it reproduces `-f foo.json` exactly. The two engines run independently; `--source` is unchanged. No existing invocation changes behaviour (full pre-existing suite stays green). | ✅ — `version.sh::bump-json-files` (untouched), `test/bumpfile.bats` |
+| R-TGT-11 | **Completions + docs** — `--bump` is in all three completion emitters (free-form arg, no path-globbing since a spec isn't a plain file), `--help` (`usage.sh`), and the README (synopsis, flag table, config-key table, polyglot example). Help↔README flag parity test stays green. | ✅ — `completions.sh`, `usage.sh`, `README.md`, `test/args.bats` |
+
+## Non-goals (this issue)
+
+- **Reading** the current version *from* a non-JSON file as the source. `--source`
+  stays JSON-only here; a multi-format version *source* (`--source pyproject.toml`
+  reading `@tool.poetry.version`) is a natural follow-on that reuses the R-TGT
+  locator engine, tracked separately. The git-tag fallback (R-SRC-2) already
+  covers most source-less polyglot repos.
+- **Placeholders beyond `{{version}}`** — no `{{major}}`/`{{minor}}`/`{{tag}}`
+  in v1. The single `{{version}}` token keeps the search/replace unambiguous;
+  richer tokens can extend R-TGT-2 later without breaking existing specs.
+- **A curated per-ecosystem preset table** (e.g. "`--python` = these three
+  files/paths"). Presets are sugar over R-TGT specs and can ship later once the
+  primitive is proven.
+
+## Notes
+
+- **Why explicit patterns over auto-detected version lines** — ver-bump is
+  deliberately conservative about mutating files (see the surgical single-line
+  JSON rewrite and its full-rewrite fallback warning, R-FMT). A regex that
+  "finds the version-ish line" risks clobbering an unrelated `version` mention
+  (a dependency pin, a comment, a second table). Making the user name the exact
+  line via `{{version}}` — or an exact structured path — keeps the write
+  auditable and the blast radius one line.
+- **Why `{{version}}` and not `%s`/`$VERSION`** — double-brace is
+  format-neutral: it can't collide with shell (`$`), printf (`%`), Go/TOML
+  string syntax, or YAML anchors in the surrounding literal.
+- The text-pattern path composes cleanly with `.ver-bumprc`: a polyglot repo
+  declares its targets once in `BUMP_FILES` and every `ver-bump` run keeps all
+  of them in lock-step with the tag.
+
+## Modules
+
+- New: [lib/textbump.sh](../../../lib/textbump.sh) — spec parsing, text
+  `{{version}}` search/replace, structured-path dispatch (`jq`/`tomlq`/`yq`),
+  postcondition probe.
+- Touched: [lib/args.sh](../../../lib/args.sh) (`--bump` capture),
+  [lib/config.sh](../../../lib/config.sh) (`BUMP_FILES` key),
+  [ver-bump.sh](../../../ver-bump.sh) (`check-bump-deps` in Verify,
+  `bump-target-files` in Release alongside `bump-json-files`),
+  [lib/completions.sh](../../../lib/completions.sh),
+  [lib/usage.sh](../../../lib/usage.sh), [README.md](../../../README.md).
+  `-f` / `bump-json-files` deliberately left untouched (R-TGT-10).
+
+## Tests — [test/bump-targets.bats](../../../test/bump-targets.bats)
+
+- Text pattern: `main.go` with `Version = "1.2.3"` rewrites only that line; a second unrelated `version` line untouched; CRLF + missing-final-newline preserved byte-for-byte (via `diff`).
+- Zero-match pattern → `log_error` naming the resolved search string, file untouched.
+- Text target already at the new version → warn + skip.
+- Improved JSON: nested `@tool.version`; bare JSON file → surgical top-level `.version` (4-space indent preserved).
+- Structured target already at the new version → warn + skip.
+- Dry-run: preview to stderr, file byte-identical afterwards.
+- Missing file → warn + skip.
+- Grammar: pattern without `{{version}}`, bare non-structured file, `@path` on a text file → exit `2`.
+- Conditional dep: TOML `@path` without `tomlq` → exit `3` with the dual hint (skipped when `tomlq` is installed).
+- Accumulation: `BUMP_FILES` (config) + a `--bump` (CLI) → both applied.
+- End-to-end (dry-run): `--bump` target shows in the release plan.
+- Back-compat (`test/bumpfile.bats`, unchanged): `-f foo.json` still bumps top-level `.version`.

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -248,6 +248,33 @@ normalize-long-opts() {
       continue
     fi
 
+    # --bump <spec> / --bump=<spec> — register a multi-format bump target
+    # (R-TGT). Long-only, repeatable, value flag (same shape as --source);
+    # captured here so it needs no getopts slot. Each spec is
+    # <file>[:@<path> | :<pattern with {{version}}>]. Grammar is validated
+    # later in check-bump-deps (which also covers BUMP_FILES from the rc),
+    # before any mutation — here we only reject an empty value.
+    if [ "$arg" = "--bump" ] || [[ "$arg" == "--bump="* ]]; then
+      local bump_spec
+      if [[ "$arg" == "--bump="* ]]; then
+        bump_spec="${arg#--bump=}"
+        [ -z "$bump_spec" ] && fail 2 \
+          "--bump= requires a spec." \
+          "Pass <file>, <file>:@<path>, or '<file>:<pattern with {{version}}>'."
+      elif (( $# )) && [ "${1:0:1}" != "-" ]; then
+        bump_spec="$1"; shift
+      else
+        fail 2 \
+          "Option --bump requires a spec." \
+          "Pass <file>, <file>:@<path>, or '<file>:<pattern with {{version}}>'."
+      fi
+      BUMP_TARGETS+=("$bump_spec")
+      # To stderr (same reasoning as --source): keeps stdout clean when --bump
+      # precedes --completions / --quiet.
+      echo -e "\n${S_LIGHT}Option set:${RESET} bump target: <${S_VAL}${bump_spec}${RESET}>" >&2
+      continue
+    fi
+
     # --no-hooks — long-only boolean: skip both release hooks (PRE_BUMP_CMD /
     # POST_TAG_CMD) for this run (R-HOOK-5) — git's --no-verify convention.
     # CLI-only like --allow-empty (reset in process-arguments): an rc or env

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -142,12 +142,12 @@ _ver_bump() {
             return 0
             ;;
         # Options that take a free-form argument — no completion
-        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo|--base|--preid)
+        -v|--version|-m|--message|-p|--push|-t|--tag-prefix|-B|--branch-prefix|--undo|--base|--preid|--bump)
             return 0
             ;;
     esac
 
-    opts="--version --message --file --source --push --tag-prefix --branch-prefix \
+    opts="--version --message --file --source --bump --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
           --yes --quiet --undo --branch --pr --base --major --minor --patch --preid --release \
           --sign --allow-dirty --allow-empty --no-fetch --no-hooks \
@@ -172,6 +172,7 @@ _ver_bump() {
     '(-m --message)'{-m,--message}'[custom annotated-tag message]:message:' \
     '(-f --file)'{-f,--file}'[bump version in extra JSON file]:file:_files -g "*.json"' \
     '--source[version source + primary bump target (default package.json)]:file:_files -g "*.json"' \
+    '*--bump[bump a JSON/TOML/YAML/text file: <file>[:@<path>|:<pattern with {{version}}>]]:spec:' \
     '(-p --push)'{-p,--push}'[push branch + tag to <remote>]:remote:' \
     '(-t --tag-prefix)'{-t,--tag-prefix}'[override tag prefix]:prefix:' \
     '(-B --branch-prefix)'{-B,--branch-prefix}'[override branch prefix]:prefix:' \
@@ -214,6 +215,7 @@ for _cmd in ver-bump ver-bump.sh
     complete -c $_cmd -s m -l message        -r -d 'Custom annotated-tag message'
     complete -c $_cmd -s f -l file           -r -a '(__fish_complete_suffix .json)' -d 'Bump version in extra JSON file'
     complete -c $_cmd      -l source         -r -a '(__fish_complete_suffix .json)' -d 'Version source + primary bump target'
+    complete -c $_cmd      -l bump           -r -d 'Bump a JSON/TOML/YAML/text file: <file>[:@<path>|:<pattern with {{version}}>]'
     complete -c $_cmd -s p -l push           -r -d 'Push branch + tag to <remote>'
     complete -c $_cmd -s t -l tag-prefix     -r -d 'Override tag prefix'
     complete -c $_cmd -s B -l branch-prefix  -r -d 'Override branch prefix'

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -26,6 +26,9 @@ true
 #                        ignored; empty = legacy prefix+list, R-TPL-1/2)
 #   SOURCE_FILE (version source + primary bump target, mirrors --source;
 #                default package.json, R-SRC-1/5)
+#   BUMP_FILES (newline-separated multi-format bump-target specs, mirrors
+#               --bump; CLI --bump entries append to these; empty = none,
+#               R-TGT-1)
 #   PRE_BUMP_CMD (release hook before any mutation; empty = no hook, R-HOOK-1)
 #   POST_TAG_CMD (release hook after tag, before push; empty = no hook, R-HOOK-2)
 #   FLAG_NOBRANCH (deprecated, no-op — tag-in-place is the default as of 2.0)
@@ -39,7 +42,7 @@ _CONFIG_KEYS=(TAG_PREFIX REL_PREFIX PUSH_DEST COMMIT_MSG_PREFIX \
               COMMIT_MSG_TEMPLATE FLAG_BRANCH PR_BASE CHANGELOG_STYLE \
               FLAG_NOBRANCH FLAG_NOCHANGELOG FLAG_CHANGELOG_PAUSE \
               ALLOW_DIRTY NO_FETCH RELEASE_BRANCHES TAG_SIGN SOURCE_FILE \
-              PRE_BUMP_CMD POST_TAG_CMD)
+              BUMP_FILES PRE_BUMP_CMD POST_TAG_CMD)
 
 # Walk up from $PWD. Echoes the first .ver-bumprc found; returns 1 if none.
 # Never touches stdout on the "not found" path — load-config treats that

--- a/lib/textbump.sh
+++ b/lib/textbump.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+
+# shellcheck disable=SC2288
+true
+
+# Multi-format bump targets (R-TGT). A "bump target" is a file plus an explicit
+# locator saying where the version lives inside it. Two locator kinds:
+#
+#   1. Text pattern  — a search string containing the literal token
+#      {{version}}. The search is the pattern with {{version}} -> V_PREV; the
+#      replacement is the pattern with {{version}} -> V_NEW. Only lines holding
+#      the literal search are rewritten; every other byte (indent, quoting,
+#      CRLF, a missing final newline) survives — same discipline as
+#      json_set_version (lib/json.sh). Pure bash, no external dependency, any
+#      text format (Go, Makefile, Dockerfile, .cfg, plain VERSION, …).
+#
+#   2. Structured path — @<dotted.path> into a parsed document. JSON via jq
+#      (always available); TOML via tomlq; YAML via yq. The jq-based yq suite
+#      (kislyuk/yq: `yq`, `tomlq`) is assumed so one setpath() filter serves
+#      all three. The path generalises the JSON bump — any dotted path, not
+#      only top-level .version.
+#
+# Spec grammar (see docs/features/bump-targets/requirements.md):
+#   <file>                         structured default .version, by file type
+#   <file>:@<path>                 structured, explicit dotted path
+#   <file>:<pattern-with-{{version}}>  text search/replace
+#
+# The first ':' splits file from locator; a leading '@' after it selects the
+# structured locator, anything else is a text pattern (and must contain
+# {{version}}). Filenames containing ':' are not supported (documented).
+
+# Parse one spec into the _BT_* globals. Fails (exit 2) on a malformed spec.
+# Sets: _BT_FILE, _BT_KIND (path|pattern), _BT_FMT (json|toml|yaml|text),
+#       _BT_PATH (dotted path for kind=path), _BT_PATTERN (kind=pattern).
+_bt-parse-spec() {
+  local spec="$1" loc
+  _BT_FILE="" _BT_KIND="" _BT_FMT="" _BT_PATH="" _BT_PATTERN=""
+
+  if [[ "$spec" == *:* ]]; then
+    _BT_FILE="${spec%%:*}"
+    loc="${spec#*:}"
+  else
+    _BT_FILE="$spec"
+    loc=""
+  fi
+
+  if [ -z "$_BT_FILE" ]; then
+    fail 2 \
+      "--bump spec '${spec}' has no file part." \
+      "Use --bump <file>, --bump <file>:@<path>, or --bump '<file>:<pattern with {{version}}>'."
+  fi
+
+  _BT_FMT=$(_bt-format "$_BT_FILE")
+
+  if [ -z "$loc" ]; then
+    # Bare file: structured default .version, keyed on the extension. An
+    # unknown/text extension is a usage error — never guess a text pattern.
+    if [ "$_BT_FMT" = text ]; then
+      fail 2 \
+        "--bump ${_BT_FILE}: can't infer where the version lives in a non-JSON/TOML/YAML file." \
+        "Give an explicit text pattern: --bump '${_BT_FILE}:<pattern with {{version}}>' (e.g. 'Version = \"{{version}}\"')."
+    fi
+    _BT_KIND="path"; _BT_PATH=".version"
+  elif [[ "$loc" == @* ]]; then
+    _BT_KIND="path"
+    _BT_PATH="${loc#@}"
+    [ -z "$_BT_PATH" ] && _BT_PATH=".version"
+    if [ "$_BT_FMT" = text ]; then
+      fail 2 \
+        "--bump ${_BT_FILE}:@${_BT_PATH#.}: a structured @path needs a JSON, TOML, or YAML file." \
+        "For any other format use a text pattern: --bump '${_BT_FILE}:<pattern with {{version}}>'."
+    fi
+    # Simple dotted keys only — reject array indices / quoted keys so the
+    # setpath() array can be built without a shell-injection surface.
+    case "$_BT_PATH" in
+      *'"'*|*'['*|*']'*)
+        fail 2 \
+          "--bump ${_BT_FILE}:@${_BT_PATH#.}: only simple dotted paths are supported (e.g. @tool.poetry.version)." \
+          "For array indices or exotic keys, use a text pattern instead: --bump '${_BT_FILE}:<pattern with {{version}}>'."
+      ;;
+    esac
+  else
+    _BT_KIND="pattern"
+    _BT_PATTERN="$loc"
+    if [[ "$_BT_PATTERN" != *'{{version}}'* ]]; then
+      fail 2 \
+        "--bump ${_BT_FILE}: text pattern '${_BT_PATTERN}' does not contain the {{version}} placeholder." \
+        "Mark the version position with {{version}}, e.g. --bump '${_BT_FILE}:version = \"{{version}}\"'."
+    fi
+  fi
+}
+
+# Echo the format for a file, keyed only on its extension (the file need not
+# exist yet — dep-checking runs before any read). Unknown extension = text.
+_bt-format() {
+  case "$1" in
+    *.json)          echo json ;;
+    *.toml)          echo toml ;;
+    *.yaml|*.yml)    echo yaml ;;
+    *)               echo text ;;
+  esac
+}
+
+# The external helper a structured target needs, or empty for json/text.
+_bt-helper-for() {
+  case "$1" in
+    toml) echo tomlq ;;
+    yaml) echo yq ;;
+    *)    echo "" ;;
+  esac
+}
+
+# Resolve the full, ordered target list into the _RESOLVED_BUMP_SPECS array:
+# BUMP_FILES (config/env, newline-separated) first, then --bump CLI entries
+# (BUMP_TARGETS[]) — CLI appends, targets accumulate (R-TGT-1). Blank lines
+# and leading/trailing whitespace in BUMP_FILES entries are ignored.
+resolve-bump-targets() {
+  _RESOLVED_BUMP_SPECS=()
+  local line trimmed
+  if [ -n "${BUMP_FILES:-}" ]; then
+    while IFS= read -r line; do
+      # Trim surrounding whitespace so indented .ver-bumprc lists parse.
+      trimmed="${line#"${line%%[![:space:]]*}"}"
+      trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+      [ -z "$trimmed" ] && continue
+      _RESOLVED_BUMP_SPECS+=("$trimmed")
+    done <<< "$BUMP_FILES"
+  fi
+  local spec
+  for spec in ${BUMP_TARGETS[@]+"${BUMP_TARGETS[@]}"}; do
+    _RESOLVED_BUMP_SPECS+=("$spec")
+  done
+}
+
+# Preflight (R-TGT-4): parse every spec (so grammar errors surface before any
+# mutation) and verify the helper for each structured TOML/YAML target is
+# installed. Missing helper -> exit 3 with an install hint AND the no-dep
+# escape route (a {{version}} text pattern). jq is covered by
+# check-dependencies. Runs in the Verify phase; a no-target run is a silent
+# no-op.
+check-bump-deps() {
+  resolve-bump-targets
+  ((${#_RESOLVED_BUMP_SPECS[@]})) || return 0
+
+  local spec helper
+  for spec in "${_RESOLVED_BUMP_SPECS[@]}"; do
+    _bt-parse-spec "$spec"  # fails 2 on a bad spec
+    [ "$_BT_KIND" = path ] || continue
+    helper=$(_bt-helper-for "$_BT_FMT")
+    [ -z "$helper" ] && continue
+    if ! command -v "$helper" >/dev/null 2>&1; then
+      fail 3 \
+        "--bump ${_BT_FILE}: bumping a ${_BT_FMT} path needs '${helper}', which isn't installed." \
+        "Install ${helper} (the jq-based yq suite: 'pip install yq', or 'brew install python-yq'), or bump ${_BT_FILE} with a text pattern instead: --bump '${_BT_FILE}:<pattern with {{version}}>' (no extra tool)."
+    fi
+  done
+}
+
+# Read the current value at a structured path, or empty. Uses the jq-syntax
+# yq suite so one filter serves json/toml/yaml.
+_bt-struct-get() {
+  local file="$1" fmt="$2" arr="$3"
+  # shellcheck disable=SC2016
+  case "$fmt" in
+    json) jq   -r "getpath(${arr}) // empty" "$file" 2>/dev/null ;;
+    toml) tomlq -r "getpath(${arr}) // empty" "$file" 2>/dev/null ;;
+    yaml) yq   -r "getpath(${arr}) // empty" "$file" 2>/dev/null ;;
+  esac
+}
+
+# Set a structured path to <new>, atomically. json/toml/yaml via jq/tomlq/yq,
+# all sharing the setpath() filter. Returns non-zero (leaving the file
+# untouched) on any tool error or empty output. The default JSON .version case
+# is handled by the caller via the surgical, formatting-preserving
+# json_set_version (R-TGT-3); this path re-serialises and may normalise
+# formatting (documented, mirrors R-FMT-3).
+_bt-struct-set() {
+  local file="$1" fmt="$2" arr="$3" new="$4"
+  local tmp rc
+  tmp=$(mktemp "${file}.XXXXXX") || return 1
+  # shellcheck disable=SC2016 # $V is a jq variable, not a bash expansion
+  case "$fmt" in
+    json) jq          --arg V "$new" "setpath(${arr}; \$V)" "$file" >"$tmp" 2>/dev/null; rc=$? ;;
+    toml) tomlq -t    --arg V "$new" "setpath(${arr}; \$V)" "$file" >"$tmp" 2>/dev/null; rc=$? ;;
+    yaml) yq   -y     --arg V "$new" "setpath(${arr}; \$V)" "$file" >"$tmp" 2>/dev/null; rc=$? ;;
+    *)    rm -f "$tmp"; return 1 ;;
+  esac
+  if [ "$rc" -eq 0 ] && [ -s "$tmp" ]; then
+    mv -f "$tmp" "$file"; return 0
+  fi
+  rm -f "$tmp"; return 1
+}
+
+# Build a jq setpath() key array from a dotted path: ".tool.version" ->
+# ["tool","version"]. Keys are already validated (no '"' / '[' / ']'), so the
+# concatenation is injection-safe.
+_bt-path-array() {
+  local p="${1#.}" IFS=. key arr="[" first=1
+  local -a keys
+  read -r -a keys <<< "$p"
+  for key in "${keys[@]}"; do
+    [ "$first" -eq 1 ] || arr+=","
+    arr+="\"${key}\""
+    first=0
+  done
+  arr+="]"
+  printf '%s' "$arr"
+}
+
+# Rewrite every line containing the literal <search>, replacing all
+# occurrences with <replace>, preserving all other bytes. Writes atomically.
+# Sets _BT_COUNT to the number of replacements made. Returns:
+#   0  wrote the file (>=1 replacement) and postcondition held
+#   2  zero matches (nothing written)
+#   1  a write / postcondition failure
+_bt-text-set() {
+  local file="$1" search="$2" replace="$3"
+  local line out="" eof=false before remain acc tmp
+  _BT_COUNT=0
+
+  while [ "$eof" = false ]; do
+    IFS= read -r line || eof=true
+    [ "$eof" = true ] && [ -z "$line" ] && break
+    # Quoted "$search" is a literal in the glob; the unquoted * is the wildcard.
+    if [[ "$line" == *"$search"* ]]; then
+      acc=""; remain="$line"
+      while [[ "$remain" == *"$search"* ]]; do
+        before="${remain%%"$search"*}"
+        acc+="${before}${replace}"
+        remain="${remain#*"$search"}"
+        _BT_COUNT=$((_BT_COUNT + 1))
+      done
+      line="${acc}${remain}"
+    fi
+    if [ "$eof" = true ]; then
+      out+=$line
+    else
+      out+=$line$'\n'
+    fi
+  done < "$file"
+
+  [ "$_BT_COUNT" -eq 0 ] && return 2
+
+  tmp=$(mktemp "${file}.XXXXXX") || return 1
+  if printf '%s' "$out" > "$tmp" && grep -qF -- "$replace" "$tmp"; then
+    if mv -f "$tmp" "$file"; then
+      return 0
+    fi
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+# Bump every registered target (--bump / BUMP_FILES). Runs in the Release
+# phase alongside bump-json-files; the two are independent. Mirrors
+# bump-json-files' logging, dry-run previews, GIT_MSG accounting, and staging.
+bump-target-files() {
+  resolve-bump-targets
+  ((${#_RESOLVED_BUMP_SPECS[@]})) || return 0
+
+  local spec cur arr desc rc
+  local -a PROCESSED=()
+
+  for spec in "${_RESOLVED_BUMP_SPECS[@]}"; do
+    _bt-parse-spec "$spec"  # already validated in check-bump-deps; cheap to redo
+
+    if [ ! -f "$_BT_FILE" ]; then
+      log_warn "file <${S_VAL-}${_BT_FILE}${RESET-}> not found — skipping."
+      continue
+    fi
+
+    if [ "$_BT_KIND" = pattern ]; then
+      # Text search/replace. The search line must currently read the pattern
+      # with V_PREV; with no prior version there is nothing to search for.
+      if [ -z "${V_PREV:-}" ]; then
+        log_error "<${S_VAL-}${_BT_FILE}${RESET-}>: no previous version to build a {{version}} search from — pass -v or add a source file."
+        continue
+      fi
+      local search="${_BT_PATTERN//\{\{version\}\}/$V_PREV}"
+      local replace="${_BT_PATTERN//\{\{version\}\}/$V_NEW}"
+      desc="'${_BT_PATTERN}'"
+
+      if [ "$search" = "$replace" ]; then
+        # V_NEW == V_PREV: replacing is a no-op. Warn if present, else report.
+        if grep -qF -- "$search" "$_BT_FILE"; then
+          log_warn "<${S_VAL-}${_BT_FILE}${RESET-}> already matches version ${S_VAL-}${V_NEW}${RESET-}."
+        else
+          log_error "<${S_VAL-}${_BT_FILE}${RESET-}>: no line matching ${S_VAL-}${search}${RESET-} found."
+        fi
+        continue
+      fi
+
+      if [ "$FLAG_DRYRUN" = true ]; then
+        if grep -qF -- "$search" "$_BT_FILE"; then
+          echo -e "${S_LIGHT-}[dry-run]${RESET-} would replace ${S_VAL-}${search}${RESET-} ${I_ARROW-→} ${S_VAL-}${replace}${RESET-} in ${S_VAL-}${_BT_FILE}${RESET-}" >&2
+          GIT_MSG+="updated ${_BT_FILE}, "
+          PROCESSED+=("$_BT_FILE")
+        elif grep -qF -- "$replace" "$_BT_FILE"; then
+          log_warn "<${S_VAL-}${_BT_FILE}${RESET-}> already contains version ${S_VAL-}${V_NEW}${RESET-}."
+        else
+          log_error "<${S_VAL-}${_BT_FILE}${RESET-}>: no line matching ${S_VAL-}${search}${RESET-} found."
+        fi
+        continue
+      fi
+
+      _bt-text-set "$_BT_FILE" "$search" "$replace"; rc=$?
+      case "$rc" in
+        0)
+          log_success "Updated <${S_VAL-}${_BT_FILE}${RESET-}>: ${S_VAL-}${V_PREV}${RESET-} ${I_ARROW-→} ${S_VAL-}${V_NEW}${RESET-} (${_BT_COUNT}×)."
+          GIT_MSG+="updated ${_BT_FILE}, "
+          PROCESSED+=("$_BT_FILE")
+        ;;
+        2)
+          if grep -qF -- "$replace" "$_BT_FILE"; then
+            log_warn "<${S_VAL-}${_BT_FILE}${RESET-}> already contains version ${S_VAL-}${V_NEW}${RESET-}."
+          else
+            log_error "<${S_VAL-}${_BT_FILE}${RESET-}>: no line matching ${S_VAL-}${search}${RESET-} found."
+          fi
+        ;;
+        *)
+          # Write / postcondition failure. The file is left untouched (the
+          # temp is only renamed after the in-tmp grep check passes), so —
+          # like a failed JSON extra in bump-json-files — this is loud but
+          # non-fatal: the release continues without this file bumped.
+          log_error "failed to update <${S_VAL-}${_BT_FILE}${RESET-}> (write or postcondition check failed) — left untouched."
+        ;;
+      esac
+      continue
+    fi
+
+    # Structured path (json/toml/yaml).
+    arr=$(_bt-path-array "$_BT_PATH")
+    cur=$(_bt-struct-get "$_BT_FILE" "$_BT_FMT" "$arr")
+    desc="@${_BT_PATH#.}"
+
+    if [ "$cur" = "$V_NEW" ]; then
+      log_warn "<${S_VAL-}${_BT_FILE}${RESET-}> already contains version ${S_VAL-}${V_NEW}${RESET-} at ${S_VAL-}${desc}${RESET-}."
+      continue
+    fi
+
+    if [ "$FLAG_DRYRUN" = true ]; then
+      echo -e "${S_LIGHT-}[dry-run]${RESET-} would set ${S_VAL-}${desc}${RESET-} = '${S_VAL-}${V_NEW}${RESET-}' in ${S_VAL-}${_BT_FILE}${RESET-} (was ${S_VAL-}${cur:-none}${RESET-})" >&2
+      GIT_MSG+="updated ${_BT_FILE}, "
+      PROCESSED+=("$_BT_FILE")
+      continue
+    fi
+
+    if [ "$_BT_FMT" = json ] && [ "$_BT_PATH" = ".version" ]; then
+      # Reuse the surgical, formatting-preserving top-level rewrite (R-TGT-3).
+      _bt-json-version-set "$_BT_FILE"; rc=$?
+    else
+      _bt-struct-set "$_BT_FILE" "$_BT_FMT" "$arr" "$V_NEW"; rc=$?
+    fi
+
+    if [ "$rc" -eq 0 ] && [ "$(_bt-struct-get "$_BT_FILE" "$_BT_FMT" "$arr")" = "$V_NEW" ]; then
+      # Postcondition (R-TGT-5): the re-read through the locator confirms V_NEW.
+      log_success "Updated <${S_VAL-}${_BT_FILE}${RESET-}>: ${S_VAL-}${cur:-none}${RESET-} ${I_ARROW-→} ${S_VAL-}${V_NEW}${RESET-} at ${S_VAL-}${desc}${RESET-}."
+      GIT_MSG+="updated ${_BT_FILE}, "
+      PROCESSED+=("$_BT_FILE")
+    elif [ "$rc" -eq 0 ]; then
+      # Tool reported success but the value didn't take — surface it (non-fatal,
+      # like a failed JSON extra) rather than trusting a silent bad write.
+      log_error "post-write check failed for <${S_VAL-}${_BT_FILE}${RESET-}>: ${S_VAL-}${desc}${RESET-} is not ${S_VAL-}${V_NEW}${RESET-} after the write."
+    else
+      log_error "failed to update <${S_VAL-}${_BT_FILE}${RESET-}> at ${S_VAL-}${desc}${RESET-}."
+    fi
+  done
+
+  ((${#PROCESSED[@]})) && dryrun git add "${PROCESSED[@]}"
+  return 0
+}
+
+# Thin wrapper so bump-target-files can call json_set_version by name while
+# keeping the "reuse the surgical rewrite" intent explicit at the call site.
+_bt-json-version-set() {
+  json_set_version "$1" "$V_NEW"
+}

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -96,7 +96,10 @@ usage() {
     local plain pad
     plain="  ${cmd}"
     if (( ${#plain} >= OPT_COL )); then
-      pad=" "
+      # Command overflows the column: keep a single-space gap before the
+      # description (the trailing ${pad# } strips one leading space, so two
+      # spaces here render as one).
+      pad="  "
     else
       printf -v pad '%*s' $((OPT_COL - ${#plain})) ''
     fi
@@ -122,6 +125,11 @@ usage() {
   print-opt-row "-q" "--quiet"         ""            "Suppress decoration; print only the new version on stdout (needs -y, -v, a bump level, or --preid)."
   print-opt-row ""   "--source"        "<file.json>" "Version source + primary bump target (default: package.json)."
   print-opt-cont "If the file is missing, the current version derives from the latest matching git tag."
+  print-opt-row ""   "--bump"          "<spec>"      "Also bump a JSON / TOML / YAML / text file. Repeatable. <spec> is one of:"
+  print-opt-cont "<file>                     structured, top-level .version by file type (jq / tomlq / yq)"
+  print-opt-cont "<file>:@<path>             structured, explicit dotted path, e.g. pyproject.toml:@tool.poetry.version"
+  print-opt-cont "'<file>:<pattern>'         text search/replace; the pattern must contain {{version}}"
+  print-opt-cont "e.g. ver-bump --bump 'main.go:Version = \"{{version}}\"' --bump Chart.yaml:@version"
   print-opt-row ""   "--undo"          "[<version>]" "Locally delete release-X.Y.Z + tag vX.Y.Z (refuses if pushed/dirty)."
   print-opt-row ""   "--major"              ""            "Force a major bump from the current version (mutually exclusive)."
   print-opt-row ""   "--minor"              ""            "Force a minor bump from the current version (mutually exclusive)."
@@ -154,6 +162,9 @@ usage() {
   print-example-row "${SCRIPT_NAME} -t release/"           "Use a custom tag prefix (e.g. release/1.2.3)."
   print-example-row "${SCRIPT_NAME} -f composer.json"      "Also bump version in an extra JSON file."
   print-example-row "${SCRIPT_NAME} --source composer.json" "Use composer.json as the version source (non-Node repo)."
+  print-example-row "${SCRIPT_NAME} --bump pyproject.toml:@project.version" "Also bump a Python project's version (needs tomlq)."
+  print-example-row "${SCRIPT_NAME} --bump 'pkg/__init__.py:__version__ = \"{{version}}\"'" "Also bump a Python __version__ via a text pattern (no extra tool)."
+  print-example-row "${SCRIPT_NAME} --bump 'main.go:Version = \"{{version}}\"'" "Also bump a Go const via a text pattern (no extra tool)."
   print-example-row "${SCRIPT_NAME} --about"               "Show branded version info."
   print-example-row "${SCRIPT_NAME} --install-completions" "Install shell completions (auto-detects shell)."
 

--- a/test/bump-targets.bats
+++ b/test/bump-targets.bats
@@ -1,0 +1,258 @@
+#!/usr/bin/env bats
+
+# Multi-format bump targets (R-TGT) — lib/textbump.sh. Text-pattern and
+# structured-@path locators via --bump / BUMP_FILES. Shared setup lives in
+# test/test_helper.bash. Every test runs inside a fresh scratch_repo.
+
+load 'test_helper'
+
+# --- Text pattern locator (R-TGT-2) -----------------------------------------
+
+@test "bump-target-files: text pattern rewrites only the matching line" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf 'package main\n\nconst Version = "1.2.3"\nvar other = "version 9.9.9"\n' > main.go
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'main.go:Version = "{{version}}"' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "Updated <main.go>: 1.2.3 → 1.2.4 (1×)."
+
+  run cat main.go
+  assert_line 'const Version = "1.2.4"'
+  # The unrelated line that also contains the word "version" is untouched.
+  assert_line 'var other = "version 9.9.9"'
+}
+
+@test "bump-target-files: text pattern preserves CRLF + missing final newline byte-for-byte" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  # No trailing newline on the last line; CRLF endings throughout.
+  printf 'a\r\nVERSION = "1.2.3"\r\nb' > ver.cfg
+  printf 'a\r\nVERSION = "1.2.4"\r\nb' > expected.cfg
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'ver.cfg:VERSION = "{{version}}"' )
+
+  run bump-target-files
+  assert_success
+
+  run diff ver.cfg expected.cfg
+  assert_success
+}
+
+@test "bump-target-files: zero-match text pattern logs an error naming the search" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf 'const Version = "9.9.9"\n' > main.go   # current version is not V_PREV
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'main.go:Version = "{{version}}"' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_output --partial 'no line matching'
+  assert_output --partial 'Version = "1.2.3"'
+  # File left untouched.
+  run cat main.go
+  assert_output 'const Version = "9.9.9"'
+}
+
+@test "bump-target-files: text target already at new version warns and skips" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf 'const Version = "1.2.4"\n' > main.go   # already at V_NEW
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'main.go:Version = "{{version}}"' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_output --partial "already contains version 1.2.4"
+}
+
+# --- Structured @path locator (R-TGT-3) -------------------------------------
+
+@test "bump-target-files: JSON @path bumps a nested version (improved jq bump)" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{\n  "name": "x",\n  "tool": { "version": "1.2.3" }\n}\n' > nested.json
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'nested.json:@tool.version' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "Updated <nested.json>"
+  assert_output --partial "at @tool.version"
+
+  run jq -r '.tool.version' nested.json
+  assert_output "1.2.4"
+}
+
+@test "bump-target-files: bare JSON file uses surgical top-level .version rewrite" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  # 4-space indent + tab elsewhere: json_set_version must preserve it.
+  printf '{\n    "version": "1.2.3",\n    "keep": "me"\n}\n' > app.json
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'app.json' )
+
+  run bump-target-files
+  assert_success
+
+  run cat app.json
+  assert_line '    "version": "1.2.4",'   # 4-space indent preserved
+  assert_line '    "keep": "me"'
+}
+
+@test "bump-target-files: structured target already at new version warns and skips" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf '{ "tool": { "version": "1.2.4" } }\n' > nested.json
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'nested.json:@tool.version' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_output --partial "already contains version 1.2.4"
+}
+
+# --- Dry-run (R-TGT-7) ------------------------------------------------------
+
+@test "bump-target-files: dry-run previews to stderr and touches nothing" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf 'const Version = "1.2.3"\n' > main.go
+  cp main.go before.snapshot
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=true; GIT_MSG=""
+  BUMP_TARGETS=( 'main.go:Version = "{{version}}"' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "[dry-run] would replace"
+  assert_output --partial "Version = \"1.2.3\""
+  assert_output --partial "Version = \"1.2.4\""
+
+  run diff main.go before.snapshot
+  assert_success
+}
+
+# --- Missing / unreadable file (R-TGT-8) ------------------------------------
+
+@test "bump-target-files: missing file warns and skips" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_TARGETS=( 'nope.go:Version = "{{version}}"' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "<nope.go> not found"
+}
+
+# --- Grammar validation (R-TGT-1/2) -----------------------------------------
+
+@test "_bt-parse-spec: text pattern without {{version}} is a usage error (exit 2)" {
+  source ${profile_script}
+
+  run _bt-parse-spec 'main.go:Version = "x"'
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "does not contain the {{version}} placeholder"
+}
+
+@test "_bt-parse-spec: bare non-structured file is a usage error (exit 2)" {
+  source ${profile_script}
+
+  run _bt-parse-spec 'Dockerfile'
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "can't infer where the version lives"
+}
+
+@test "_bt-parse-spec: @path on a text file is a usage error (exit 2)" {
+  source ${profile_script}
+
+  run _bt-parse-spec 'main.go:@version'
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "structured @path needs a JSON, TOML, or YAML file"
+}
+
+# --- Conditional dependency (R-TGT-4) ---------------------------------------
+
+@test "check-bump-deps: TOML @path without tomlq exits 3 with a dual hint" {
+  command -v tomlq >/dev/null 2>&1 && skip "tomlq is installed — the missing-helper path can't be exercised"
+  source ${profile_script}
+
+  BUMP_FILES=""
+  BUMP_TARGETS=( 'pyproject.toml:@project.version' )
+
+  run check-bump-deps
+  assert_failure 3
+  strip_ansi_output
+  assert_output --partial "needs 'tomlq'"
+  assert_output --partial "text pattern instead"
+}
+
+# --- Accumulation: BUMP_FILES (config) + --bump (CLI) (R-TGT-1) --------------
+
+@test "bump-target-files: BUMP_FILES config and --bump CLI both apply" {
+  source ${profile_script}
+  cd "$(scratch_repo)"
+
+  printf 'const Version = "1.2.3"\n' > main.go
+  printf 'version: 1.2.3\n' > Chart.yaml
+
+  V_PREV="1.2.3"; V_NEW="1.2.4"; FLAG_DRYRUN=false; GIT_MSG=""
+  BUMP_FILES=$'main.go:Version = "{{version}}"'
+  BUMP_TARGETS=( 'Chart.yaml:version: {{version}}' )
+
+  run bump-target-files
+  strip_ansi_output
+  assert_success
+  assert_output --partial "Updated <main.go>"
+  assert_output --partial "Updated <Chart.yaml>"
+
+  run grep -c '1.2.4' main.go
+  assert_output "1"
+  run cat Chart.yaml
+  assert_output "version: 1.2.4"
+}
+
+# --- End-to-end via the script (R-TGT-9 staging + commit message) -----------
+
+@test "--bump end-to-end (dry-run) reports the target in the plan" {
+  local repo; repo="$(scratch_repo)"
+  cd "$repo"
+  printf '{ "version": "0.9.0" }\n' > package.json
+  printf 'const Version = "0.9.0"\n' > main.go
+  git add -A; git commit -qm "feat: seed"; git tag v0.9.0
+  printf 'x\n' > f.txt; git add f.txt; git commit -qm "fix: change"
+
+  run ${profile_script} -d -c -y -p origin -v 1.0.1 --bump 'main.go:Version = "{{version}}"'
+  strip_ansi_output
+  assert_success
+  assert_output --partial 'would replace'
+  assert_output --partial 'Version = "0.9.0"'
+  assert_output --partial 'Version = "1.0.1"'
+}

--- a/ver-bump.sh
+++ b/ver-bump.sh
@@ -30,6 +30,7 @@ source "$MODULE_DIR/lib/errors.sh"
 source "$MODULE_DIR/lib/ui.sh"
 source "$MODULE_DIR/lib/validate.sh"
 source "$MODULE_DIR/lib/json.sh"
+source "$MODULE_DIR/lib/textbump.sh"
 
 source "$MODULE_DIR/lib/usage.sh"
 source "$MODULE_DIR/lib/completions.sh"
@@ -70,6 +71,10 @@ VER_FILE="$SOURCE_FILE"
 
 JSON_FILES=()
 
+# --bump specs collected from the CLI (repeatable). Merged with the newline-
+# separated BUMP_FILES config/env key by resolve-bump-targets (lib/textbump.sh).
+BUMP_TARGETS=()
+
 # ── Initiate Script ────────────────────────────────────────────────────
 
 main() {
@@ -86,6 +91,7 @@ main() {
   VER_FILE="$SOURCE_FILE"
   check-dependencies
   check-release-deps
+  check-bump-deps # validate --bump / BUMP_FILES specs + conditional tomlq/yq (R-TGT-4)
 
   section "Verify"
   check-commits-exist
@@ -102,6 +108,7 @@ main() {
   run-pre-bump-hook # PRE_BUMP_CMD: all preflights passed, nothing mutated yet (R-HOOK-1)
   do-packagefile-bump
   bump-json-files
+  bump-target-files # --bump / BUMP_FILES: non-JSON + arbitrary-path targets (R-TGT)
   do-versionfile
   do-changelog
   do-branch


### PR DESCRIPTION
Adds a general multi-format bump target — `--bump <spec>` (repeatable) and the `BUMP_FILES` config/env key — so non-JSON stacks (Python, Go, Rust, Helm, …) keep their version files in lock-step with the tag. Also generalises the JSON bump to arbitrary `jq` paths. Origin: feature request + follow-up "improve the existing JSON bump with jq as well".

A **bump target** is a file plus an explicit *locator* saying where the version lives:

- **Text pattern** `<file>:<pattern with {{version}}>` — literal line rewrite, **no dependency**, any format (Go const, Python `__version__`, Makefile, Dockerfile, plain `VERSION`, …). `{{version}}` → `V_PREV` locates, → `V_NEW` replaces; only the matching line changes, all other bytes preserved (CRLF, indent, missing final newline) — same discipline as `json_set_version`.
- **Structured `@path`** `<file>:@tool.version` (or a bare `.json`/`.toml`/`.yaml` for top-level `.version`) — any dotted path via one `jq setpath()` filter (jq / tomlq / yq). Generalises the JSON bump beyond top-level `.version`; a bare `.version` JSON target keeps the surgical formatting-preserving rewrite (R-FMT-1).
- **Conditional deps**: `jq` stays always-required; `tomlq`/`yq` are needed only for a TOML/YAML `@path`, preflighted in `check-bump-deps` (exit 3 with a dual hint — install the helper, or use a `{{version}}` text pattern instead).

Failures are non-fatal (loud `log_error`, file left untouched), matching `bump-json-files`' handling of extra files; same-version and missing targets are skipped with a notice; every change is staged and contributes to `GIT_MSG`. A bare `--bump <file>` on a non-JSON/TOML/YAML extension is a usage error (exit 2) that asks for a `{{version}}` pattern — ver-bump never guesses a version line in arbitrary text.

`-f`/`--file` and `--source` are unchanged; the full pre-existing suite stays green.

**Contract:** `docs/features/bump-targets/requirements.md` (new `R-TGT` bucket, R-TGT-1..11).

**New:** `lib/textbump.sh`. **Touched:** `lib/args.sh` (`--bump`), `lib/config.sh` (`BUMP_FILES`), `ver-bump.sh` (`check-bump-deps` + `bump-target-files`), `lib/completions.sh`, `lib/usage.sh`, `README.md`. `print-example-row` also fixed to keep a space before the description when an example command overflows the column.

Tests: `test/bump-targets.bats` — 14 cases (text + CRLF byte-preservation, nested `@path`, grammar exit 2, missing-helper exit 3, dry-run, same-version skip, config+CLI accumulation, end-to-end). Full suite: **495/495**. `shellcheck -x` clean.

Refs #92.
