### PR TITLE
fix(tests): pin stdin in the monorepo suites

### DIFF
--- a/test/monorepo-preflights.bats
+++ b/test/monorepo-preflights.bats
@@ -9,6 +9,9 @@
 
 load 'test_helper'
 
+# Runs that clear the preflights reach the interactive version prompt, so
+# stdin is pinned with `</dev/null` — see the header of monorepo-scope.bats.
+
 # ── dirty-tree split (R-MONO-5) ─────────────────────────────────────────────
 
 @test "dirty: unstaged changes outside the scope don't block (R-MONO-5)" {
@@ -16,7 +19,7 @@ load 'test_helper'
   echo "wip" >> packages/pkg-b/widget.txt
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
 }
 
@@ -25,7 +28,7 @@ load 'test_helper'
   echo "wip" >> packages/pkg-a/rounding.txt
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_failure 3
   strip_ansi_output
   assert_output --partial "uncommitted changes"
@@ -37,7 +40,7 @@ load 'test_helper'
   git add packages/pkg-b/widget.txt
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_failure 3
   strip_ansi_output
   assert_output --partial "sweep them into the bump commit"
@@ -49,7 +52,7 @@ load 'test_helper'
   echo "wip" >> packages/pkg-a/rounding.txt
   cd packages/pkg-a
 
-  ALLOW_DIRTY=true run ${profile_script} -d -y -p origin
+  ALLOW_DIRTY=true run ${profile_script} -d -y -p origin </dev/null
   assert_success
 }
 
@@ -60,7 +63,7 @@ load 'test_helper'
   git commit -qm "chore: add afile"
   echo "change" >> afile
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_failure 3
   strip_ansi_output
   assert_output --partial "uncommitted changes"
@@ -73,7 +76,7 @@ load 'test_helper'
   git branch release-1.2.4
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin --branch -v 1.2.4
+  run ${profile_script} -d -y -p origin --branch -v 1.2.4 </dev/null
   assert_failure 3
   strip_ansi_output
   assert_output --partial "REL_PREFIX"

--- a/test/monorepo-scope.bats
+++ b/test/monorepo-scope.bats
@@ -11,6 +11,13 @@ load 'test_helper'
 
 # monorepo_fixture (pkg-a 1.2.3 / pkg-b 0.4.0, per-package rc + tags, one
 # feat(pkg-b) + one fix(pkg-a) commit) comes from test_helper.bash.
+#
+# Every full run here MUST pin stdin (`</dev/null`, or a piped answer). None
+# of these pass -v / --major|--minor|--patch, so they reach the interactive
+# version prompt, whose first read is `read -rsn1` — with ambient stdin it
+# consumes whatever the terminal supplies, and a stray ESC aborts the run
+# with exit 5. `-y` does NOT cover this prompt. EOF falls through to the
+# suggested version, which is what these tests assert.
 
 # ── bump suggestion (R-MONO-2) ──────────────────────────────────────────────
 
@@ -18,7 +25,7 @@ load 'test_helper'
   monorepo_fixture
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   refute_output --partial "suggesting minor bump"
@@ -29,7 +36,7 @@ load 'test_helper'
   monorepo_fixture
   cd packages/pkg-b
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "suggesting minor bump"
@@ -42,7 +49,7 @@ load 'test_helper'
   monorepo_fixture
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "correct rounding"
@@ -76,7 +83,7 @@ load 'test_helper'
   monorepo_fixture
   cd packages/pkg-a
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "packages/pkg-a"
@@ -97,11 +104,11 @@ load 'test_helper'
   git add ../pkg-b/widget.txt
   git commit -qm "feat(pkg-b): more widgets"
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "Nothing to release"
-  run bash -c '"$1" -d -y -p origin | grep -c "^no-release"' _ "${profile_script}"
+  run bash -c '"$1" -d -y -p origin </dev/null | grep -c "^no-release"' _ "${profile_script}"
   assert_output "1"
 }
 
@@ -116,7 +123,7 @@ load 'test_helper'
   git add .verbumprc
   git commit -qm "chore(pkg-a): set COMMIT_PATHS"
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   refute_output --partial "Unknown .verbumprc key"
@@ -127,7 +134,7 @@ load 'test_helper'
   cd packages/pkg-a
 
   # Env beats the rc-derived default "." — pkg-b's feat now counts.
-  COMMIT_PATHS=". ../pkg-b" run ${profile_script} -d -y -p origin
+  COMMIT_PATHS=". ../pkg-b" run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "suggesting minor bump"
@@ -144,7 +151,7 @@ load 'test_helper'
   git add .verbumprc
   git commit -qm "chore(pkg-a): widen COMMIT_PATHS"
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   # pkg-b's feat commit now counts toward pkg-a's suggestion.
@@ -185,7 +192,7 @@ load 'test_helper'
   git commit -qm "chore: drop pkg-b manifest"
   cd packages/pkg-b
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "derived from git tag <pkg-b-v0.4.0>: 0.4.0"
@@ -196,7 +203,7 @@ load 'test_helper'
   git remote set-url origin https://github.com/acme/mono.git
   cd packages/pkg-a
 
-  CHANGELOG_STYLE=grouped run ${profile_script} -d -y -p origin --no-fetch
+  CHANGELOG_STYLE=grouped run ${profile_script} -d -y -p origin --no-fetch </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "compare/pkg-a-v1.2.3...pkg-a-v1.2.4"
@@ -209,7 +216,7 @@ load 'test_helper'
   git commit -q --allow-empty -m "fix: something new"
 
   TAG_PREFIX="rel/" CHANGELOG_STYLE=grouped \
-    run ${profile_script} -d -y -p origin --no-fetch
+    run ${profile_script} -d -y -p origin --no-fetch </dev/null
   assert_success
   strip_ansi_output
   assert_output --partial "compare/rel%2F1.2.3...rel%2F1.2.4"
@@ -220,7 +227,7 @@ load 'test_helper'
   printf 'TAG_PREFIX=v\n' > .verbumprc
   chmod 644 .verbumprc
 
-  run ${profile_script} -d -y -p origin
+  run ${profile_script} -d -y -p origin </dev/null
   assert_success
   strip_ansi_output
   refute_output --partial "Package scope"


### PR DESCRIPTION
The monorepo suites added in #130 pass neither `-v` nor a forced bump level, so every full run reaches the interactive version prompt. Its first read is `read -rsn1`, which with ambient stdin consumes whatever the terminal supplies — a stray ESC aborts with exit 5 and the test fails. (`-y` does not cover the version prompt.)

CI and non-interactive runs saw EOF and fell through to the suggested version, so the suite was green on #130 and stayed green on `main` — the failure only appears in a terminal. There it fails `PRE_BUMP_CMD` (`pnpm lint && pnpm tests:run`) and **blocks `pnpm bump-release`**, which is how it was found.

- Every full run in `monorepo-scope.bats` / `monorepo-preflights.bats` now pins stdin with `</dev/null`, including the runs that currently abort at a preflight before ever reaching the prompt — so a later ordering change can't silently reintroduce the dependency.
- File headers document why, since the trap is invisible when the suite is run non-interactively.

No product code changed; this is entirely a test-harness regression from #130.

Verification: piping an endless ESC stream into the whole suite reproduces it deterministically — 14 failures before, **0 after**, all 14 in the two files from #130 (the other 546 tests were already stdin-safe). Normal run: 563/563. Shellcheck clean. `./verbump.sh --patch -y --release -p origin --dry-run` — the exact `bump-release` command — now clears the hook and previews 4.0.3 → 4.0.4.

Refs #128.