### PR TITLE
feat(json): add --dry-run --json structured release preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ VerBump             # cut it: reads commits, suggests a bump, prompts before pus
 - [Bumping non-Node projects and extra files](#bumping-non-node-projects-and-extra-files)
 - [Version suggestion](#version-suggestion)
 - [Dry-run](#dry-run)
+  - [The release plan as JSON (`--dry-run --json`)](#the-release-plan-as-json---dry-run---json)
 - [Release hooks](#release-hooks)
 - [Exit codes](#exit-codes)
 - [Shell completions](#shell-completions)
@@ -312,6 +313,7 @@ The three bump levels are mutually exclusive with each other and with `-v`. With
 | `-d`, `--dry-run` | Print every side-effect without executing. |
 | `-y`, `--yes` | Skip interactive confirmation prompts. |
 | `-q`, `--quiet` | Suppress decoration and print only the new version on stdout (needs `-y`, `-v`, a bump level, or `--preid`). |
+| `--json` | With `--dry-run`: print the release plan as a single JSON object on stdout, for scripts and CI (needs `-y`, `-v`, a bump level, or `--preid`). |
 | `-h`, `--help` | Show the help message (paged through `less`/`more` when the terminal is short). |
 | `--completions <shell>` | Emit a completion script for bash, zsh, or fish. |
 | `--install-completions[=<shell>]` | Install the completion script (auto-detects the shell). |
@@ -508,6 +510,26 @@ $ verbump --dry-run
 ```
 
 Combine with `--no-commit` / `--no-changelog` to narrow the preview down to just the steps you want to see.
+
+### The release plan as JSON (`--dry-run --json`)
+
+The preview above is written for people. Add `--json` and the same preview comes out as data: one JSON object on stdout that says what the release would be (`1.4.2 → 1.5.0`) and lists every step VerBump would take — which files it would touch, the commit, the tag, what gets pushed where — in the order it would take them. All the human-readable output moves to stderr, so redirecting stdout captures pure JSON:
+
+```sh
+$ verbump --minor --yes -p origin --dry-run --json > plan.json
+$ jq -r '.version.from + " → " + .version.to' plan.json
+1.4.2 → 1.5.0
+$ jq -r '.effects[].action' plan.json
+bump-json
+changelog
+commit
+tag
+push
+```
+
+This is for anything that isn't a person reading a terminal: a CI job that posts the release plan for approval before the real run, a script that needs the next version number, or an AI agent checking what a release would do before asking you to pull the trigger. The plan only ever lists steps that would actually run — leave out `--pr` and there's no `open-pr` entry to filter around.
+
+Two rules keep it predictable: `--json` only works together with `--dry-run` (it previews a release; it never performs one), and like `--quiet` it needs a non-interactive version choice (`-y`, `-v`, a bump level, or `--preid`). If nothing needs releasing, stdout stays empty. The payload is versioned (`"schema": "verbump.dry-run/v1"`), and the full field reference lives in [`docs/features/dry-run-json/DESIGN.md`](docs/features/dry-run-json/DESIGN.md).
 
 ## Release hooks
 

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -175,6 +175,7 @@ lib/git-actions.sh   side-effecting git ops (branch, commit, tag, push,
                      GitHub release, undo) + the dryrun helper
 lib/config.sh        .verbumprc discovery, safety checks, precedence
 lib/json.sh          atomic jq_inplace JSON writes
+lib/effects.sh       --dry-run --json effects accumulator + emitter (R-OUT-5)
 lib/errors.sh        fail + the exit-code contract
 lib/completions.sh   completion emit + --install-completions installer
 lib/usage.sh         --help output

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -27,7 +27,8 @@ contract); IDs added after the PRD are backfilled here first.
 | [undo](./undo/requirements.md) | R-UNDO | `undo.bats` |
 | [safety-preflights](./safety-preflights/requirements.md) | R-SAFE | `worktree-clean.bats`, `release-branch-guard.bats`, `remote-sync.bats`, `no-release.bats` |
 | [hooks](./hooks/requirements.md) | R-HOOK | `hooks.bats`, `args.bats` |
-| [ui-output](./ui-output/requirements.md) | R-UI, R-OUT | `ui.bats`, `color.bats`, `about.bats`, `quiet.bats` |
+| [ui-output](./ui-output/requirements.md) | R-UI, R-OUT-1..4 | `ui.bats`, `color.bats`, `about.bats`, `quiet.bats` |
+| [dry-run-json](./dry-run-json/requirements.md) | R-OUT-5..7 | `dry-run-json.bats` |
 | [dev-sandbox](./dev-sandbox/requirements.md) | R-DEV | `sandbox.bats` |
 | [json-bump-formatting](./json-bump-formatting/requirements.md) | R-FMT | `json.bats`, `bumpfile.bats` |
 | [bump-targets](./bump-targets/requirements.md) | R-TGT | `bump-targets.bats` |

--- a/docs/features/dry-run-json/DESIGN.md
+++ b/docs/features/dry-run-json/DESIGN.md
@@ -1,0 +1,176 @@
+# `--dry-run --json` — structured release preview
+
+Status: **shipped** (R-OUT-5..7, issue #107). Requirements contract in
+[`requirements.md`](./requirements.md); accumulator in
+[`lib/effects.sh`](../../../lib/effects.sh); tests in
+`test/dry-run-json.bats`.
+
+## Goal
+
+Give a script, a CI job, or an agent a machine-readable answer to *"what
+would a release do?"* without side effects. Same information the human
+`[dry-run] would ...` lines already carry, emitted once as a single JSON
+object instead of prose scattered across stderr.
+
+Deliberately **preview-only**: `--json` without `--dry-run` exits 2. Lowering
+the barrier to *reading* a release plan is safe; lowering it to *triggering*
+one is not (this is also why an MCP server was rejected in #107 — the
+mutating path stays human-gated). A post-run *result* object remains a
+possible later extension precisely because the combination is rejected today.
+
+## How it works
+
+| Piece | Mechanism |
+| --- | --- |
+| Serializer | `jq` — already a hard runtime dep, adds none. Not pure bash: hand-built JSON corrupts on the first `"` in a commit subject. |
+| Stream discipline | reuses R-OUT-1's FD-3 redirect (`exec 3>&1 1>&2` in `process-arguments`): decoration → stderr, the one JSON object → the saved real stdout. |
+| Effect collection | one `record-effect` call beside each `[dry-run]` preview line — the structured sibling of the prose. Guards (`FLAG_*`/`DO_*`) already decide whether a site runs, so `effects[]` contains only what *would* run. |
+| Bash 3.2 | no associative arrays → the accumulator is one JSON-array *string* (`VB_EFFECTS`), grown via `jq --arg` calls. |
+
+`record-effect key value ...` builds one object through jq's `$ARGS.named`
+(every value escaped by jq; all values strings). `record-effect-raw '<json>'`
+is the escape hatch for typed fields — booleans and counts — with jq
+validating the fragment on merge. Both are **no-ops unless `FLAG_JSON=true`**,
+so normal runs pay nothing. `emit-effects-json` writes the final object to
+FD 3 at the end of `main()`.
+
+`FLAG_JSON` is CLI-only (reset in `process-arguments`, like `FLAG_QUIET`),
+and `--json` requires a non-interactive version choice (`--yes`, `-v`, a
+bump level, or `--preid`) — a JSON pipeline must not stop at a prompt.
+
+## Schema — `verbump.dry-run/v1`
+
+Top level:
+
+| field | type | notes |
+| --- | --- | --- |
+| `schema` | string | `verbump.dry-run/v1`; bump on breaking change |
+| `dryRun` | bool | always `true` in this mode |
+| `version` | object | `{from, to}` + `level` only when a bump level drove the version (absent under `-v`) + `preid` only when set |
+| `source` | string | resolved version source (`--source` / default `package.json`) |
+| `tag` | string | `TAG_PREFIX + V_NEW` |
+| `effects` | array | ordered as `main()` would execute them — the array doubles as the execution plan |
+
+Each `effects[]` object carries an `action` discriminator plus
+action-specific fields. All values are strings unless noted:
+
+| `action` | fields | recorded by |
+| --- | --- | --- |
+| `run-hook` | `hook` (`pre-bump` \| `post-tag`), `command` | `_run-hook` (lib/hooks.sh) |
+| `bump-json` | `target`, `from`, `to`, `role` (`source` \| `lock` \| `extra`) | `do-packagefile-bump`, `bump-json-files` |
+| `bump-text` | `target`, `pattern` (with `{{version}}`), `from`, `to` | `bump-target-files` (text patterns) |
+| `bump-struct` | `target`, `format` (`json` \| `toml` \| `yaml`), `path` (dotted), `from`, `to` | `bump-target-files` (structured paths) |
+| `write` | `target` (`VERSION`), `to` | `do-versionfile` |
+| `changelog` | `target`, `op` (`created` \| `updated`), `heading`, `entries` (**number**: commit bullets + the bump entry) | `do-changelog` |
+| `branch` | `ref` | `do-branch` |
+| `commit` | `message` (full rendered message; no `paths` field — the file effects before it already enumerate every staged path) | `do-commit` |
+| `tag` | `ref`, `annotated` (**bool**, always `true`), `signed` (**bool**), `message` | `do-tag` |
+| `push` | `remote`, `branch`, `tag` | `do-push` |
+| `open-pr` | `head`, `base`, `title` | `do-pr` |
+| `github-release` | `tag`, `notes` (`generated` \| `command`), `prerelease` (**bool**) | `do-github-release` |
+
+A no-op run (nothing to release) emits **nothing** on stdout and exits 0 —
+`[ -s plan.json ]` is the "a release would happen" test, mirroring R-OUT-4.
+`--quiet --json` emits only the JSON object; the bare-version line is
+skipped because the same fact lives at `.version.to`.
+
+## Sample payload
+
+Verbatim output of the dev sandbox — reproducible by anyone with:
+
+```sh
+SANDBOX_COMMITS='feat: add login; fix: null crash' \
+  ./dev/sandbox.sh --minor --yes --remote -p origin --dry-run --json 2>/dev/null | jq .
+```
+
+```json
+{
+  "schema": "verbump.dry-run/v1",
+  "dryRun": true,
+  "version": {
+    "from": "0.1.0",
+    "to": "0.2.0",
+    "level": "minor"
+  },
+  "source": "package.json",
+  "tag": "v0.2.0",
+  "effects": [
+    {
+      "action": "bump-json",
+      "target": "package.json",
+      "from": "0.1.0",
+      "to": "0.2.0",
+      "role": "source"
+    },
+    {
+      "action": "changelog",
+      "target": "CHANGELOG.md",
+      "op": "created",
+      "heading": "## 0.2.0 (2026-07-19)",
+      "entries": 3
+    },
+    {
+      "action": "commit",
+      "message": "chore: updated package.json, created CHANGELOG.md, bumped 0.1.0 -> 0.2.0"
+    },
+    {
+      "action": "tag",
+      "ref": "v0.2.0",
+      "annotated": true,
+      "signed": false,
+      "message": "Tag version 0.2.0."
+    },
+    {
+      "action": "push",
+      "remote": "origin",
+      "branch": "main",
+      "tag": "v0.2.0"
+    }
+  ]
+}
+```
+
+### Fuller plan
+
+The same schema with more of the surface switched on —
+`verbump --minor --yes --pr --release -f composer.json --dry-run --json`:
+
+```json
+{
+  "schema": "verbump.dry-run/v1",
+  "dryRun": true,
+  "version": { "from": "1.2.3", "to": "1.3.0", "level": "minor" },
+  "source": "package.json",
+  "tag": "v1.3.0",
+  "effects": [
+    { "action": "bump-json", "target": "package.json", "from": "1.2.3", "to": "1.3.0", "role": "source" },
+    { "action": "bump-json", "target": "composer.json", "from": "1.2.3", "to": "1.3.0", "role": "extra" },
+    { "action": "changelog", "target": "CHANGELOG.md", "op": "created", "heading": "## 1.3.0 (2026-07-19)", "entries": 2 },
+    { "action": "branch", "ref": "release-1.3.0" },
+    { "action": "commit", "message": "chore: updated package.json, updated composer.json, created CHANGELOG.md, bumped 1.2.3 -> 1.3.0" },
+    { "action": "tag", "ref": "v1.3.0", "annotated": true, "signed": false, "message": "Tag version 1.3.0." },
+    { "action": "push", "remote": "origin", "branch": "release-1.3.0", "tag": "v1.3.0" },
+    { "action": "open-pr", "head": "release-1.3.0", "base": "main", "title": "Release v1.3.0" },
+    { "action": "github-release", "tag": "v1.3.0", "notes": "generated", "prerelease": false }
+  ]
+}
+```
+
+## Decisions (resolved 2026-07-19)
+
+1. **Typed fields** — booleans and counts are real JSON types via
+   `record-effect-raw`; everything else stays a string.
+2. **`--json` without `--dry-run` rejects** (exit 2). Preview-only for v1; a
+   result object can be added later without a breaking change.
+3. **`effects` is flat + ordered** — it doubles as the execution plan.
+   Consumers group trivially: `jq '.effects | group_by(.action)'`.
+4. **Requirement ids** — R-OUT-5..7 in [`requirements.md`](./requirements.md),
+   extending the `--quiet` R-OUT bucket.
+5. **Field deviations from the issue's abridged sample** (all deliberate):
+   `commit` has no `paths` field (the file effects before it already
+   enumerate every staged path); structured `--bump` targets get their own
+   `bump-struct` action (they can be TOML/YAML, not just text patterns);
+   `push` uses separate `branch` + `tag` fields instead of a joined `refs`
+   string; `github-release` records `notes` + `prerelease` and drops `title`
+   (gh derives the title from the tag); `version.level` is absent under an
+   explicit `-v`.

--- a/docs/features/dry-run-json/requirements.md
+++ b/docs/features/dry-run-json/requirements.md
@@ -1,0 +1,21 @@
+# `--dry-run --json` — structured release preview
+
+Machine-readable answer to *"what would this release do?"* (issue #107).
+Extends the R-OUT bucket started by `--quiet`
+([ui-output](../ui-output/requirements.md)): `--quiet` gives machines the
+*result* of a release; `--json` gives them the *plan* before one.
+
+| ID | Requirement | Status |
+| --- | --- | --- |
+| R-OUT-5 | `--dry-run --json` emits exactly one JSON object (`"schema": "verbump.dry-run/v1"`) on stdout via the R-OUT-1 FD-3 channel — decoration, prompts, and `[dry-run]` lines stay on stderr. `effects[]` is ordered as `main()` would execute the steps and contains **only** the operations that would actually run (each site's `FLAG`/`DO_` guard decides membership — no "skipped" noise). Values are jq-escaped: commit messages / paths with quotes, newlines, or backslashes round-trip byte-exact. Counts and booleans are typed (`changelog.entries` number; `tag.annotated`/`tag.signed`, `github-release.prerelease` booleans). | ✅ shipped — `test/dry-run-json.bats` |
+| R-OUT-6 | `--json` is **preview-only** and prompt-free by construction: without `--dry-run` it exits `2` naming the fix; without `--yes`, `-v`, a forced bump level, or `--preid` it exits `2` (mirrors R-OUT-2). `--json=value` exits `2` (boolean flag, R-OPT-2). `FLAG_JSON` is CLI-only — reset in `process-arguments`; an rc key or env var can never switch JSON mode on. | ✅ shipped — `test/dry-run-json.bats` |
+| R-OUT-7 | Composes with the rest of the output contract: `--quiet --json` emits only the JSON object (the bare-version line is skipped; the version lives at `.version.to`); a no-op run (nothing to release, R-SAFE-14) leaves stdout **empty** and exits `0`, mirroring R-OUT-4; without `--json`, dry-run output is byte-identical to before (the accumulator is a no-op). | ✅ shipped — `test/dry-run-json.bats` |
+
+Schema, field reference, and the integration map live in
+[`DESIGN.md`](./DESIGN.md).
+
+Modules: `lib/effects.sh` (accumulator + emitter), `lib/args.sh` (flag,
+stream discipline, guards), `verbump.sh` (emit at end of `main()`), plus one
+`record-effect` call beside each `[dry-run]` preview site in `lib/hooks.sh`,
+`lib/version.sh`, `lib/textbump.sh`, `lib/changelog.sh`, `lib/git-actions.sh`.
+Tests: `test/dry-run-json.bats`.

--- a/docs/features/ui-output/requirements.md
+++ b/docs/features/ui-output/requirements.md
@@ -27,6 +27,10 @@ capture pattern.
 | R-OUT-3 | Composes with `--dry-run`: stdout gets the would-be version; the `[dry-run]` side-effect lines target stderr (R-DRY-2), so the pipe stays clean. | ✅ shipped — `test/quiet.bats` |
 | R-OUT-4 | A quiet no-op (nothing to release, R-SAFE-14) prints **nothing** on stdout — the `no-release` token is rerouted with the rest of the decoration — and exits `0`, so `[ -z "$out" ]` is the CI branch test for "no release happened". | ✅ shipped — `test/quiet.bats` |
 
+The bucket continues in
+[dry-run-json](../dry-run-json/requirements.md): R-OUT-5..7 cover
+`--dry-run --json`, the structured release *plan* on the same FD-3 channel.
+
 Implementation is stream discipline, not a renderer: `process-arguments`
 (`lib/args.sh`) pre-scans argv for `-q`/`--quiet`, saves the real stdout on
 FD 3 and redirects FD 1 to stderr (`exec 3>&1 1>&2`) before any option echo

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -275,6 +275,20 @@ normalize-long-opts() {
       continue
     fi
 
+    # --json — long-only boolean: with --dry-run, emit the release plan as one
+    # JSON object on stdout (R-OUT-5). CLI-only like --quiet (reset in
+    # process-arguments): a machine-output mode must be an explicit
+    # per-invocation choice. The --dry-run requirement and the prompt guard
+    # are enforced after parsing, once FLAG_DRYRUN is known.
+    if [ "$arg" = "--json" ]; then
+      FLAG_JSON=true
+      continue
+    elif [[ "$arg" == "--json="* ]]; then
+      fail 2 \
+        "Option --json doesn't take a value." \
+        "Drop the '=<value>' — --json is a boolean flag."
+    fi
+
     # --no-hooks — long-only boolean: skip both release hooks (PRE_BUMP_CMD /
     # POST_TAG_CMD) for this run (R-HOOK-5) — git's --no-verify convention.
     # CLI-only like --allow-empty (reset in process-arguments): an rc or env
@@ -434,6 +448,18 @@ normalize-long-opts() {
   done
 }
 
+# Shared guard for the machine-output modes (--quiet R-OUT-2, --json
+# R-OUT-6): both capture stdout, where an interactive version prompt is a
+# hung pipeline. Exits 2 with the caller's message unless the version choice
+# is already non-interactive (--yes, -v, a forced level, or --preid).
+_require-noninteractive-version() {
+  if [ "${FLAG_YES:-false}" != true ] && [ -z "${V_USR_SUPPLIED-}" ] && [ -z "${BUMP_LEVEL-}" ] && [ -z "${PRE_ID-}" ]; then
+    fail 2 \
+      "$1" \
+      "Add --yes to accept the suggested version, pass -v <version>, or force a level with --major/--minor/--patch/--preid."
+  fi
+}
+
 # Process script options
 process-arguments() {
   local OPTIONS OPTIND OPTARG
@@ -452,7 +478,12 @@ process-arguments() {
   PRE_ID=
   ALLOW_EMPTY=false
   FLAG_QUIET=false
+  FLAG_JSON=false
   FLAG_NOHOOKS=false
+  # Effects accumulator (lib/effects.sh): reset alongside FLAG_JSON so a
+  # sourced VerBump running main() twice can't leak run-1 effects into
+  # run-2's --json payload (R-OUT-5).
+  reset-effects
 
   normalize-long-opts "$@"
   set -- ${NORMALIZED_ARGV[@]+"${NORMALIZED_ARGV[@]}"}
@@ -476,7 +507,12 @@ process-arguments() {
       -q*|-[!-]*q*) FLAG_QUIET=true; break ;;
     esac
   done
-  if [ "$FLAG_QUIET" = true ]; then
+  # --json shares the same stream discipline (R-OUT-5): the single JSON
+  # object main() emits at the end goes to the saved real stdout on FD 3,
+  # everything else to stderr — so `VerBump --dry-run --json >plan.json`
+  # captures nothing but JSON. FLAG_JSON is already final here
+  # (normalize-long-opts set it above; it has no short form to pre-scan).
+  if [ "$FLAG_QUIET" = true ] || [ "$FLAG_JSON" = true ]; then
     exec 3>&1 1>&2
   fi
 
@@ -592,10 +628,21 @@ process-arguments() {
         "--quiet is incompatible with -l/--pause-changelog (an interactive pause would hang a captured pipeline)." \
         "Drop -l/--pause-changelog (or unset FLAG_CHANGELOG_PAUSE in .verbumprc), or drop --quiet."
     fi
-    if [ "${FLAG_YES:-false}" != true ] && [ -z "${V_USR_SUPPLIED-}" ] && [ -z "${BUMP_LEVEL-}" ] && [ -z "${PRE_ID-}" ]; then
+    _require-noninteractive-version \
+      "--quiet would hide the interactive version prompt (a hidden prompt is a hung pipeline)."
+  fi
+
+  # --json is preview-only in v1 (R-OUT-6): it describes what a release
+  # *would* do, so it is meaningful only with --dry-run. A post-run result
+  # object is a possible later extension — rejecting now keeps that door
+  # open without a breaking change.
+  if [ "$FLAG_JSON" = true ]; then
+    if [ "${FLAG_DRYRUN:-false}" != true ]; then
       fail 2 \
-        "--quiet would hide the interactive version prompt (a hidden prompt is a hung pipeline)." \
-        "Add --yes to accept the suggested version, pass -v <version>, or force a level with --major/--minor/--patch/--preid."
+        "--json requires --dry-run (it emits a preview of the release plan; real runs keep their normal output)." \
+        "Add -d/--dry-run, or drop --json."
     fi
+    _require-noninteractive-version \
+      "--json needs a non-interactive version choice (a JSON pipeline must not stop at a prompt)."
   fi
 }

--- a/lib/changelog.sh
+++ b/lib/changelog.sh
@@ -225,7 +225,7 @@ _changelog-grouped-section() {
 do-changelog() {
   [ "$FLAG_NOCHANGELOG" = true ] && return
   subsection "changelog"
-  local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP _chlog_line
+  local ACTION_MSG COMMITS_MSG LOG_MSG LOG_RC RANGE TMP _chlog_line _chlog_entries
 
   RANGE=$([ "$(git tag -l "${TAG_PREFIX}${V_PREV}")" ] && echo "${TAG_PREFIX}${V_PREV}..HEAD")
   if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then
@@ -285,6 +285,23 @@ do-changelog() {
   fi
 
   if [ "$FLAG_DRYRUN" = true ]; then
+    # Structured sibling of the preview below (R-OUT-5). `entries` counts the
+    # commit bullets plus the bump commit's own entry — typed via
+    # record-effect-raw so consumers get a number, not a string. Guarded by
+    # FLAG_JSON so the counting work only happens when the payload is wanted.
+    if [ "${FLAG_JSON:-false}" = true ]; then
+      if [ "${CHANGELOG_STYLE-}" = "grouped" ]; then
+        # Grouped records are \x1f-terminated — count the separators.
+        _chlog_entries=$(printf '%s' "$COMMITS_MSG" | tr -cd '\037' | wc -c | tr -d ' ')
+      else
+        _chlog_entries=$(grep -c '^- ' <<<"$COMMITS_MSG" || true)
+      fi
+      record-effect-raw "$(jq -nc \
+        --arg op "$ACTION_MSG" \
+        --arg heading "$(head -n1 "$TMP")" \
+        --argjson entries "$((_chlog_entries + 1))" \
+        '{action:"changelog", target:"CHANGELOG.md", op:$op, heading:$heading, entries:$entries}')"
+    fi
     # Subordinate to the "changelog" pill above: header via log_trace (dim
     # ↳, keeps the "[dry-run]" marker text R-DRY-2 requires), preview body
     # as a dim, 2-space-indented block — so the whole changelog step reads

--- a/lib/completions.sh
+++ b/lib/completions.sh
@@ -155,7 +155,7 @@ _verbump() {
 
     opts="--version --message --file --source --bump --push --tag-prefix --branch-prefix \
           --dry-run --no-commit --no-branch --no-changelog --pause-changelog \
-          --yes --quiet --undo --branch --pr --base --major --minor --patch --preid --release \
+          --yes --quiet --json --undo --branch --pr --base --major --minor --patch --preid --release \
           --sign --allow-dirty --allow-empty --no-fetch --no-hooks \
           --help --completions --install-completions --about \
           -v -m -f -p -t -B -d -n -b -c -l -y -q -h"
@@ -196,6 +196,7 @@ _verbump() {
     '(-h --help)'{-h,--help}'[show help]' \
     '(-y --yes)'{-y,--yes}'[skip interactive confirmation prompts]' \
     '(-q --quiet)'{-q,--quiet}'[suppress decoration; print only the new version on stdout]' \
+    '--json[with --dry-run: print the release plan as JSON on stdout]' \
     '--undo[locally delete release branch + tag for <version>]::version:' \
     '--branch[cut a release-x.x.x branch (else tag in place)]' \
     '--pr[branch + push + open a release PR via gh]' \
@@ -239,6 +240,7 @@ for _cmd in verbump verbump.sh VerBump
     complete -c $_cmd -s h -l help           -d 'Show help'
     complete -c $_cmd -s y -l yes            -d 'Skip interactive confirmation prompts'
     complete -c $_cmd -s q -l quiet          -d 'Suppress decoration; print only the new version on stdout'
+    complete -c $_cmd      -l json           -d 'With --dry-run: print the release plan as JSON on stdout'
     complete -c $_cmd      -l undo           -d 'Locally delete release branch + tag for <version>'
     complete -c $_cmd      -l branch         -d 'Cut a release-x.x.x branch (else tag in place)'
     complete -c $_cmd      -l pr             -d 'Branch + push + open a release PR via gh'

--- a/lib/effects.sh
+++ b/lib/effects.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# shellcheck disable=SC2288
+true
+
+# ── Effects accumulator (R-OUT-5) ──────────────────────────────────────────
+#
+# Structured sibling of the human "[dry-run] would ..." lines. Every mutating
+# site records ONE fact here; emit-effects-json serialises the lot once, at the
+# end of main(), as a single JSON object on FD 3 — the same clean-stdout
+# channel --quiet uses for the bare version (R-OUT-1). Human decoration keeps
+# going to stderr exactly as today; --json only adds the machine payload.
+#
+# Why jq and not printf: the payload carries commit messages, changelog text
+# and arbitrary file paths — values that contain quotes, newlines and the odd
+# control char. Hand-built JSON corrupts on the first `"` in a commit subject.
+# jq owns all escaping (same discipline as lib/json.sh). jq is already a hard
+# runtime dependency, so this adds none.
+#
+# Bash 3.2: no associative arrays. The accumulator is a single string holding
+# JSON array text (`[]` → grows by one object per record-effect). Indexed
+# arrays and here-strings only — both are 3.2-safe.
+
+# JSON array text, grown by record-effect. Reset per run in reset-effects.
+VB_EFFECTS='[]'
+
+reset-effects() { VB_EFFECTS='[]'; }
+
+# record-effect <key> <value> [<key> <value> ...]
+#
+# Appends one object to VB_EFFECTS, built from the key/value pairs via jq's
+# `$ARGS.named` — every value arrives through --arg, so jq escapes it. All
+# values are strings (the common case: paths, versions, messages, refs). For a
+# typed or nested field (a boolean, a list) use record-effect-raw instead.
+#
+# No-op unless FLAG_JSON is on, so the hot path (normal runs) pays nothing:
+# every call site can invoke it unconditionally, the way `dryrun` wraps git.
+record-effect() {
+  [ "${FLAG_JSON:-false}" = true ] || return 0
+  local jqargs=() obj merged
+  while [ "$#" -ge 2 ]; do
+    jqargs+=(--arg "$1" "$2")
+    shift 2
+  done
+  obj=$(jq -nc "${jqargs[@]}" '$ARGS.named') || return 1
+  # Merge into a temp first: a failed jq must not clobber the accumulator
+  # (VB_EFFECTS= empty would make emit-effects-json fail on --argjson).
+  merged=$(jq -c --argjson e "$obj" '. + [$e]' <<<"$VB_EFFECTS") || return 1
+  VB_EFFECTS=$merged
+}
+
+# record-effect-raw '<json-object-text>'
+#
+# Escape hatch for effects that need non-string fields (e.g. {"annotated":true})
+# or nesting. Caller is responsible for well-formed JSON; jq validates on merge
+# and a bad fragment fails loudly rather than corrupting the array.
+record-effect-raw() {
+  [ "${FLAG_JSON:-false}" = true ] || return 0
+  local merged
+  merged=$(jq -c --argjson e "$1" '. + [$e]' <<<"$VB_EFFECTS") || return 1
+  VB_EFFECTS=$merged
+}
+
+# emit-effects-json
+#
+# One object on FD 3 (the real stdout saved by process-arguments under the
+# --quiet/--json stream discipline). Mirrors R-OUT-1's channel so a caller can
+# `verbump --minor --dry-run --json >preview.json` and get nothing but JSON on
+# stdout, all decoration on stderr. `level` and `preid` are dropped when empty
+# (an explicit -v X.Y.Z run has no bump level) so payloads carry no null noise.
+emit-effects-json() {
+  [ "${FLAG_JSON:-false}" = true ] || return 0
+  jq -n \
+    --arg from   "${V_PREV-}" \
+    --arg to     "${V_NEW-}" \
+    --arg level  "${BUMP_LEVEL-}" \
+    --arg preid  "${PRE_ID-}" \
+    --arg source "${VER_FILE-}" \
+    --arg tag    "${TAG_PREFIX-}${V_NEW-}" \
+    --argjson effects "$VB_EFFECTS" \
+    '{
+      schema:  "verbump.dry-run/v1",
+      dryRun:  true,
+      version: ({ from: $from, to: $to }
+                 + (if $level == "" then {} else { level: $level } end)
+                 + (if $preid == "" then {} else { preid: $preid } end)),
+      source:  $source,
+      tag:     $tag,
+      effects: $effects
+    }' >&3
+}

--- a/lib/git-actions.sh
+++ b/lib/git-actions.sh
@@ -20,6 +20,7 @@ do-branch() {
   echo -e "\nCreating release branch..."
 
   if [ "$FLAG_DRYRUN" = true ]; then
+    record-effect action branch ref "${REL_PREFIX}${V_NEW}"
     echo -e "${S_LIGHT}[dry-run]${RESET} would run: git branch ${S_VAL}${REL_PREFIX}${V_NEW}${RESET} && git checkout ${S_VAL}${REL_PREFIX}${V_NEW}${RESET}" >&2
     log_success "Switched to (dry-run) branch '${S_VAL}${REL_PREFIX}${V_NEW}${RESET}'"
     return
@@ -64,6 +65,9 @@ do-commit() {
   echo -e "\nCommitting..."
 
   if [ "$FLAG_DRYRUN" = true ]; then
+    # No `paths` field: the file effects recorded before this one already
+    # enumerate every path this commit would stage, in order (R-OUT-5).
+    record-effect action commit message "$FINAL_MSG"
     # %q shell-quotes the message so the preview stays copy-pasteable even
     # when a template carries quotes, backslashes, or $(...) text.
     printf '%b[dry-run]%b would run: git commit -m %b%q%b\n' \
@@ -98,6 +102,15 @@ do-tag() {
   [ "${TAG_SIGN:-false}" = true ] && tag_opt="-s"
 
   if [ "$FLAG_DRYRUN" = true ]; then
+    # `signed` is a real boolean (record-effect-raw); a -s tag is annotated
+    # too in git's model, so annotated stays true either way.
+    if [ "${FLAG_JSON:-false}" = true ]; then
+      record-effect-raw "$(jq -nc \
+        --arg ref "${TAG_PREFIX}${V_NEW}" \
+        --arg message "$tag_msg" \
+        --argjson signed "$([ "$tag_opt" = "-s" ] && echo true || echo false)" \
+        '{action:"tag", ref:$ref, annotated:true, signed:$signed, message:$message}')"
+    fi
     # printf, not echo -e: tag_msg is user-supplied (-m/REL_NOTE) and must
     # print verbatim — %s never interprets backslash escapes.
     printf "%b[dry-run]%b would run: git tag %s %b%s%b -m '%s'\n" \
@@ -142,6 +155,7 @@ do-push() {
       fi
 
       if [ "$FLAG_DRYRUN" = true ]; then
+        record-effect action push remote "${PUSH_DEST}" branch "${REMOTE_REF}" tag "${TAG_PREFIX}${V_NEW}"
         echo -e "${S_LIGHT}[dry-run]${RESET} would run: git push -u ${S_VAL}${PUSH_DEST}${RESET} ${S_VAL}${REMOTE_REF}${RESET} ${S_VAL}${TAG_PREFIX}${V_NEW}${RESET}" >&2
         log_success "(dry-run) push prepared"
         return
@@ -312,6 +326,15 @@ do-github-release() {
   fi
 
   if [ "${FLAG_DRYRUN:-false}" = true ]; then
+    # notes: "generated" (gh --generate-notes) vs "command" (a custom
+    # VERBUMP_RELEASE_NOTES_CMD ran). prerelease is a real boolean.
+    if [ "${FLAG_JSON:-false}" = true ]; then
+      record-effect-raw "$(jq -nc \
+        --arg tag "$tag" \
+        --arg notes "$([ -n "$notes_cmd" ] && echo command || echo generated)" \
+        --argjson prerelease "$([ -n "$pre_flag" ] && echo true || echo false)" \
+        '{action:"github-release", tag:$tag, notes:$notes, prerelease:$prerelease}')"
+    fi
     local notes_preview="--generate-notes"
     [ -n "$notes_cmd" ] && notes_preview="--notes '${notes}'"
     echo -e "${S_LIGHT}[dry-run]${RESET} would run: gh release create ${S_VAL}${tag}${RESET} ${pre_flag:+${pre_flag} }${notes_preview}" >&2
@@ -360,6 +383,7 @@ do-pr() {
   echo -e "\nOpening release PR..."
 
   if [ "${FLAG_DRYRUN:-false}" = true ]; then
+    record-effect action open-pr head "$head" base "$PR_BASE" title "$title"
     echo -e "${S_LIGHT}[dry-run]${RESET} would run: gh pr create --head ${S_VAL}${head}${RESET} --base ${S_VAL}${PR_BASE}${RESET} --title '${title}'" >&2
     log_success "(dry-run) release PR prepared: ${S_VAL}${head}${RESET} → ${S_VAL}${PR_BASE}${RESET}"
     return

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -32,6 +32,7 @@ _run-hook() {
   local name=$1 cmd=$2
 
   if [ "${FLAG_DRYRUN:-false}" = true ]; then
+    record-effect action run-hook hook "$name" command "$cmd"
     echo -e "${S_LIGHT-}[dry-run]${RESET-} would run ${name} hook: bash -c '${cmd}'" >&2
     return 0
   fi

--- a/lib/textbump.sh
+++ b/lib/textbump.sh
@@ -292,6 +292,7 @@ bump-target-files() {
 
       if [ "$FLAG_DRYRUN" = true ]; then
         if grep -qF -- "$search" "$_BT_FILE"; then
+          record-effect action bump-text target "$_BT_FILE" pattern "$_BT_PATTERN" from "$V_PREV" to "$V_NEW"
           echo -e "${S_LIGHT-}[dry-run]${RESET-} would replace ${S_VAL-}${search}${RESET-} ${I_ARROW-→} ${S_VAL-}${replace}${RESET-} in ${S_VAL-}${_BT_FILE}${RESET-}" >&2
           GIT_MSG+="updated ${_BT_FILE}, "
           PROCESSED+=("$_BT_FILE")
@@ -339,6 +340,7 @@ bump-target-files() {
     fi
 
     if [ "$FLAG_DRYRUN" = true ]; then
+      record-effect action bump-struct target "$_BT_FILE" format "$_BT_FMT" path "$_BT_PATH" from "${cur:-}" to "$V_NEW"
       echo -e "${S_LIGHT-}[dry-run]${RESET-} would set ${S_VAL-}${desc}${RESET-} = '${S_VAL-}${V_NEW}${RESET-}' in ${S_VAL-}${_BT_FILE}${RESET-} (was ${S_VAL-}${cur:-none}${RESET-})" >&2
       GIT_MSG+="updated ${_BT_FILE}, "
       PROCESSED+=("$_BT_FILE")

--- a/lib/usage.sh
+++ b/lib/usage.sh
@@ -346,6 +346,7 @@ usage() {
   print-opt-row "-d" "--dry-run"       ""            "Dry-run: print every side-effect without executing."
   print-opt-row "-y" "--yes"           ""            "Skip interactive confirmation prompts."
   print-opt-row "-q" "--quiet"         ""            "Suppress decoration; print only the new version on stdout (needs -y, -v, a bump level, or --preid)."
+  print-opt-row ""   "--json"          ""            "With --dry-run: print the release plan as one JSON object on stdout (needs -y, -v, a bump level, or --preid)."
 
   print-opt-group "Help & completions"
   print-opt-row "-h" "--help"          ""            "Show this help message."
@@ -357,6 +358,7 @@ usage() {
   print-example-row "${SCRIPT_CMD}"                       "Interactive — reads commits, suggests bump, prompts."
   print-example-row "${SCRIPT_CMD} -v 2.0.0"              "Non-interactive, explicit version."
   print-example-row "${SCRIPT_CMD} --dry-run"             "Preview every side-effect without executing."
+  print-example-row "${SCRIPT_CMD} --minor --dry-run --json" "Print the release plan as JSON (for scripts, CI, agents)."
   print-example-row "${SCRIPT_CMD} -p origin"             "Push the release branch + tag when done."
   print-example-row "${SCRIPT_CMD} --pr"                  "Branch, push, and open a release PR (needs gh)."
   print-example-row "${SCRIPT_CMD} -t release/"           "Use a custom tag prefix (e.g. release/1.2.3)."

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -348,7 +348,7 @@ set-v-suggest() {
 # actually package.json — a --source composer.json run must not touch a
 # stray lock file.
 do-packagefile-bump() {
-  local NOTICE_MSG BUMP_LOCK=false
+  local NOTICE_MSG BUMP_LOCK=false LOCK_PREV
   NOTICE_MSG="<${S_VAL}${VER_FILE}${RESET}>"
 
   # Skip entirely if the source file is absent. In tag-derived mode
@@ -368,8 +368,18 @@ do-packagefile-bump() {
   [ "$VER_FILE" = "package.json" ] && [ -f package-lock.json ] && BUMP_LOCK=true
 
   if [ "$FLAG_DRYRUN" = true ]; then
+    record-effect action bump-json target "$VER_FILE" from "$V_PREV" to "$V_NEW" role source
     echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in ${VER_FILE}" >&2
-    [ "$BUMP_LOCK" = true ] && echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package-lock.json" >&2
+    if [ "$BUMP_LOCK" = true ]; then
+      # The lock file can drift from package.json — the plan records the
+      # lock's actual current version (falling back to V_PREV when it can't
+      # be read). Guarded so non-json dry-runs skip the extra jq read.
+      if [ "${FLAG_JSON:-false}" = true ]; then
+        LOCK_PREV=$(jq -r '.version // empty' package-lock.json 2>/dev/null)
+        record-effect action bump-json target package-lock.json from "${LOCK_PREV:-$V_PREV}" to "$V_NEW" role lock
+      fi
+      echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in package-lock.json" >&2
+    fi
   else
     # Bump the source file via jq (no npm dependency), preserving the file's
     # own formatting where possible (R-FMT-1..3, lib/json.sh).
@@ -421,6 +431,7 @@ bump-json-files() {
       elif [ "$FILE_V_PREV" = "$V_NEW" ]; then
         log_warn "<${S_VAL}$FILE${RESET}> already contains version ${S_VAL}$FILE_V_PREV${RESET}."
       elif [ "$FLAG_DRYRUN" = true ]; then
+        record-effect action bump-json target "$FILE" from "$FILE_V_PREV" to "$V_NEW" role extra
         echo -e "${S_LIGHT}[dry-run]${RESET} would set .version = '${S_VAL}$V_NEW${RESET}' in ${S_VAL}$FILE${RESET} (was ${S_VAL}$FILE_V_PREV${RESET})" >&2
         GIT_MSG+="updated $FILE, "
       else
@@ -448,6 +459,7 @@ do-versionfile() {
   if [ -f VERSION ]; then
     GIT_MSG+="updated VERSION, "
     if [ "$FLAG_DRYRUN" = true ]; then
+      record-effect action write target VERSION to "$V_NEW"
       echo -e "${S_LIGHT}[dry-run]${RESET} would write '${S_VAL}$V_NEW${RESET}' to VERSION" >&2
     else
       echo "$V_NEW" > VERSION # Overwrite file

--- a/test/dry-run-json.bats
+++ b/test/dry-run-json.bats
@@ -1,0 +1,295 @@
+#!/usr/bin/env bats
+
+# --dry-run --json (R-OUT-5, issue #107): structured release preview.
+# One JSON object on stdout (the R-OUT-1 clean channel), decoration on
+# stderr. effects[] is ordered as main() would execute it, and contains
+# only the operations that would actually run — each site's FLAG/DO_
+# guard decides membership, so there is no "skipped" noise. Preview-only:
+# --json without --dry-run exits 2 at parse time.
+
+load 'test_helper'
+
+# releasable_repo / released_repo fixtures come from test_helper.bash.
+
+# ── happy path: one valid JSON object on stdout ─────────────────────────────
+
+@test "json: stdout is exactly one valid JSON object, decoration on stderr" {
+  releasable_repo
+
+  run bash -c '"$1" --minor --yes -p origin --dry-run --json >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  # The whole of stdout parses as a single JSON value...
+  run jq -e 'has("schema")' "$BATS_TEST_TMPDIR/out"
+  assert_success
+  assert_output "true"
+  # ...and the human story still lands on stderr, [dry-run] markers included.
+  # (-F: the literal marker — the schema id "verbump.dry-run/v1" legitimately
+  # puts the substring "dry-run" on stdout.)
+  run grep -cF "[dry-run]" "$BATS_TEST_TMPDIR/err"
+  refute_output "0"
+  run grep -cF "[dry-run]" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+}
+
+@test "json: schema, version delta, source, and tag are all present (R-OUT-5)" {
+  releasable_repo
+
+  run bash -c '"$1" --minor --yes -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[.schema, .dryRun, .version.from, .version.to, .version.level, .source, .tag] | join("|")' \
+    "$BATS_TEST_TMPDIR/out"
+  assert_output "verbump.dry-run/v1|true|1.2.3|1.3.0|minor|package.json|v1.3.0"
+}
+
+@test "json: effects[] is ordered as main() would execute it" {
+  releasable_repo
+  printf '{ "version": "1.2.3" }\n' > composer.json
+  echo "1.2.3" > VERSION
+  git add composer.json VERSION && git commit -qm "chore: add extra bump files"
+
+  run bash -c '"$1" --minor --yes -p origin --branch -f composer.json --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[.effects[].action] | join(",")' "$BATS_TEST_TMPDIR/out"
+  assert_output "bump-json,bump-json,write,changelog,branch,commit,tag,push"
+  # Roles distinguish the source file from -f extras.
+  run jq -r '[.effects[] | select(.action == "bump-json") | .role] | join(",")' "$BATS_TEST_TMPDIR/out"
+  assert_output "source,extra"
+}
+
+@test "json: package-lock effect records the lock's own (drifted) version" {
+  releasable_repo
+  # Lock file deliberately behind package.json (1.2.2 vs 1.2.3): the plan
+  # must report what the lock actually contains, not the source version.
+  printf '{ "name": "x", "version": "1.2.2", "packages": { "": { "version": "1.2.2" } } }\n' > package-lock.json
+  git add package-lock.json && git commit -qm "chore: add drifted lockfile"
+
+  run bash -c '"$1" --minor --yes -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '.effects[] | select(.role == "lock") | .from + ">" + .to' "$BATS_TEST_TMPDIR/out"
+  assert_output "1.2.2>1.3.0"
+}
+
+@test "json: guarded-off steps leave no trace in effects[]" {
+  releasable_repo
+
+  # -c (no changelog), no --branch, no -p (push is prompted, not planned —
+  # but --json needs a prompt-free run, so -n skips commit/tag/push wholesale).
+  run bash -c '"$1" --minor --yes -c -n --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[.effects[].action] | join(",")' "$BATS_TEST_TMPDIR/out"
+  assert_output "bump-json"
+}
+
+@test "json: hooks are recorded with their commands when set" {
+  releasable_repo
+
+  PRE_BUMP_CMD='echo pre' POST_TAG_CMD='echo post' \
+    run bash -c '"$1" --minor --yes -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[.effects[] | select(.action == "run-hook") | "\(.hook):\(.command)"] | join(",")' \
+    "$BATS_TEST_TMPDIR/out"
+  assert_output "pre-bump:echo pre,post-tag:echo post"
+  # pre-bump is the plan's first step; post-tag sits between tag and push.
+  run jq -r '.effects[0].action' "$BATS_TEST_TMPDIR/out"
+  assert_output "run-hook"
+}
+
+@test "json: full plan with --pr --release (stub gh) ends open-pr, github-release" {
+  releasable_repo
+  local shim="$BATS_TEST_TMPDIR/shim"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 0\n' > "$shim/gh"
+  chmod +x "$shim/gh"
+
+  PATH="$shim:$PATH" run bash -c '"$1" --minor --yes --pr --release --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[.effects[].action] | join(",")' "$BATS_TEST_TMPDIR/out"
+  assert_output "bump-json,changelog,branch,commit,tag,push,open-pr,github-release"
+  run jq -r '.effects[] | select(.action == "open-pr") | .head' "$BATS_TEST_TMPDIR/out"
+  assert_output "release-1.3.0"
+}
+
+# ── typed fields: booleans and counts are real JSON types ───────────────────
+
+@test "json: tag.annotated/signed and github-release.prerelease are booleans, changelog.entries a number" {
+  releasable_repo
+  local shim="$BATS_TEST_TMPDIR/shim"
+  mkdir -p "$shim"
+  printf '#!/bin/sh\nexit 0\n' > "$shim/gh"
+  chmod +x "$shim/gh"
+
+  PATH="$shim:$PATH" run bash -c '"$1" --minor --yes -p origin --release --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run jq -r '[
+      (.effects[] | select(.action == "tag") | (.annotated | type), (.signed | type)),
+      (.effects[] | select(.action == "github-release") | (.prerelease | type)),
+      (.effects[] | select(.action == "changelog") | (.entries | type))
+    ] | join(",")' "$BATS_TEST_TMPDIR/out"
+  assert_output "boolean,boolean,boolean,number"
+}
+
+# ── escaping: adversarial values round-trip through jq ──────────────────────
+
+@test "json: a tag message with quotes and a newline round-trips exactly" {
+  releasable_repo
+
+  run bash -c '"$1" --minor --yes -p origin -m "$3" --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR" $'He said "ship it"\nline2 \\ backslash'
+  assert_success
+
+  run jq -r '.effects[] | select(.action == "tag") | .message' "$BATS_TEST_TMPDIR/out"
+  assert_output $'He said "ship it"\nline2 \\ backslash'
+}
+
+# ── version object shape ────────────────────────────────────────────────────
+
+@test "json: explicit -v drops version.level; --preid adds version.preid" {
+  releasable_repo
+
+  run bash -c '"$1" -v 3.0.0 --yes -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run jq -r '.version | has("level"), has("preid")' "$BATS_TEST_TMPDIR/out"
+  assert_output $'false\nfalse'
+
+  # --preid on a stable version needs a level (R-PRE) — --minor --preid rc.
+  run bash -c '"$1" --minor --preid rc --yes -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run jq -r '.version.preid' "$BATS_TEST_TMPDIR/out"
+  assert_output "rc"
+}
+
+# ── stream discipline with --quiet ──────────────────────────────────────────
+
+@test "json: --quiet --json emits only the JSON object — no bare-version line" {
+  releasable_repo
+
+  run bash -c '"$1" --minor --yes --quiet -p origin --dry-run --json >"$2/out" 2>/dev/null </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+
+  run grep -cx "1.3.0" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+  run jq -r '.version.to' "$BATS_TEST_TMPDIR/out"
+  assert_output "1.3.0"
+}
+
+# ── parse-time rejections (exit 2, with hints) ──────────────────────────────
+
+@test "json: --json without --dry-run -> exit 2 naming the fix" {
+  releasable_repo
+
+  run ${profile_script} --json --yes --minor
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "requires --dry-run"
+  assert_output --partial "--json"
+}
+
+@test "json: --json without --yes/-v/level -> exit 2 (prompt guard, mirrors R-OUT-2)" {
+  releasable_repo
+
+  run ${profile_script} --dry-run --json
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "non-interactive version choice"
+  assert_output --partial "--yes"
+}
+
+@test "json: --json=value is rejected as a boolean flag (R-OPT-2)" {
+  releasable_repo
+
+  run ${profile_script} --json=true --dry-run --yes
+  assert_failure 2
+  strip_ansi_output
+  assert_output --partial "doesn't take a value"
+}
+
+# ── CLI-only: rc/env cannot switch JSON mode on ─────────────────────────────
+
+@test "json: FLAG_JSON is CLI-only — a .verbumprc key cannot force JSON output" {
+  releasable_repo
+  printf 'FLAG_JSON=true\n' > .verbumprc
+  chmod 644 .verbumprc
+
+  run bash -c '"$1" --minor --yes -c -n --dry-run >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  # Normal dry-run output — nothing JSON-shaped anywhere.
+  run grep -c "verbump.dry-run/v1" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+  run grep -c "verbump.dry-run/v1" "$BATS_TEST_TMPDIR/err"
+  assert_output "0"
+}
+
+@test "json: env FLAG_JSON cannot force JSON output either (CLI-only reset)" {
+  releasable_repo
+
+  FLAG_JSON=true run bash -c '"$1" --minor --yes -c -n --dry-run >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep -c "verbump.dry-run/v1" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+}
+
+# ── no-op and non-json runs ─────────────────────────────────────────────────
+
+@test "json: no-op run (nothing to release) -> exit 0, stdout completely empty" {
+  released_repo
+
+  run bash -c '"$1" --yes -v 1.2.4 --dry-run --json >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  # Like --quiet's R-OUT-4: empty stdout is the "no release would happen" test.
+  [ ! -s "$BATS_TEST_TMPDIR/out" ]
+  run grep -c "^no-release" "$BATS_TEST_TMPDIR/err"
+  assert_output "1"
+}
+
+@test "json: without --json a dry-run emits no JSON (zero-cost accumulator)" {
+  releasable_repo
+
+  run bash -c '"$1" --minor --yes -c -n --dry-run >"$2/out" 2>"$2/err" </dev/null' _ \
+    "${profile_script}" "$BATS_TEST_TMPDIR"
+  assert_success
+  run grep -c "verbump.dry-run/v1" "$BATS_TEST_TMPDIR/out"
+  assert_output "0"
+}
+
+# ── surface parity ──────────────────────────────────────────────────────────
+
+@test "json: --help lists --json" {
+  run bash -c 'get_help_msg() { "$1" -h 2>&1; }; get_help_msg "$1"' _ "${profile_script}"
+  assert_success
+  strip_ansi_output
+  assert_output --partial "--json"
+}
+
+@test "json: completions list --json in bash/zsh/fish" {
+  run ${profile_script} --completions bash
+  assert_success
+  assert_output --partial -- "--json"
+  run ${profile_script} --completions zsh
+  assert_success
+  assert_output --partial -- "--json"
+  run ${profile_script} --completions fish
+  assert_success
+  assert_output --partial -- "-l json"
+}

--- a/test/no-release.bats
+++ b/test/no-release.bats
@@ -9,16 +9,7 @@
 
 load 'test_helper'
 
-# Scratch repo where package.json's version is already tagged at HEAD:
-# zero commits since the previous tag.
-released_repo() {
-  local repo
-  repo="$(scratch_repo)"
-  cd "$repo" || exit 1
-  printf '{ "version": "1.2.3" }\n' > package.json
-  git add package.json && git commit -qm "chore: bumped to 1.2.3"
-  git tag -a v1.2.3 -m "v1.2.3"
-}
+# released_repo (tagged 1.2.3, zero commits since) comes from test_helper.bash.
 
 @test "no-release: zero commits since tag -> exit 0, token, no mutation (R-SAFE-14/15)" {
   released_repo

--- a/test/quiet.bats
+++ b/test/quiet.bats
@@ -11,28 +11,7 @@
 
 load 'test_helper'
 
-# Scratch repo whose package.json version is already tagged, plus one
-# feat: commit — a releasable state where the conventional-commits
-# suggestion is a minor bump (1.2.3 -> 1.3.0).
-releasable_repo() {
-  local repo
-  repo="$(scratch_repo)"
-  cd "$repo" || exit 1
-  printf '{ "version": "1.2.3" }\n' > package.json
-  git add package.json && git commit -qm "chore: bumped to 1.2.3"
-  git tag -a v1.2.3 -m "v1.2.3"
-  git commit -q --allow-empty -m "feat: something new"
-}
-
-# Same, but with zero commits since the tag — the no-op state (#60).
-released_repo() {
-  local repo
-  repo="$(scratch_repo)"
-  cd "$repo" || exit 1
-  printf '{ "version": "1.2.3" }\n' > package.json
-  git add package.json && git commit -qm "chore: bumped to 1.2.3"
-  git tag -a v1.2.3 -m "v1.2.3"
-}
+# releasable_repo / released_repo fixtures come from test_helper.bash.
 
 # ── R-OUT-1: success prints exactly the bare version on stdout ─────────────
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -84,6 +84,26 @@ strip_ansi_output() {
   while IFS= read -r _line; do lines+=("$_line"); done <<< "$output"
 }
 
+# Scratch repo whose package.json version (1.2.3) is already tagged, plus
+# one releasable feat: commit — the conventional-commits suggestion is a
+# minor bump (1.2.3 -> 1.3.0). Shared by quiet.bats / dry-run-json.bats.
+releasable_repo() {
+  released_repo
+  git commit -q --allow-empty -m "feat: something new"
+}
+
+# Scratch repo where package.json's version (1.2.3) is already tagged at
+# HEAD: zero commits since the previous tag — the no-op state (#60).
+# Shared by no-release.bats / quiet.bats / dry-run-json.bats.
+released_repo() {
+  local repo
+  repo="$(scratch_repo)"
+  cd "$repo" || exit 1
+  printf '{ "version": "1.2.3" }\n' > package.json
+  git add package.json && git commit -qm "chore: bumped to 1.2.3"
+  git tag -a v1.2.3 -m "v1.2.3"
+}
+
 # Make a throwaway git repo under /tmp and echo its path. Adds cleanup.
 # Initial state: one empty commit on the default branch. No tags.
 scratch_repo() {

--- a/verbump.sh
+++ b/verbump.sh
@@ -30,6 +30,7 @@ source "$MODULE_DIR/lib/errors.sh"
 source "$MODULE_DIR/lib/ui.sh"
 source "$MODULE_DIR/lib/validate.sh"
 source "$MODULE_DIR/lib/json.sh"
+source "$MODULE_DIR/lib/effects.sh"
 source "$MODULE_DIR/lib/textbump.sh"
 
 source "$MODULE_DIR/lib/usage.sh"
@@ -51,6 +52,9 @@ GIT_MSG=""
 REL_NOTE=""
 FLAG_DRYRUN=false
 FLAG_QUIET=false # -q/--quiet: decoration to stderr, bare new version on stdout (R-OUT-1). CLI-only; reset in process-arguments.
+FLAG_JSON=false # --json: with --dry-run, emit the release plan as one JSON object on stdout (R-OUT-5). CLI-only; reset in process-arguments.
+# VB_EFFECTS (declared in lib/effects.sh): JSON-array text of recorded release
+# effects for --json; reset per run in process-arguments via reset-effects.
 
 # Config-keyed defaults use `:=` so exported env values survive. An
 # unconditional assignment (e.g. `TAG_PREFIX="v"`) would clobber
@@ -129,9 +133,16 @@ main() {
   # tag prefix, no colour. A no-op run never reaches this point
   # (check-releasable-commits exits 0 first), so quiet stdout stays empty
   # for "no release happened" (R-OUT-4).
-  if [ "$FLAG_QUIET" = true ]; then
+  # Under --json the payload owns stdout: the bare-version line is skipped
+  # (its information lives at .version.to), so `--quiet --json` still yields
+  # a stream that is exactly one JSON object.
+  if [ "$FLAG_QUIET" = true ] && [ "$FLAG_JSON" != true ]; then
     printf '%s\n' "$V_NEW" >&3
   fi
+
+  # --dry-run --json: one JSON object with the recorded release plan on FD 3
+  # (R-OUT-5). Self-guarded — a no-op without --json.
+  emit-effects-json
 }
 
 # Execute script when it is executed as a script, and when it is brought into the environment with source (so it can be tested)


### PR DESCRIPTION
Adds the missing read side of the machine contract: with `--dry-run`, `--json` emits one JSON object (`verbump.dry-run/v1`) on the clean FD-3 stdout channel `--quiet` already uses — the version delta, source, tag, and an `effects[]` array ordered exactly as `main()` would execute it. `--quiet` tells a script what a release *did*; `--json` tells it what one *would do*, so a CI gate, a script, or an agent can reason about the plan before a human pulls the trigger. Deliberately preview-only: `--json` without `--dry-run` exits 2, keeping the mutating path human-gated (the issue's MCP alternative stays rejected).

- `lib/effects.sh`: jq-backed accumulator (`record-effect`, `record-effect-raw` for typed fields, `emit-effects-json`); no-op unless `FLAG_JSON` is set, so normal runs pay nothing
- `lib/args.sh`: `--json` flag (CLI-only, reset per run alongside a new `reset-effects` call), FD-3 redirect shared with `--quiet`, preview-only guard, and a `_require-noninteractive-version` helper now shared with `--quiet`'s prompt guard
- one `record-effect` beside each `[dry-run]` preview site in `hooks.sh`, `version.sh`, `textbump.sh`, `changelog.sh`, `git-actions.sh` — the guard structure means the payload only ever lists steps that would run
- typed fields: `changelog.entries` is a number; `tag.annotated`/`tag.signed` and `github-release.prerelease` are booleans
- `--quiet --json` emits only the JSON object (the version lives at `.version.to`); a no-op run leaves stdout empty and exits 0, mirroring R-OUT-4
- docs: README "release plan as JSON" section, R-OUT-5..7 ratified in `docs/features/dry-run-json/requirements.md`, DESIGN.md de-drafted with a reproducible sandbox sample; `--help` row and bash/zsh/fish completions
- tests: `releasable_repo`/`released_repo` fixtures hoisted into `test_helper.bash` (were duplicated across `quiet.bats` / `no-release.bats`)

Behavioural notes: escaping is jq-owned end to end — a tag message containing quotes, a newline, and a backslash round-trips byte-exact (asserted in tests). `version.level` is omitted under an explicit `-v`; deliberate field deviations from the issue's abridged sample (no `commit.paths`, a distinct `bump-struct` action for TOML/YAML targets, `push` as separate `branch`+`tag` fields) are recorded in DESIGN.md §Decisions. Rebased onto the lowercase-`verbump` rename; the new docs/examples follow the lowercase command convention.

Tests: `test/dry-run-json.bats`, 19 cases (schema shape, ordering, guard membership, typed fields, adversarial escaping, `--quiet` composition, rc/env cannot force JSON on, no-op empty stdout, help/completions parity). Full suite: 538/538. Shellcheck: zero warnings.

Refs #107.