### PR TITLE
docs(docs): document the package-lock companion bump

### DIFF
--- a/packages/docs-site/content/docs/guides/bump-targets.mdx
+++ b/packages/docs-site/content/docs/guides/bump-targets.mdx
@@ -56,3 +56,21 @@ that the JSON `.version` default can't reach. A `{{version}}` text pattern
 covers everything else with no dependency. Same-version and missing files are
 skipped with a notice, and every change is staged and listed in the bump
 commit.
+
+## npm lock file
+
+One bump target is implicit: when the version source is the default
+`package.json` and a `package-lock.json` sits beside it, the release bumps
+the lock file too. Matching `npm version`, this companion bump rewrites the
+lock's top-level `.version` and, when present, the root
+`.packages[""].version` entry — via `jq` alone, so npm is never invoked and
+the git + jq dependency contract holds. The lock file lands in the same bump
+commit as every other target, so there is nothing to declare: never list
+`package-lock.json` under `--bump` or `--file`.
+
+The companion bump fires only when the version source is actually
+`package.json` — a `--source composer.json` run never touches a stray lock
+file. Like any bump target it appears in `--dry-run` output, and the
+[release preview](/docs/guides/dry-run-undo) records it as its own entry
+(`"role": "lock"`) reporting the lock's real current version, which can
+differ from `package.json` when the two have drifted.

--- a/packages/docs-site/content/docs/guides/bump-targets.mdx
+++ b/packages/docs-site/content/docs/guides/bump-targets.mdx
@@ -59,14 +59,14 @@ commit.
 
 ## npm lock file
 
-One bump target is implicit: when the version source is the default
-`package.json` and a `package-lock.json` sits beside it, the release bumps
-the lock file too. Matching `npm version`, this companion bump rewrites the
+One bump target is implicit: when the version source is `package.json` (the
+default) and a `package-lock.json` sits beside it, the release bumps the
+lock file too. Matching `npm version`, this companion bump rewrites the
 lock's top-level `.version` and, when present, the root
 `.packages[""].version` entry — via `jq` alone, so npm is never invoked and
 the git + jq dependency contract holds. The lock file lands in the same bump
-commit as every other target, so there is nothing to declare: never list
-`package-lock.json` under `--bump` or `--file`.
+commit as every other target, so there is nothing to declare — leave
+`package-lock.json` out of `--bump` and `--file`.
 
 The companion bump fires only when the version source is actually
 `package.json` — a `--source composer.json` run never touches a stray lock

--- a/packages/docs-site/content/docs/reference/cli.mdx
+++ b/packages/docs-site/content/docs/reference/cli.mdx
@@ -30,7 +30,7 @@ the stable core (`1.2.3-dev.5 --patch` → `1.2.4`) — the full rules live in
 
 | Flag | Description |
 | --- | --- |
-| `--source <file.json>` | Version source and primary bump target (default: `package.json`). If the file is missing, the current version derives from the latest matching git tag. With the default source, an adjacent `package-lock.json` is bumped automatically — see [npm lock file](/docs/guides/bump-targets#npm-lock-file). |
+| `--source <file.json>` | Version source and primary bump target (default: `package.json`). If the file is missing, the current version derives from the latest matching git tag. When the source is `package.json`, an adjacent `package-lock.json` is bumped automatically — see [npm lock file](/docs/guides/bump-targets#npm-lock-file). |
 | `--bump <spec>` | Also bump a JSON / TOML / YAML / text file. Repeatable. `<file>` (top-level `.version` by file type), `<file>:@<path>` (explicit dotted path, e.g. `pyproject.toml:@tool.poetry.version`), or `'<file>:<pattern>'` (text search/replace, where the pattern must contain `{{version}}`). |
 | `-f`, `--file <file.json>` | Also bump `"version"` in this JSON file. Repeatable. Superseded by `--bump`. |
 

--- a/packages/docs-site/content/docs/reference/cli.mdx
+++ b/packages/docs-site/content/docs/reference/cli.mdx
@@ -30,7 +30,7 @@ the stable core (`1.2.3-dev.5 --patch` → `1.2.4`) — the full rules live in
 
 | Flag | Description |
 | --- | --- |
-| `--source <file.json>` | Version source and primary bump target (default: `package.json`). If the file is missing, the current version derives from the latest matching git tag. |
+| `--source <file.json>` | Version source and primary bump target (default: `package.json`). If the file is missing, the current version derives from the latest matching git tag. With the default source, an adjacent `package-lock.json` is bumped automatically — see [npm lock file](/docs/guides/bump-targets#npm-lock-file). |
 | `--bump <spec>` | Also bump a JSON / TOML / YAML / text file. Repeatable. `<file>` (top-level `.version` by file type), `<file>:@<path>` (explicit dotted path, e.g. `pyproject.toml:@tool.poetry.version`), or `'<file>:<pattern>'` (text search/replace, where the pattern must contain `{{version}}`). |
 | `-f`, `--file <file.json>` | Also bump `"version"` in this JSON file. Repeatable. Superseded by `--bump`. |
 


### PR DESCRIPTION
## Summary

The user docs never mentioned that a release rewrites an adjacent
`package-lock.json` when the version source is `package.json` (R-OPT-7's
companion bump) — the behavior is shipped and bats-covered, but a docs audit
found no user-docs page or README section stating it.

- Adds an **npm lock file** section to the Bump targets guide, framed as the
  one *implicit* bump target: the trigger condition (`package.json` source +
  adjacent lock), the never-under-`--source` scoping, the npm-parity
  dual-field update (`.version` + root `.packages[""].version`), the jq-only
  mechanics, and the dry-run / release-preview visibility (`"role": "lock"`,
  reporting the lock's real, possibly drifted, current version).
- One-line cross-reference from the `--source` row in the CLI options
  reference.

Content-only; no runtime, CLI, or README changes.

## Test plan

- [x] Docs-site build check (`fumadocs-mdx` + `next typegen` + `tsc`) passes —
  the single seam agreed in the spec; no bats changes (behavior untouched and
  already covered by bumpfile / version-source / json / dry-run-json tests).
- [x] Two-axis review (standards + spec) run; wording tightened per findings.

Refs #127.