### PR TITLE
fix(ui): terminate prompt line when enter accepts the suggestion

### DIFF
--- a/lib/version.sh
+++ b/lib/version.sh
@@ -159,6 +159,10 @@ process-version() {
         "Re-run and enter a version (or <enter> for the suggestion), or pass -v <version> to skip the prompt."
     fi
     if [ -z "$_first" ]; then
+      # Enter accepted the suggestion, but the silent read swallowed the
+      # keystroke unechoed — terminate the (no-newline) prompt line so the
+      # next section header keeps its blank line above.
+      printf '\n'
       V_USR_INPUT=""
     elif [ -t 0 ] && (( ${BASH_VERSINFO[0]:-0} >= 4 )); then
       # Interactive on bash 4+: pre-fill readline so the first char stays


### PR DESCRIPTION
The RELEASE header printed flush under the version prompt — the only section without its blank line above. Section pills bring their own leading newline (`_render_pill`), so the gap only appears if the previous line was terminated; the version prompt reads its first keystroke silently (`read -rsn1`), and a bare `<enter>` accepting the suggestion was swallowed unechoed, leaving the prompt line open.

- `lib/version.sh`: print `\n` in the enter-accept branch of `process-version`, mirroring the existing ESC path.

Only the enter-accept path was affected: typing a version goes through readline (or a cooked-mode `read`), which echoes the newline itself — which is also why the CONFIRM pill spaced correctly.

Tests: none added — the missing newline is TTY echo behaviour, so it needs a pty. Verified manually by driving `ver-bump.sh -n` under `expect`: before, ` RELEASE ` rendered adjacent to the prompt line; after, exactly one blank line, matching every other section. Full suite: 518/518.

No linked issue — one-line UI polish spotted in a release run screenshot; filing an issue would outweigh the fix.